### PR TITLE
Declare Linux package metadata for ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Current release scope:
 - `AppImage`, `.deb`, and `.rpm` outputs
 - one rolled-up `SHA256SUMS` file per published release
 
+Linux package dependency behaviour today:
+
+- `.deb` packages declare a hard dependency on `ffmpeg`
+- `.rpm` packages declare a recommendation for `ffmpeg` or `ffmpeg-free`, since RPM package naming differs across distributions
+- `AppImage` builds still rely on the host system to provide `ffmpeg` and `ffprobe`
+
 Typical release sequence:
 
 1. Run `pnpm release:version:prepare --version <x.y.z>`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -201,6 +201,7 @@ Someone who understands FFmpeg and DVD authoring basics and wants a better front
 - Support future compliance and QA reporting for authored output.
 - Ship a Linux-first desktop release pipeline for the Tauri shell, including `AppImage`, `.deb`, and `.rpm` packages plus a consolidated `SHA256SUMS` manifest.
 - Keep release versioning coordinated across the workspace package, desktop package, Tauri config, and release-facing Rust crates so published tags map cleanly to bundled outputs.
+- Express Linux package-manager metadata for host `ffmpeg` requirements where the target package format supports it, while keeping host-tool detection in the app for portable bundle formats such as `AppImage`.
 
 ---
 

--- a/apps/spindle/src-tauri/tauri.conf.json
+++ b/apps/spindle/src-tauri/tauri.conf.json
@@ -31,6 +31,14 @@
 	"bundle": {
 		"active": true,
 		"targets": "all",
+		"linux": {
+			"deb": {
+				"depends": ["ffmpeg"]
+			},
+			"rpm": {
+				"recommends": ["(ffmpeg or ffmpeg-free)"]
+			}
+		},
 		"category": "Video",
 		"publisher": "Liminal HQ",
 		"shortDescription": "A desktop optical-disc authoring workstation for DVD projects.",


### PR DESCRIPTION
## Summary

### Packaging
- **Declare Debian ffmpeg dependency:** Add Linux package metadata so Spindle `.deb` bundles declare a hard dependency on `ffmpeg`, which lets Debian-family package managers surface the host transcoding requirement during install.
- **Keep RPM metadata distro-friendly:** Add an RPM recommendation for `(ffmpeg or ffmpeg-free)` instead of a single hard dependency name, so the package metadata stays compatible with the differing package names used across RPM ecosystems.
- **Preserve AppImage behaviour:** Leave `AppImage` expectations unchanged, with host `ffmpeg` and `ffprobe` still discovered through the existing toolchain checks at runtime.

### Documentation
- **Document install expectations:** Update `README.md` and `SPEC.md` to spell out the Debian, RPM, and AppImage dependency behaviour for `ffmpeg` and `ffprobe`.

## Test plan

- [x] `pnpm exec prettier --check apps/spindle/src-tauri/tauri.conf.json README.md SPEC.md`
- [x] `git diff --check apps/spindle/src-tauri/tauri.conf.json README.md SPEC.md`
- [x] `pnpm release:version:check`
- [ ] Build a fresh `.deb` and `.rpm` from this branch and inspect the emitted package metadata to confirm the dependency fields are present as expected.

The untracked local review notes and diagnostics files were intentionally left out of this PR.
