### PR TITLE
Make the menu workspace responsive on narrow and high-DPI windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,11 +332,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -817,6 +826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,9 +913,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1958,6 +1973,8 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2387,10 +2404,10 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "serde",
@@ -2509,6 +2526,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,15 +2553,44 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2538,8 +2600,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2548,8 +2633,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2560,7 +2645,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2571,9 +2656,21 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2582,8 +2679,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2592,8 +2701,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2603,7 +2712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -2625,14 +2734,26 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2643,8 +2764,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2654,9 +2812,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications 0.2.2",
 ]
 
 [[package]]
@@ -2666,18 +2855,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-location",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
  "objc2-core-text",
- "objc2-foundation",
- "objc2-quartz-core",
- "objc2-user-notifications",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2686,8 +2899,21 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bc69301064cebefc6c4c90ce9cba69225239e4b8ff99d445a2b5563797da65"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2697,11 +2923,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2747,9 +2973,9 @@ dependencies = [
  "android_system_properties",
  "log",
  "nix",
- "objc2",
- "objc2-foundation",
- "objc2-ui-kit",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "serde",
  "windows-sys 0.61.2",
 ]
@@ -3301,6 +3527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,6 +3557,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,6 +3582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3489,17 +3744,17 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
  "js-sys",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3873,6 +4128,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4013,11 +4279,11 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "raw-window-handle",
  "redox_syscall 0.5.18",
  "tracing",
@@ -4064,6 +4330,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
+ "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-shell",
@@ -4223,7 +4490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
@@ -4239,9 +4506,9 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
@@ -4310,11 +4577,11 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "percent-encoding",
  "plist",
  "raw-window-handle",
@@ -4469,8 +4736,8 @@ dependencies = [
  "byte-unit",
  "fern",
  "log",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4482,6 +4749,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-mcp-bridge"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c97bb0d4c68e94ef4d132b6d572416b9d9144144ab185fe3c421f02340fee96e"
+dependencies = [
+ "base64 0.22.1",
+ "block2 0.5.1",
+ "futures-util",
+ "image",
+ "jni",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "objc2-web-kit 0.2.2",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite",
+ "uuid",
+ "webview2-com",
+ "windows",
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,8 +4785,8 @@ checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
 dependencies = [
  "dunce",
  "glob",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "open",
  "schemars 0.8.22",
  "serde",
@@ -4600,9 +4896,9 @@ dependencies = [
  "gtk",
  "http",
  "jni",
- "objc2",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2 0.6.4",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "raw-window-handle",
  "serde",
  "serde_json",
@@ -4624,8 +4920,8 @@ dependencies = [
  "http",
  "jni",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -4830,7 +5126,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4845,6 +5143,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -5066,11 +5376,11 @@ dependencies = [
  "dirs",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "serde",
@@ -5083,6 +5393,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"
@@ -5553,10 +5880,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -6079,7 +6406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs",
@@ -6093,12 +6420,12 @@ dependencies = [
  "jni",
  "libc",
  "ndk",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-ui-kit",
- "objc2-web-kit",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "objc2-web-kit 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -6319,6 +6646,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +925,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "display-info"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0aca670967c2528799e316f9f97913efcc034867614d55681dd41a1c2f7830"
+dependencies = [
+ "fxhash",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "scopeguard",
+ "smithay-client-toolkit",
+ "thiserror 2.0.18",
+ "widestring",
+ "windows 0.62.2",
+ "xcb",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +993,12 @@ dependencies = [
  "selectors 0.36.1",
  "tendril 0.5.0",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -2343,6 +2376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,9 +2617,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -2633,6 +2683,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.0",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -2644,7 +2695,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -2655,10 +2708,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -2670,7 +2726,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -2715,6 +2771,19 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2793,6 +2862,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2882,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3286,7 +3366,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3467,9 +3547,27 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -4261,6 +4359,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix",
+ "thiserror 2.0.18",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,6 +4451,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-display-awareness",
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-mcp-bridge",
@@ -4515,7 +4639,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4603,7 +4727,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4705,6 +4829,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-display-awareness"
+version = "0.1.0"
+dependencies = [
+ "display-info",
+ "serde",
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4773,7 +4907,7 @@ dependencies = [
  "tokio-tungstenite",
  "uuid",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4795,7 +4929,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4907,7 +5041,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4932,7 +5066,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5742,6 +5876,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5815,7 +6067,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5839,9 +6091,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -5895,11 +6153,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5909,6 +6179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5945,7 +6224,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5990,6 +6280,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6119,6 +6419,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6437,7 +6746,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -6482,6 +6791,29 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "apps/spindle/src-tauri",
+    "plugins/tauri-plugin-display-awareness",
     "plugins/tauri-plugin-spindle-project",
     "tools/menu-debug",
 ]

--- a/apps/spindle/package.json
+++ b/apps/spindle/package.json
@@ -4,11 +4,15 @@
 	"version": "0.3.0",
 	"type": "module",
 	"scripts": {
+		"predev": "pnpm --filter tauri-plugin-display-awareness-api build",
 		"dev": "vite",
+		"prebuild": "pnpm --filter tauri-plugin-display-awareness-api build",
 		"build": "tsc && vite build",
 		"preview": "vite preview",
 		"tauri": "tauri",
+		"pretest": "pnpm --filter tauri-plugin-display-awareness-api build",
 		"test": "vitest run",
+		"pretest:ci": "pnpm --filter tauri-plugin-display-awareness-api build",
 		"test:ci": "mkdir -p ../../test-results/spindle && vitest run --reporter=default --reporter=junit --outputFile.junit=../../test-results/spindle/junit.xml",
 		"test:watch": "vitest"
 	},

--- a/apps/spindle/package.json
+++ b/apps/spindle/package.json
@@ -24,6 +24,7 @@
 		"@tauri-apps/plugin-window-state": "^2.4.1",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
+		"tauri-plugin-display-awareness-api": "workspace:*",
 		"zustand": "^5.0.12"
 	},
 	"devDependencies": {

--- a/apps/spindle/src-tauri/Cargo.toml
+++ b/apps/spindle/src-tauri/Cargo.toml
@@ -38,4 +38,5 @@ log = "0.4"
 tauri-plugin-mcp-bridge = "0.11"
 
 # Spindle plugins (workspace)
+tauri-plugin-display-awareness = { path = "../../../plugins/tauri-plugin-display-awareness" }
 tauri-plugin-spindle-project = { path = "../../../plugins/tauri-plugin-spindle-project" }

--- a/apps/spindle/src-tauri/Cargo.toml
+++ b/apps/spindle/src-tauri/Cargo.toml
@@ -33,5 +33,9 @@ tauri-plugin-os = "2"
 tauri-plugin-log = "2"
 log = "0.4"
 
+# Dev/debug tooling: the MCP bridge plugin is only registered under
+# `#[cfg(debug_assertions)]` in code, so it is compiled in but inert in release.
+tauri-plugin-mcp-bridge = "0.11"
+
 # Spindle plugins (workspace)
 tauri-plugin-spindle-project = { path = "../../../plugins/tauri-plugin-spindle-project" }

--- a/apps/spindle/src-tauri/Cargo.toml
+++ b/apps/spindle/src-tauri/Cargo.toml
@@ -33,8 +33,9 @@ tauri-plugin-os = "2"
 tauri-plugin-log = "2"
 log = "0.4"
 
-# Dev/debug tooling: the MCP bridge plugin is only registered under
-# `#[cfg(debug_assertions)]` in code, so it is compiled in but inert in release.
+# Dev/debug tooling. This is a normal (non-optional) dependency, always
+# compiled in; the plugin is only *registered* under `#[cfg(debug_assertions)]`
+# in src/lib.rs, so it is present but inert in release builds.
 tauri-plugin-mcp-bridge = "0.11"
 
 # Spindle plugins (workspace)

--- a/apps/spindle/src-tauri/capabilities/default.json
+++ b/apps/spindle/src-tauri/capabilities/default.json
@@ -25,6 +25,7 @@
 		"window-state:default",
 		"os:default",
 		"log:default",
-		"spindle-project:default"
+		"spindle-project:default",
+		"mcp-bridge:default"
 	]
 }

--- a/apps/spindle/src-tauri/capabilities/default.json
+++ b/apps/spindle/src-tauri/capabilities/default.json
@@ -25,6 +25,7 @@
 		"window-state:default",
 		"os:default",
 		"log:default",
+		"display-awareness:default",
 		"spindle-project:default",
 		"mcp-bridge:default"
 	]

--- a/apps/spindle/src-tauri/src/lib.rs
+++ b/apps/spindle/src-tauri/src/lib.rs
@@ -97,7 +97,7 @@ fn cache_dir_size_and_count(path: &Path) -> std::io::Result<(u64, usize)> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             read_text_file,
             write_text_file,
@@ -114,7 +114,12 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_log::Builder::new().build())
         // Spindle plugins
-        .plugin(tauri_plugin_spindle_project::init())
+        .plugin(tauri_plugin_spindle_project::init());
+
+    #[cfg(debug_assertions)]
+    let builder = builder.plugin(tauri_plugin_mcp_bridge::init());
+
+    builder
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/spindle/src-tauri/src/lib.rs
+++ b/apps/spindle/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_log::Builder::new().build())
         // Spindle plugins
+        .plugin(tauri_plugin_display_awareness::init())
         .plugin(tauri_plugin_spindle_project::init());
 
     #[cfg(debug_assertions)]

--- a/apps/spindle/src/components/menus/MenuMap.tsx
+++ b/apps/spindle/src/components/menus/MenuMap.tsx
@@ -566,11 +566,16 @@ export function MiniMenuMap({
 	selectedMenuId,
 	onSelect,
 	onExpand,
+	collapsed = false,
+	onToggleCollapsed,
 }: {
 	project: SpindleProjectFile;
 	selectedMenuId: string | null;
 	onSelect: (id: string) => void;
 	onExpand: () => void;
+	/** When true, only the header (with its own toggle) is rendered. */
+	collapsed?: boolean;
+	onToggleCollapsed?: () => void;
 }) {
 	const layout = useMemo(() => computeMapLayout(project, true), [project.disc]);
 
@@ -579,34 +584,52 @@ export function MiniMenuMap({
 	return (
 		<div className="mini-map">
 			<div className="mini-map__header">
-				<span className="mini-map__label">Navigation Map</span>
+				{onToggleCollapsed ? (
+					<button
+						className="mini-map__collapse-toggle"
+						type="button"
+						onClick={onToggleCollapsed}
+						aria-expanded={!collapsed}
+					>
+						<span className="mini-map__label">Navigation Map</span>
+						<span className="menu-nav__panel-chevron" aria-hidden="true">
+							⌄
+						</span>
+					</button>
+				) : (
+					<span className="mini-map__label">Navigation Map</span>
+				)}
 				<button className="btn btn--ghost btn--xs" onClick={onExpand} title="Open full map">
 					⤢
 				</button>
 			</div>
-			<div className="mini-map__canvas">
-				<MapSvg
-					layout={layout}
-					selectedMenuId={selectedMenuId}
-					compact={true}
-					onSelect={onSelect}
-				/>
-			</div>
-			{/* Edge type legend */}
-			<div className="mini-map__legend">
-				<span className="mini-map__legend-item">
-					<span className="mini-map__legend-line mini-map__legend-line--show" />
-					<span>show</span>
-				</span>
-				<span className="mini-map__legend-item">
-					<span className="mini-map__legend-line mini-map__legend-line--play" />
-					<span>play</span>
-				</span>
-				<span className="mini-map__legend-item">
-					<span className="mini-map__legend-line mini-map__legend-line--return" />
-					<span>return</span>
-				</span>
-			</div>
+			{collapsed ? null : (
+				<>
+					<div className="mini-map__canvas">
+						<MapSvg
+							layout={layout}
+							selectedMenuId={selectedMenuId}
+							compact={true}
+							onSelect={onSelect}
+						/>
+					</div>
+					{/* Edge type legend */}
+					<div className="mini-map__legend">
+						<span className="mini-map__legend-item">
+							<span className="mini-map__legend-line mini-map__legend-line--show" />
+							<span>show</span>
+						</span>
+						<span className="mini-map__legend-item">
+							<span className="mini-map__legend-line mini-map__legend-line--play" />
+							<span>play</span>
+						</span>
+						<span className="mini-map__legend-item">
+							<span className="mini-map__legend-line mini-map__legend-line--return" />
+							<span>return</span>
+						</span>
+					</div>
+				</>
+			)}
 		</div>
 	);
 }

--- a/apps/spindle/src/hooks/useDisplayDensity.test.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.test.ts
@@ -1,0 +1,121 @@
+// Tests for the display-density breakpoint hook.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { classify, useDisplayDensity, type DisplayGeometry } from './useDisplayDensity';
+
+const { getActiveDisplay, onDisplayChanged } = vi.hoisted(() => ({
+	getActiveDisplay: vi.fn(),
+	onDisplayChanged: vi.fn(),
+}));
+
+vi.mock('tauri-plugin-display-awareness-api', () => ({
+	getActiveDisplay,
+	onDisplayChanged,
+}));
+
+function makeDisplay(overrides: Partial<DisplayGeometry> = {}): DisplayGeometry {
+	return {
+		name: 'DP-1',
+		isPrimary: true,
+		scale: 2,
+		physicalWidth: 3840,
+		physicalHeight: 2160,
+		logicalWidth: 1920,
+		logicalHeight: 1080,
+		positionX: 0,
+		positionY: 0,
+		widthMm: 620,
+		heightMm: 340,
+		...overrides,
+	};
+}
+
+function setWindowInnerSize(width: number, height: number) {
+	Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
+	Object.defineProperty(window, 'innerHeight', {
+		writable: true,
+		configurable: true,
+		value: height,
+	});
+}
+
+describe('classify', () => {
+	it('classifies widths below 900 as compact', () => {
+		expect(classify(0)).toBe('compact');
+		expect(classify(899)).toBe('compact');
+	});
+
+	it('classifies widths from 900 up to (not including) 1280 as medium', () => {
+		expect(classify(900)).toBe('medium');
+		expect(classify(1279)).toBe('medium');
+	});
+
+	it('classifies widths from 1280 and up as wide', () => {
+		expect(classify(1280)).toBe('wide');
+		expect(classify(5000)).toBe('wide');
+	});
+});
+
+describe('useDisplayDensity', () => {
+	beforeEach(() => {
+		getActiveDisplay.mockReset();
+		onDisplayChanged.mockReset();
+		onDisplayChanged.mockReturnValue(Promise.resolve(() => {}));
+		setWindowInnerSize(1280, 800);
+	});
+
+	it('falls back to window size and classifies the breakpoint when no container ref is given', () => {
+		getActiveDisplay.mockResolvedValue(null);
+		const { result } = renderHook(() => useDisplayDensity());
+
+		expect(result.current.viewportWidth).toBe(1280);
+		expect(result.current.viewportHeight).toBe(800);
+		expect(result.current.breakpoint).toBe('wide');
+		expect(result.current.isWide).toBe(true);
+		expect(result.current.isCompact).toBe(false);
+	});
+
+	it('classifies a narrower window as compact', () => {
+		setWindowInnerSize(800, 600);
+		getActiveDisplay.mockResolvedValue(null);
+		const { result } = renderHook(() => useDisplayDensity());
+
+		expect(result.current.breakpoint).toBe('compact');
+		expect(result.current.isCompact).toBe(true);
+	});
+
+	it('applies the active display scale once the plugin resolves', async () => {
+		getActiveDisplay.mockResolvedValue(makeDisplay({ scale: 2 }));
+		const { result } = renderHook(() => useDisplayDensity());
+
+		await waitFor(() => expect(result.current.activeDisplay).not.toBeNull());
+		expect(result.current.scale).toBe(2);
+	});
+
+	it('keeps working off window/DPR signals when the plugin is unavailable', async () => {
+		getActiveDisplay.mockRejectedValue(new Error('not running in a Tauri context'));
+		const { result } = renderHook(() => useDisplayDensity());
+
+		await waitFor(() => expect(getActiveDisplay).toHaveBeenCalled());
+		expect(result.current.activeDisplay).toBeNull();
+		expect(result.current.breakpoint).toBe('wide');
+	});
+
+	it('subscribes to and unsubscribes from display-change notifications', () => {
+		getActiveDisplay.mockResolvedValue(null);
+		const unlisten = vi.fn();
+		onDisplayChanged.mockReturnValue(Promise.resolve(unlisten));
+
+		const { unmount } = renderHook(() => useDisplayDensity());
+		expect(onDisplayChanged).toHaveBeenCalledTimes(1);
+
+		unmount();
+		return Promise.resolve().then(() => {
+			expect(unlisten).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/apps/spindle/src/hooks/useDisplayDensity.test.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.test.ts
@@ -173,4 +173,46 @@ describe('useDisplayDensity', () => {
 			expect(unlisten).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	it('re-measures the attached container, not the window, on a display-change event', () => {
+		// Regression test: a display-change event used to call
+		// setSize(readWindowSize()) unconditionally, clobbering a correct
+		// container-based measurement with the window's width — with nothing
+		// to correct it afterwards unless the container's own size also
+		// happened to change. The handler must re-measure the container
+		// directly when one is attached, and only fall back to the window
+		// when none is.
+		getActiveDisplay.mockResolvedValue(null);
+		let displayChangeHandler: (() => void) | undefined;
+		onDisplayChanged.mockImplementation((handler: () => void) => {
+			displayChangeHandler = handler;
+			return Promise.resolve(() => {});
+		});
+
+		const { result } = renderHook(() => useDisplayDensity());
+
+		const node = document.createElement('div');
+		vi.spyOn(node, 'getBoundingClientRect').mockReturnValue({
+			width: 700,
+			height: 500,
+			top: 0,
+			left: 0,
+			right: 700,
+			bottom: 500,
+			x: 0,
+			y: 0,
+			toJSON: () => ({}),
+		});
+
+		act(() => {
+			result.current.containerRef(node);
+		});
+
+		act(() => {
+			displayChangeHandler?.();
+		});
+
+		expect(result.current.viewportWidth).toBe(700);
+		expect(result.current.viewportWidth).not.toBe(window.innerWidth);
+	});
 });

--- a/apps/spindle/src/hooks/useDisplayDensity.test.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.test.ts
@@ -4,8 +4,28 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { classify, useDisplayDensity, type DisplayGeometry } from './useDisplayDensity';
+
+class MockResizeObserver {
+	static instances: MockResizeObserver[] = [];
+	observedElements: Element[] = [];
+	disconnected = false;
+
+	constructor(public callback: ResizeObserverCallback) {
+		MockResizeObserver.instances.push(this);
+	}
+
+	observe(element: Element) {
+		this.observedElements.push(element);
+	}
+
+	unobserve() {}
+
+	disconnect() {
+		this.disconnected = true;
+	}
+}
 
 const { getActiveDisplay, onDisplayChanged } = vi.hoisted(() => ({
 	getActiveDisplay: vi.fn(),
@@ -66,6 +86,8 @@ describe('useDisplayDensity', () => {
 		onDisplayChanged.mockReset();
 		onDisplayChanged.mockReturnValue(Promise.resolve(() => {}));
 		setWindowInnerSize(1280, 800);
+		MockResizeObserver.instances = [];
+		vi.stubGlobal('ResizeObserver', MockResizeObserver);
 	});
 
 	it('falls back to window size and classifies the breakpoint when no container ref is given', () => {
@@ -103,6 +125,39 @@ describe('useDisplayDensity', () => {
 		await waitFor(() => expect(getActiveDisplay).toHaveBeenCalled());
 		expect(result.current.activeDisplay).toBeNull();
 		expect(result.current.breakpoint).toBe('wide');
+	});
+
+	it('switches from the window fallback to observing the container once it attaches', () => {
+		// Regression test: the hook used to accept a plain useRef object, whose
+		// .current only updates on commit with no signal an effect can depend
+		// on — so a node that mounts on a *later* render than the one where
+		// the hook first ran (e.g. a parent that renders null until some data
+		// loads) was never observed; the breakpoint silently kept measuring
+		// the window forever. A callback ref fixes this by re-firing exactly
+		// when the node attaches, regardless of which render that happens on.
+		getActiveDisplay.mockResolvedValue(null);
+		const { result } = renderHook(() => useDisplayDensity());
+
+		// Nothing attached yet — falls back to the window-resize listener,
+		// not a ResizeObserver.
+		expect(MockResizeObserver.instances).toHaveLength(0);
+
+		const node = document.createElement('div');
+		act(() => {
+			result.current.containerRef(node);
+		});
+
+		// Attaching the node (simulating React committing the ref on a later
+		// render) must start observing it.
+		expect(MockResizeObserver.instances).toHaveLength(1);
+		expect(MockResizeObserver.instances[0]?.observedElements).toContain(node);
+
+		act(() => {
+			result.current.containerRef(null);
+		});
+
+		// Detaching tears down the observer and falls back to the window again.
+		expect(MockResizeObserver.instances[0]?.disconnected).toBe(true);
 	});
 
 	it('subscribes to and unsubscribes from display-change notifications', () => {

--- a/apps/spindle/src/hooks/useDisplayDensity.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.ts
@@ -31,7 +31,7 @@
 // want them, and drives re-evaluation when the window moves between monitors
 // with different scale factors.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	getActiveDisplay,
 	onDisplayChanged,
@@ -96,12 +96,17 @@ export function useDisplayDensity(): DisplayDensity {
 	);
 	const [activeDisplay, setActiveDisplay] = useState<DisplayGeometry | null>(null);
 	const [containerNode, setContainerNode] = useState<HTMLElement | null>(null);
+	// Mirrors containerNode for synchronous reads from the display-change
+	// effect below, without making that effect depend on (and resubscribe
+	// its listener whenever) the container changes.
+	const containerNodeRef = useRef<HTMLElement | null>(null);
 
 	// A callback ref re-fires whenever the node actually attaches/detaches —
 	// unlike a plain useRef object, which doesn't notify anything when its
 	// .current changes, so an effect that captured it before the node existed
 	// would never know to re-measure once it mounted.
 	const containerRef = useCallback((node: HTMLElement | null) => {
+		containerNodeRef.current = node;
 		setContainerNode(node);
 	}, []);
 
@@ -143,7 +148,20 @@ export function useDisplayDensity(): DisplayDensity {
 
 		void refresh();
 		const unlisten = onDisplayChanged(() => {
-			setSize(readWindowSize());
+			// Re-measure whichever source is actually driving the breakpoint.
+			// Falling back to the window unconditionally here would clobber a
+			// correct container measurement with the window's width the moment
+			// the window moves to a monitor with a different scale, with
+			// nothing to correct it afterwards unless the container's actual
+			// size also happened to change (which a ResizeObserver would catch,
+			// but isn't guaranteed here).
+			const node = containerNodeRef.current;
+			if (node) {
+				const rect = node.getBoundingClientRect();
+				setSize({ width: rect.width, height: rect.height });
+			} else {
+				setSize(readWindowSize());
+			}
 			void refresh();
 		});
 

--- a/apps/spindle/src/hooks/useDisplayDensity.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.ts
@@ -1,20 +1,20 @@
 // Density- and size-aware layout signal for responsive UIs.
 //
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
 // The breakpoint we care about is *effective logical width* — how many CSS
 // pixels the window actually has to lay out in — because that is what decides
 // whether multi-column layouts fit. At high DPI the logical viewport is much
-// smaller than the physical resolution (e.g. a 5120x2880 panel at 2x scale only
-// offers ~2560 logical px, and a non-maximised window far less), so keying off
-// physical resolution would be wrong.
+// smaller than the physical resolution (e.g. a 5120x2880 panel at 2x scale
+// only offers ~2560 logical px, and a non-maximised window far less), so
+// keying off physical resolution would be wrong.
 //
-// Primary source is the window's own viewport (`innerWidth`/`innerHeight`,
-// already in logical px). The display-awareness plugin augments this with the
-// active monitor's scale and best-effort physical size, surfaced for callers
-// that want them, and drives re-evaluation when the window moves between
-// monitors with different scale factors.
-//
-// (c) Copyright 2026 Liminal HQ, Scott Morris
-// SPDX-License-Identifier: MIT
+// Primary source is the window's own viewport (innerWidth/innerHeight,
+// already in logical px). The display-awareness plugin augments this with
+// the active monitor's scale and best-effort physical size, surfaced for
+// callers that want them, and drives re-evaluation when the window moves
+// between monitors with different scale factors.
 
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';

--- a/apps/spindle/src/hooks/useDisplayDensity.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.ts
@@ -7,10 +7,19 @@
 // being laid out*, not the whole window — the window also contains the app's
 // own persistent sidebar and padding, so window.innerWidth overstates how
 // much room a given workspace actually has (e.g. the default 1280px window
-// leaves a menu workspace under 1100px after the sidebar). Callers pass a
-// ref to the element whose width should drive the breakpoint; it is measured
-// with a ResizeObserver, falling back to window.innerWidth only until the
-// element is mounted or when no ref is supplied at all.
+// leaves a menu workspace under 1100px after the sidebar). Callers attach
+// the returned `containerRef` callback to the element whose width should
+// drive the breakpoint; it is measured with a ResizeObserver, falling back
+// to window.innerWidth until the element is mounted or when the callback
+// isn't attached to anything.
+//
+// `containerRef` is a *callback* ref rather than a plain `useRef` object on
+// purpose: a plain ref's `.current` only updates when React commits, with no
+// signal that tells an effect to re-run, so an effect that captured the ref
+// object early (e.g. before the element exists, such as while a parent
+// component is still showing a loading/empty state) never re-measures once
+// the element actually mounts later. A callback ref doesn't have that gap —
+// React calls it directly with the node every time it attaches or detaches.
 //
 // At high DPI the logical viewport is also much smaller than the physical
 // resolution (e.g. a 5120x2880 panel at 2x scale only offers ~2560 logical
@@ -22,7 +31,7 @@
 // want them, and drives re-evaluation when the window moves between monitors
 // with different scale factors.
 
-import { useEffect, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
 	getActiveDisplay,
 	onDisplayChanged,
@@ -41,7 +50,7 @@ export type { DisplayGeometry };
 export type LayoutBreakpoint = 'compact' | 'medium' | 'wide';
 
 export interface DisplayDensity {
-	/** Measured workspace (or window, if no container ref given) width in logical px. */
+	/** Measured workspace (or window, if containerRef isn't attached) width in logical px. */
 	viewportWidth: number;
 	/** Measured workspace (or window) height in logical px. */
 	viewportHeight: number;
@@ -53,6 +62,8 @@ export interface DisplayDensity {
 	isCompact: boolean;
 	isMedium: boolean;
 	isWide: boolean;
+	/** Attach to the element whose width should drive the breakpoint. */
+	containerRef: (node: HTMLElement | null) => void;
 }
 
 const MEDIUM_MIN = 900;
@@ -73,24 +84,33 @@ function readWindowSize(): { width: number; height: number } {
 }
 
 /**
- * Reactive display-density signal. Recomputes on resize of the given
- * container (or the window, if no container ref is supplied) and when the
- * active monitor changes (via the display-awareness plugin's change event).
+ * Reactive display-density signal. Recomputes on resize of the element
+ * attached via the returned `containerRef` (or the window, while nothing is
+ * attached) and when the active monitor changes (via the display-awareness
+ * plugin's change event).
  */
-export function useDisplayDensity(containerRef?: RefObject<HTMLElement | null>): DisplayDensity {
+export function useDisplayDensity(): DisplayDensity {
 	const [size, setSize] = useState(readWindowSize);
 	const [scale, setScale] = useState(() =>
 		typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1,
 	);
 	const [activeDisplay, setActiveDisplay] = useState<DisplayGeometry | null>(null);
+	const [containerNode, setContainerNode] = useState<HTMLElement | null>(null);
 
-	// Measure the container (preferred) or fall back to the window.
+	// A callback ref re-fires whenever the node actually attaches/detaches —
+	// unlike a plain useRef object, which doesn't notify anything when its
+	// .current changes, so an effect that captured it before the node existed
+	// would never know to re-measure once it mounted.
+	const containerRef = useCallback((node: HTMLElement | null) => {
+		setContainerNode(node);
+	}, []);
+
+	// Measure the attached container (preferred) or fall back to the window.
 	useEffect(() => {
-		const element = containerRef?.current;
-
-		if (!element) {
+		if (!containerNode) {
 			const onResize = () => setSize(readWindowSize());
 			window.addEventListener('resize', onResize);
+			setSize(readWindowSize());
 			return () => window.removeEventListener('resize', onResize);
 		}
 
@@ -100,9 +120,9 @@ export function useDisplayDensity(containerRef?: RefObject<HTMLElement | null>):
 			const { width, height } = entry.contentRect;
 			setSize({ width, height });
 		});
-		observer.observe(element);
+		observer.observe(containerNode);
 		return () => observer.disconnect();
-	}, [containerRef]);
+	}, [containerNode]);
 
 	// Pull the active monitor's geometry from the plugin, and refresh it whenever
 	// the window crosses to a monitor with a different scale factor.
@@ -144,5 +164,6 @@ export function useDisplayDensity(containerRef?: RefObject<HTMLElement | null>):
 		isCompact: breakpoint === 'compact',
 		isMedium: breakpoint === 'medium',
 		isWide: breakpoint === 'wide',
+		containerRef,
 	};
 }

--- a/apps/spindle/src/hooks/useDisplayDensity.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.ts
@@ -3,41 +3,36 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-// The breakpoint we care about is *effective logical width* — how many CSS
-// pixels the window actually has to lay out in — because that is what decides
-// whether multi-column layouts fit. At high DPI the logical viewport is much
-// smaller than the physical resolution (e.g. a 5120x2880 panel at 2x scale
-// only offers ~2560 logical px, and a non-maximised window far less), so
-// keying off physical resolution would be wrong.
+// The breakpoint we care about is *effective logical width of the workspace
+// being laid out*, not the whole window — the window also contains the app's
+// own persistent sidebar and padding, so window.innerWidth overstates how
+// much room a given workspace actually has (e.g. the default 1280px window
+// leaves a menu workspace under 1100px after the sidebar). Callers pass a
+// ref to the element whose width should drive the breakpoint; it is measured
+// with a ResizeObserver, falling back to window.innerWidth only until the
+// element is mounted or when no ref is supplied at all.
 //
-// Primary source is the window's own viewport (innerWidth/innerHeight,
-// already in logical px). The display-awareness plugin augments this with
-// the active monitor's scale and best-effort physical size, surfaced for
-// callers that want them, and drives re-evaluation when the window moves
-// between monitors with different scale factors.
+// At high DPI the logical viewport is also much smaller than the physical
+// resolution (e.g. a 5120x2880 panel at 2x scale only offers ~2560 logical
+// px), so keying off physical resolution instead of logical width would be
+// wrong on top of the window-vs-workspace issue above.
+//
+// The display-awareness plugin augments the size signal with the active
+// monitor's scale and best-effort physical size, surfaced for callers that
+// want them, and drives re-evaluation when the window moves between monitors
+// with different scale factors.
 
-import { useEffect, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
+import { useEffect, useState, type RefObject } from 'react';
+import {
+	getActiveDisplay,
+	onDisplayChanged,
+	type DisplayGeometry,
+} from 'tauri-plugin-display-awareness-api';
 
-/** Mirrors `DisplayGeometry` from tauri-plugin-display-awareness. */
-export interface DisplayGeometry {
-	name: string;
-	isPrimary: boolean;
-	scale: number;
-	physicalWidth: number;
-	physicalHeight: number;
-	logicalWidth: number;
-	logicalHeight: number;
-	positionX: number;
-	positionY: number;
-	/** Best-effort physical size in millimetres; null when unavailable. */
-	widthMm: number | null;
-	heightMm: number | null;
-}
+export type { DisplayGeometry };
 
 /**
- * Layout breakpoints keyed off the window's effective logical width.
+ * Layout breakpoints keyed off the workspace's effective logical width.
  *
  * - `compact`  (< 900):   single column; rail + inspector become slide-overs.
  * - `medium`   (900-1280): canvas central; side panels dock but are collapsible.
@@ -46,9 +41,9 @@ export interface DisplayGeometry {
 export type LayoutBreakpoint = 'compact' | 'medium' | 'wide';
 
 export interface DisplayDensity {
-	/** Window viewport width in logical (CSS) pixels. */
+	/** Measured workspace (or window, if no container ref given) width in logical px. */
 	viewportWidth: number;
-	/** Window viewport height in logical (CSS) pixels. */
+	/** Measured workspace (or window) height in logical px. */
 	viewportHeight: number;
 	/** Device pixel ratio of the window's current monitor. */
 	scale: number;
@@ -69,31 +64,44 @@ function classify(width: number): LayoutBreakpoint {
 	return 'compact';
 }
 
-function readViewport(): { width: number; height: number; scale: number } {
+function readWindowSize(): { width: number; height: number } {
 	if (typeof window === 'undefined') {
-		return { width: WIDE_MIN, height: 800, scale: 1 };
+		return { width: WIDE_MIN, height: 800 };
 	}
-	return {
-		width: window.innerWidth,
-		height: window.innerHeight,
-		scale: window.devicePixelRatio || 1,
-	};
+	return { width: window.innerWidth, height: window.innerHeight };
 }
 
 /**
- * Reactive display-density signal. Recomputes on window resize and when the
- * active monitor changes (via the `display://changed` plugin event).
+ * Reactive display-density signal. Recomputes on resize of the given
+ * container (or the window, if no container ref is supplied) and when the
+ * active monitor changes (via the display-awareness plugin's change event).
  */
-export function useDisplayDensity(): DisplayDensity {
-	const [viewport, setViewport] = useState(readViewport);
+export function useDisplayDensity(containerRef?: RefObject<HTMLElement | null>): DisplayDensity {
+	const [size, setSize] = useState(readWindowSize);
+	const [scale, setScale] = useState(() =>
+		typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1,
+	);
 	const [activeDisplay, setActiveDisplay] = useState<DisplayGeometry | null>(null);
 
-	// Track viewport changes (resize + DPR shifts surface here as resize events).
+	// Measure the container (preferred) or fall back to the window.
 	useEffect(() => {
-		const onResize = () => setViewport(readViewport());
-		window.addEventListener('resize', onResize);
-		return () => window.removeEventListener('resize', onResize);
-	}, []);
+		const element = containerRef?.current;
+
+		if (!element) {
+			const onResize = () => setSize(readWindowSize());
+			window.addEventListener('resize', onResize);
+			return () => window.removeEventListener('resize', onResize);
+		}
+
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			const { width, height } = entry.contentRect;
+			setSize({ width, height });
+		});
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, [containerRef]);
 
 	// Pull the active monitor's geometry from the plugin, and refresh it whenever
 	// the window crosses to a monitor with a different scale factor.
@@ -102,19 +110,19 @@ export function useDisplayDensity(): DisplayDensity {
 
 		const refresh = async () => {
 			try {
-				const display = await invoke<DisplayGeometry | null>(
-					'plugin:display-awareness|get_active_display',
-				);
-				if (!cancelled) setActiveDisplay(display);
+				const display = await getActiveDisplay();
+				if (cancelled) return;
+				setActiveDisplay(display);
+				if (display) setScale(display.scale);
 			} catch (error) {
-				// Plugin unavailable (e.g. non-Tauri context) — viewport signals still work.
-				console.debug('display-awareness unavailable, using viewport signals only', error);
+				// Plugin unavailable (e.g. non-Tauri context) — size signal still works.
+				console.debug('display-awareness unavailable, using window/DPR signals only', error);
 			}
 		};
 
 		void refresh();
-		const unlisten = listen('display://changed', () => {
-			setViewport(readViewport());
+		const unlisten = onDisplayChanged(() => {
+			setSize(readWindowSize());
 			void refresh();
 		});
 
@@ -124,12 +132,12 @@ export function useDisplayDensity(): DisplayDensity {
 		};
 	}, []);
 
-	const breakpoint = classify(viewport.width);
+	const breakpoint = classify(size.width);
 
 	return {
-		viewportWidth: viewport.width,
-		viewportHeight: viewport.height,
-		scale: activeDisplay?.scale ?? viewport.scale,
+		viewportWidth: size.width,
+		viewportHeight: size.height,
+		scale,
 		activeDisplay,
 		breakpoint,
 		isCompact: breakpoint === 'compact',

--- a/apps/spindle/src/hooks/useDisplayDensity.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.ts
@@ -1,0 +1,139 @@
+// Density- and size-aware layout signal for responsive UIs.
+//
+// The breakpoint we care about is *effective logical width* — how many CSS
+// pixels the window actually has to lay out in — because that is what decides
+// whether multi-column layouts fit. At high DPI the logical viewport is much
+// smaller than the physical resolution (e.g. a 5120x2880 panel at 2x scale only
+// offers ~2560 logical px, and a non-maximised window far less), so keying off
+// physical resolution would be wrong.
+//
+// Primary source is the window's own viewport (`innerWidth`/`innerHeight`,
+// already in logical px). The display-awareness plugin augments this with the
+// active monitor's scale and best-effort physical size, surfaced for callers
+// that want them, and drives re-evaluation when the window moves between
+// monitors with different scale factors.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+/** Mirrors `DisplayGeometry` from tauri-plugin-display-awareness. */
+export interface DisplayGeometry {
+	name: string;
+	isPrimary: boolean;
+	scale: number;
+	physicalWidth: number;
+	physicalHeight: number;
+	logicalWidth: number;
+	logicalHeight: number;
+	positionX: number;
+	positionY: number;
+	/** Best-effort physical size in millimetres; null when unavailable. */
+	widthMm: number | null;
+	heightMm: number | null;
+}
+
+/**
+ * Layout breakpoints keyed off the window's effective logical width.
+ *
+ * - `compact`  (< 900):   single column; rail + inspector become slide-overs.
+ * - `medium`   (900-1280): canvas central; side panels dock but are collapsible.
+ * - `wide`     (>= 1280):  rail + canvas + inspector all persistent.
+ */
+export type LayoutBreakpoint = 'compact' | 'medium' | 'wide';
+
+export interface DisplayDensity {
+	/** Window viewport width in logical (CSS) pixels. */
+	viewportWidth: number;
+	/** Window viewport height in logical (CSS) pixels. */
+	viewportHeight: number;
+	/** Device pixel ratio of the window's current monitor. */
+	scale: number;
+	/** Active monitor geometry from the plugin, or null before it resolves. */
+	activeDisplay: DisplayGeometry | null;
+	breakpoint: LayoutBreakpoint;
+	isCompact: boolean;
+	isMedium: boolean;
+	isWide: boolean;
+}
+
+const MEDIUM_MIN = 900;
+const WIDE_MIN = 1280;
+
+function classify(width: number): LayoutBreakpoint {
+	if (width >= WIDE_MIN) return 'wide';
+	if (width >= MEDIUM_MIN) return 'medium';
+	return 'compact';
+}
+
+function readViewport(): { width: number; height: number; scale: number } {
+	if (typeof window === 'undefined') {
+		return { width: WIDE_MIN, height: 800, scale: 1 };
+	}
+	return {
+		width: window.innerWidth,
+		height: window.innerHeight,
+		scale: window.devicePixelRatio || 1,
+	};
+}
+
+/**
+ * Reactive display-density signal. Recomputes on window resize and when the
+ * active monitor changes (via the `display://changed` plugin event).
+ */
+export function useDisplayDensity(): DisplayDensity {
+	const [viewport, setViewport] = useState(readViewport);
+	const [activeDisplay, setActiveDisplay] = useState<DisplayGeometry | null>(null);
+
+	// Track viewport changes (resize + DPR shifts surface here as resize events).
+	useEffect(() => {
+		const onResize = () => setViewport(readViewport());
+		window.addEventListener('resize', onResize);
+		return () => window.removeEventListener('resize', onResize);
+	}, []);
+
+	// Pull the active monitor's geometry from the plugin, and refresh it whenever
+	// the window crosses to a monitor with a different scale factor.
+	useEffect(() => {
+		let cancelled = false;
+
+		const refresh = async () => {
+			try {
+				const display = await invoke<DisplayGeometry | null>(
+					'plugin:display-awareness|get_active_display',
+				);
+				if (!cancelled) setActiveDisplay(display);
+			} catch (error) {
+				// Plugin unavailable (e.g. non-Tauri context) — viewport signals still work.
+				console.debug('display-awareness unavailable, using viewport signals only', error);
+			}
+		};
+
+		void refresh();
+		const unlisten = listen('display://changed', () => {
+			setViewport(readViewport());
+			void refresh();
+		});
+
+		return () => {
+			cancelled = true;
+			unlisten.then((fn) => fn());
+		};
+	}, []);
+
+	const breakpoint = classify(viewport.width);
+
+	return {
+		viewportWidth: viewport.width,
+		viewportHeight: viewport.height,
+		scale: activeDisplay?.scale ?? viewport.scale,
+		activeDisplay,
+		breakpoint,
+		isCompact: breakpoint === 'compact',
+		isMedium: breakpoint === 'medium',
+		isWide: breakpoint === 'wide',
+	};
+}

--- a/apps/spindle/src/hooks/useDisplayDensity.ts
+++ b/apps/spindle/src/hooks/useDisplayDensity.ts
@@ -58,7 +58,8 @@ export interface DisplayDensity {
 const MEDIUM_MIN = 900;
 const WIDE_MIN = 1280;
 
-function classify(width: number): LayoutBreakpoint {
+/** Exported for direct unit testing of the breakpoint boundaries. */
+export function classify(width: number): LayoutBreakpoint {
 	if (width >= WIDE_MIN) return 'wide';
 	if (width >= MEDIUM_MIN) return 'medium';
 	return 'compact';

--- a/apps/spindle/src/pages/MenusPage.css
+++ b/apps/spindle/src/pages/MenusPage.css
@@ -90,7 +90,12 @@
 }
 
 .menu-nav__list {
-	flex: 1;
+	/* Size to actual content (one menu card is far shorter than half the rail)
+	   instead of claiming an even split with the lower stack regardless of how
+	   much content either side has; scrolls on its own once it's the side with
+	   too much to fit. */
+	flex: 0 1 auto;
+	max-height: 50%;
 	min-height: 0;
 	overflow-y: auto;
 	padding: var(--space-3) var(--space-2);
@@ -107,15 +112,15 @@
 .menu-nav__lower-stack {
 	display: flex;
 	flex-direction: column;
-	flex-shrink: 0;
+	/* Take whatever the (content-sized) menu list above doesn't need, instead
+	   of a fixed 50/50 split that wastes space when the list is short and
+	   starves the nav map + panels when it's long. */
+	flex: 1;
 	gap: var(--space-3);
 	padding: 0 0 var(--space-3);
 	border-top: 1px solid var(--border-subtle);
 	background: linear-gradient(180deg, rgba(10, 10, 16, 0), rgba(10, 10, 16, 0.65));
-	/* Never let the nav map + collapsible panels squeeze the menu list above
-	   them down to nothing — cap at roughly half the rail body and scroll
-	   internally past that, regardless of how many panels are expanded. */
-	max-height: 50%;
+	min-height: 0;
 	overflow-y: auto;
 }
 
@@ -125,6 +130,11 @@
 	border-radius: var(--radius-md);
 	background: rgba(8, 8, 12, 0.72);
 	overflow: hidden;
+	/* As a flex child of .menu-nav__lower-stack, an overflow:hidden element's
+	   flex-basis defaults to min-height:0, so flexbox was free to squeeze this
+	   down to header-only height and silently clip the expanded panel body
+	   underneath. flex-shrink:0 keeps it at its natural content height. */
+	flex-shrink: 0;
 }
 
 .menu-nav__panel-header {

--- a/apps/spindle/src/pages/MenusPage.css
+++ b/apps/spindle/src/pages/MenusPage.css
@@ -810,6 +810,20 @@
 	color: var(--text-muted);
 }
 
+.mini-map__collapse-toggle {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+	border: none;
+	background: transparent;
+	padding: 0;
+	cursor: pointer;
+}
+
+.mini-map__collapse-toggle[aria-expanded='true'] .menu-nav__panel-chevron {
+	transform: rotate(180deg);
+}
+
 .mini-map__canvas {
 	height: 148px;
 	overflow: hidden;

--- a/apps/spindle/src/pages/MenusPage.css
+++ b/apps/spindle/src/pages/MenusPage.css
@@ -8,6 +8,7 @@
 /* ── Layout ───────────────────────────────────────────────── */
 
 .menus-content {
+	position: relative;
 	display: grid;
 	grid-template-columns: 260px 1fr;
 	height: 100%;
@@ -106,10 +107,16 @@
 .menu-nav__lower-stack {
 	display: flex;
 	flex-direction: column;
+	flex-shrink: 0;
 	gap: var(--space-3);
 	padding: 0 0 var(--space-3);
 	border-top: 1px solid var(--border-subtle);
 	background: linear-gradient(180deg, rgba(10, 10, 16, 0), rgba(10, 10, 16, 0.65));
+	/* Never let the nav map + collapsible panels squeeze the menu list above
+	   them down to nothing — cap at roughly half the rail body and scroll
+	   internally past that, regardless of how many panels are expanded. */
+	max-height: 50%;
+	overflow-y: auto;
 }
 
 .menu-nav__panel {
@@ -542,6 +549,13 @@
 	color: var(--brand-pink);
 }
 
+/* Pinned to the far right of the toolbar, beside where the inspector overlay
+   actually opens, so the trigger sits next to the thing it controls rather
+   than wherever it happens to land in the wrapping toggle group. */
+.editor-toolbar__toggle--inspector {
+	margin-left: auto;
+}
+
 .editor-toolbar__toggle-dot {
 	width: 6px;
 	height: 6px;
@@ -607,6 +621,7 @@
 /* ── Workspace split ──────────────────────────────────────── */
 
 .editor-body {
+	position: relative;
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) 356px;
 	flex: 1;
@@ -627,6 +642,12 @@
 	grid-template-columns: 1fr;
 }
 
+/* When the inspector is closed below 'wide', the canvas claims the full
+   width — there is no second column to reserve space for until it opens. */
+.editor-body--inspector-closed {
+	grid-template-columns: 1fr;
+}
+
 .menus__canvas-zone {
 	position: relative;
 	display: flex;
@@ -638,7 +659,11 @@
 		rgba(255, 170, 64, 0.012) 0%,
 		transparent 55%
 	);
-	overflow: hidden;
+	/* .menus__canvas-scroll owns the real scroll/clip boundary one level in;
+	   clipping here too left no room between the two, so the inner element's
+	   own scrollbar (drawn at its edge) was being clipped out of existence by
+	   this parent before it could ever render. */
+	overflow: visible;
 	min-width: 0;
 	min-height: 0;
 }
@@ -698,7 +723,12 @@
 	width: 100%;
 	height: 100%;
 	display: grid;
-	place-items: center;
+	/* `center` only centers when content fits; once the 720x{canvasHeight}
+	   viewport overflows this container (the common case below 'wide'),
+	   center-alignment clips the start edge with no way to scroll back to it.
+	   `safe center` falls back to start-alignment instead of clipping when the
+	   content doesn't fit, keeping the whole canvas reachable by scrolling. */
+	place-items: safe center;
 	overflow: auto;
 	padding: clamp(12px, 2vw, 22px);
 }
@@ -1460,4 +1490,86 @@
 	border-radius: var(--radius-sm);
 	font-style: italic;
 	color: var(--text-muted);
+}
+
+/* ── Responsive: rail becomes an overlay, inspector narrows in-place ──
+   Breakpoints are driven by useDisplayDensity (effective logical width),
+   set as data-breakpoint on .menus. Below 'wide' there is not enough room
+   for the menu rail alongside a useable canvas, so the rail becomes a
+   dismissable overlay the author opens deliberately. The inspector instead
+   shrinks/grows the canvas's grid column in place when toggled — it must
+   never float over canvas content the author may be looking at while it is
+   open, so it is not an overlay.
+
+   This block is intentionally placed at the end of the file: --hidden must
+   win over the base .menu-nav display rule, and with equal specificity that
+   requires later source order rather than relying on selector weight. */
+
+.menus__editor-column {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	min-height: 0;
+	height: 100%;
+	overflow: hidden;
+}
+
+.menus__editor-column > .editor-area {
+	flex: 1;
+	min-height: 0;
+}
+
+.menus[data-breakpoint='medium'] .menus-content,
+.menus[data-breakpoint='compact'] .menus-content {
+	grid-template-columns: 1fr;
+}
+
+.menus[data-breakpoint='medium'] .editor-body:not(.editor-body--inspector-closed) {
+	grid-template-columns: minmax(0, 1fr) 300px;
+}
+
+.menus[data-breakpoint='compact'] .editor-body:not(.editor-body--inspector-closed) {
+	grid-template-columns: minmax(0, 1fr) 280px;
+}
+
+/* Rail overlay */
+
+.menu-nav-scrim {
+	position: absolute;
+	inset: 0;
+	z-index: 20;
+	border: none;
+	background: rgba(0, 0, 0, 0.5);
+	cursor: pointer;
+}
+
+.menu-nav--overlay {
+	position: absolute;
+	inset: 0 auto 0 0;
+	z-index: 21;
+	width: min(300px, 85vw);
+	box-shadow: 8px 0 24px rgba(0, 0, 0, 0.4);
+}
+
+.menu-nav__rail-toggle {
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	font-size: var(--text-sm);
+	cursor: pointer;
+	padding: 2px 6px;
+	border-radius: var(--radius-sm);
+}
+
+.menu-nav__rail-toggle:hover {
+	color: var(--text-primary);
+	background: rgba(255, 255, 255, 0.06);
+}
+
+/* Must come last: equal-specificity --hidden vs. the base .menu-nav display
+   rule is resolved by source order. */
+
+.menu-nav--hidden {
+	display: none;
 }

--- a/apps/spindle/src/pages/MenusPage.tsx
+++ b/apps/spindle/src/pages/MenusPage.tsx
@@ -3,7 +3,7 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { CSSProperties } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { save } from '@tauri-apps/plugin-dialog';
@@ -98,11 +98,13 @@ export function MenusPage() {
 	const menuEditorMode = useProjectStore((s) => s.menuEditorMode);
 	const setMenuEditorMode = useProjectStore((s) => s.setMenuEditorMode);
 	const { consumePendingEntityId } = useNavigation();
-	const menusContainerRef = useRef<HTMLDivElement>(null);
 	// Measured against the workspace container, not the window — the window
 	// also contains the app's own sidebar and padding, so window width
-	// overstates how much room the workspace actually has.
-	const density = useDisplayDensity(menusContainerRef);
+	// overstates how much room the workspace actually has. `containerRef` is
+	// a callback ref attached to the `.menus` div below, which re-measures
+	// correctly even though that div doesn't exist yet on the render where
+	// `project` is still null (see the early return a few lines down).
+	const { containerRef: menusContainerRef, ...density } = useDisplayDensity();
 	// Below 'wide' the rail becomes an overlay, but starts open — picking a
 	// menu to work on is the first thing an author does, so it should not be
 	// hidden by default the way the inspector (a detail panel) is.
@@ -754,7 +756,7 @@ function MenuEditor({
 	onUpdate: (updater: (m: Menu) => Menu) => void;
 	onRemove: () => void;
 	onAutoNav: () => void;
-	density: DisplayDensity;
+	density: Omit<DisplayDensity, 'containerRef'>;
 	railIsOverlay: boolean;
 	railVisible: boolean;
 	onOpenRail: () => void;

--- a/apps/spindle/src/pages/MenusPage.tsx
+++ b/apps/spindle/src/pages/MenusPage.tsx
@@ -1439,18 +1439,18 @@ function MenuEditor({
 								title="Toggle inspector panel"
 							>
 								Inspector
-							<svg
-								width="14"
-								height="14"
-								viewBox="0 0 16 16"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="1.5"
-								aria-hidden="true"
-							>
-								<rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
-								<line x1="10" y1="2.5" x2="10" y2="13.5" />
-							</svg>
+								<svg
+									width="14"
+									height="14"
+									viewBox="0 0 16 16"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="1.5"
+									aria-hidden="true"
+								>
+									<rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
+									<line x1="10" y1="2.5" x2="10" y2="13.5" />
+								</svg>
 							</button>
 						)}
 					</>
@@ -1583,42 +1583,44 @@ function MenuEditor({
 					{(!inspectorIsOverlay || inspectorVisible) && (
 						<div className="menus__side-panel">
 							<InspectorPanel
-							selectedNode={selectedNode}
-							selectedButton={selectedButton}
-							highlightColours={highlightColours}
-							allTitles={allTitles}
-							allMenus={allMenus}
-							currentMenuId={menu.id}
-							onUpdateButton={handleUpdateButton}
-							onUpdateHighlightColours={handleUpdateHighlightColours}
-							onRemoveButton={handleRemoveButton}
-							onUpdateSceneNode={handleUpdateSceneNode}
-							onRemoveNode={handleRemoveNode}
-							assets={project.assets}
-							buttons={currentButtons}
-							interactionNodes={menu.authoredDocument?.interaction.nodes ?? []}
-							defaultFocusId={defaultFocusId}
-							document={menu.authoredDocument ?? null}
-							canvasHeight={canvasHeight}
-							onSetDefaultFocus={handleSetDefaultFocus}
-							sceneNodes={sceneNodes}
-							selectedNodeId={selectedNodeId}
-							onSelectSceneNode={setSelectedNodeId}
-							menu={menu}
-							onUpdateBackgroundAsset={handleBackgroundChange}
-							onUpdateBackgroundColour={handleBackgroundColourChange}
-							onUpdateBackgroundMode={handleBackgroundModeChange}
-							onUpdateMotionAudioAsset={handleMotionAudioChange}
-							onUpdateMotionDurationSecs={handleMotionDurationChange}
-							onUpdateMotionLoopCount={handleMotionLoopCountChange}
-							onAutoNav={onAutoNav}
-							onExportRenderPreview={menu.authoredDocument ? handleExportRenderPreview : undefined}
-							buttonPreviewState={buttonPreviewState}
-							onButtonPreviewStateChange={setButtonPreviewState}
-							displayAspect={displayAspect}
-							onDisplayAspectChange={handleDisplayAspectChange}
-							availableFonts={availableFonts}
-						/>
+								selectedNode={selectedNode}
+								selectedButton={selectedButton}
+								highlightColours={highlightColours}
+								allTitles={allTitles}
+								allMenus={allMenus}
+								currentMenuId={menu.id}
+								onUpdateButton={handleUpdateButton}
+								onUpdateHighlightColours={handleUpdateHighlightColours}
+								onRemoveButton={handleRemoveButton}
+								onUpdateSceneNode={handleUpdateSceneNode}
+								onRemoveNode={handleRemoveNode}
+								assets={project.assets}
+								buttons={currentButtons}
+								interactionNodes={menu.authoredDocument?.interaction.nodes ?? []}
+								defaultFocusId={defaultFocusId}
+								document={menu.authoredDocument ?? null}
+								canvasHeight={canvasHeight}
+								onSetDefaultFocus={handleSetDefaultFocus}
+								sceneNodes={sceneNodes}
+								selectedNodeId={selectedNodeId}
+								onSelectSceneNode={setSelectedNodeId}
+								menu={menu}
+								onUpdateBackgroundAsset={handleBackgroundChange}
+								onUpdateBackgroundColour={handleBackgroundColourChange}
+								onUpdateBackgroundMode={handleBackgroundModeChange}
+								onUpdateMotionAudioAsset={handleMotionAudioChange}
+								onUpdateMotionDurationSecs={handleMotionDurationChange}
+								onUpdateMotionLoopCount={handleMotionLoopCountChange}
+								onAutoNav={onAutoNav}
+								onExportRenderPreview={
+									menu.authoredDocument ? handleExportRenderPreview : undefined
+								}
+								buttonPreviewState={buttonPreviewState}
+								onButtonPreviewStateChange={setButtonPreviewState}
+								displayAspect={displayAspect}
+								onDisplayAspectChange={handleDisplayAspectChange}
+								availableFonts={availableFonts}
+							/>
 						</div>
 					)}
 				</div>

--- a/apps/spindle/src/pages/MenusPage.tsx
+++ b/apps/spindle/src/pages/MenusPage.tsx
@@ -161,6 +161,10 @@ export function MenusPage() {
 	// list crowds out the menu list and nav map above it, especially in the
 	// rail's overlay form below 'wide'.
 	const [generatorsOpen, setGeneratorsOpen] = useState(false);
+	// Open by default (orientation at a glance is the point of the mini map),
+	// but collapsible like its siblings so it can be tucked away on request
+	// rather than always claiming rail space.
+	const [navMapOpen, setNavMapOpen] = useState(true);
 
 	useEffect(() => {
 		if (!firstMenuId) {
@@ -460,6 +464,8 @@ export function MenusPage() {
 									selectedMenuId={selectedMenuId}
 									onSelect={setSelectedMenuId}
 									onExpand={() => setMenuEditorMode('map')}
+									collapsed={!navMapOpen}
+									onToggleCollapsed={() => setNavMapOpen((open) => !open)}
 								/>
 								<div className="menu-nav__panel">
 									<button

--- a/apps/spindle/src/pages/MenusPage.tsx
+++ b/apps/spindle/src/pages/MenusPage.tsx
@@ -9,6 +9,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { save } from '@tauri-apps/plugin-dialog';
 import { useProjectStore } from '../store/project-store';
 import { useNavigation } from '../App';
+import { useDisplayDensity } from '../hooks/useDisplayDensity';
 import type {
 	AspectMode,
 	ButtonStyleMap,
@@ -97,6 +98,13 @@ export function MenusPage() {
 	const menuEditorMode = useProjectStore((s) => s.menuEditorMode);
 	const setMenuEditorMode = useProjectStore((s) => s.setMenuEditorMode);
 	const { consumePendingEntityId } = useNavigation();
+	const density = useDisplayDensity();
+	// Below 'wide' the rail becomes an overlay, but starts open — picking a
+	// menu to work on is the first thing an author does, so it should not be
+	// hidden by default the way the inspector (a detail panel) is.
+	const [railOpenOverlay, setRailOpenOverlay] = useState(true);
+	const railIsOverlay = !density.isWide;
+	const railVisible = density.isWide || railOpenOverlay;
 
 	// Consume navigation target from validation issue click
 	useEffect(() => {
@@ -149,7 +157,10 @@ export function MenusPage() {
 	const audioSetupCount = selectedTitleset ? getMaxAudioTrackCount(selectedTitleset) : 0;
 	const subtitleSetupCount = selectedTitleset ? getMaxSubtitleTrackCount(selectedTitleset) : 0;
 	const [templatesOpen, setTemplatesOpen] = useState(false);
-	const [generatorsOpen, setGeneratorsOpen] = useState(true);
+	// Collapsed by default, matching Templates — an always-expanded generator
+	// list crowds out the menu list and nav map above it, especially in the
+	// rail's overlay form below 'wide'.
+	const [generatorsOpen, setGeneratorsOpen] = useState(false);
 
 	useEffect(() => {
 		if (!firstMenuId) {
@@ -322,10 +333,32 @@ export function MenusPage() {
 	};
 
 	return (
-		<div className="menus">
+		<div className="menus" data-breakpoint={density.breakpoint}>
 			<div className="menus-content">
-				<aside className="menu-nav">
+				{railIsOverlay && railVisible && (
+					<button
+						type="button"
+						className="menu-nav-scrim"
+						aria-label="Close menu rail"
+						onClick={() => setRailOpenOverlay(false)}
+					/>
+				)}
+				<aside
+					className={`menu-nav ${railIsOverlay ? 'menu-nav--overlay' : ''} ${
+						railIsOverlay && !railVisible ? 'menu-nav--hidden' : ''
+					}`}
+				>
 					<div className="menu-nav__header">
+						{railIsOverlay && (
+							<button
+								type="button"
+								className="menu-nav__rail-toggle"
+								aria-label="Close menu rail"
+								onClick={() => setRailOpenOverlay(false)}
+							>
+								✕
+							</button>
+						)}
 						<span className="menu-nav__title">Menus</span>
 						<div className="menu-nav__view-toggle" role="group" aria-label="Workspace view">
 							<button
@@ -532,18 +565,23 @@ export function MenusPage() {
 					</div>
 				</aside>
 
-				{selectedEntry ? (
-					<MenuEditor
-						menu={selectedEntry.menu}
-						project={project}
-						canvasHeight={MENU_HEIGHT[disc.standard]}
-						onUpdate={(updater) => handleUpdateMenu(selectedEntry.menu.id, updater)}
-						onRemove={() => handleRemoveMenu(selectedEntry.menu.id)}
-						onAutoNav={() => autoGenerateMenuNav(selectedEntry.menu.id)}
-					/>
-				) : (
-					<EmptyMenuWorkspace />
-				)}
+				<div className="menus__editor-column">
+					{selectedEntry ? (
+						<MenuEditor
+							menu={selectedEntry.menu}
+							project={project}
+							canvasHeight={MENU_HEIGHT[disc.standard]}
+							onUpdate={(updater) => handleUpdateMenu(selectedEntry.menu.id, updater)}
+							onRemove={() => handleRemoveMenu(selectedEntry.menu.id)}
+							onAutoNav={() => autoGenerateMenuNav(selectedEntry.menu.id)}
+							railIsOverlay={railIsOverlay}
+							railVisible={railVisible}
+							onOpenRail={() => setRailOpenOverlay(true)}
+						/>
+					) : (
+						<EmptyMenuWorkspace />
+					)}
+				</div>
 			</div>
 		</div>
 	);
@@ -672,6 +710,9 @@ function MenuEditor({
 	onUpdate,
 	onRemove,
 	onAutoNav,
+	railIsOverlay,
+	railVisible,
+	onOpenRail,
 }: {
 	menu: Menu;
 	project: SpindleProjectFile;
@@ -679,6 +720,9 @@ function MenuEditor({
 	onUpdate: (updater: (m: Menu) => Menu) => void;
 	onRemove: () => void;
 	onAutoNav: () => void;
+	railIsOverlay: boolean;
+	railVisible: boolean;
+	onOpenRail: () => void;
 }) {
 	const handleExportRenderPreview = useCallback(async () => {
 		const outputPath = await save({
@@ -727,6 +771,13 @@ function MenuEditor({
 	const [activeTool, setActiveTool] = useState<'select' | 'button' | 'text' | 'image' | 'shape'>(
 		'select',
 	);
+	const density = useDisplayDensity();
+	// At wide widths the inspector is a persistent column; below that it becomes
+	// an overlay the author opens deliberately, since there isn't room for it
+	// alongside a useable canvas.
+	const [inspectorOpenOverlay, setInspectorOpenOverlay] = useState(false);
+	const inspectorIsOverlay = !density.isWide;
+	const inspectorVisible = density.isWide || inspectorOpenOverlay;
 	const [availableFonts, setAvailableFonts] = useState<FontEntry[] | undefined>(undefined);
 
 	// Load available fonts once when the menu is selected or when project assets change.
@@ -1249,6 +1300,16 @@ function MenuEditor({
 		<section className="editor-area">
 			<div className={`editor-toolbar ${activeView === 'map' ? 'editor-toolbar--map' : ''}`}>
 				<div className="editor-toolbar__left">
+					{railIsOverlay && !railVisible && (
+						<button
+							type="button"
+							className="editor-toolbar__toggle"
+							onClick={onOpenRail}
+							title="Show menus rail"
+						>
+							☰ Menus
+						</button>
+					)}
 					{activeView === 'editor' ? (
 						<input
 							className="editor-toolbar__name"
@@ -1361,6 +1422,31 @@ function MenuEditor({
 								Delete Menu
 							</button>
 						</div>
+						{inspectorIsOverlay && (
+							<button
+								type="button"
+								className={`editor-toolbar__toggle editor-toolbar__toggle--inspector ${
+									inspectorVisible ? 'editor-toolbar__toggle--active' : ''
+								}`}
+								onClick={() => setInspectorOpenOverlay((v) => !v)}
+								aria-pressed={inspectorVisible}
+								title="Toggle inspector panel"
+							>
+								Inspector
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 16 16"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="1.5"
+								aria-hidden="true"
+							>
+								<rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
+								<line x1="10" y1="2.5" x2="10" y2="13.5" />
+							</svg>
+							</button>
+						)}
 					</>
 				) : (
 					<div className="editor-toolbar__legend" aria-label="Map legend">
@@ -1381,7 +1467,11 @@ function MenuEditor({
 			</div>
 
 			{activeView === 'editor' ? (
-				<div className="editor-body">
+				<div
+					className={`editor-body ${
+						inspectorIsOverlay && !inspectorVisible ? 'editor-body--inspector-closed' : ''
+					}`}
+				>
 					<div className="menus__canvas-zone">
 						<div className="menus__tools-floating" role="toolbar" aria-label="Scene tools">
 							<button
@@ -1484,8 +1574,9 @@ function MenuEditor({
 						</div>
 					</div>
 
-					<div className="menus__side-panel">
-						<InspectorPanel
+					{(!inspectorIsOverlay || inspectorVisible) && (
+						<div className="menus__side-panel">
+							<InspectorPanel
 							selectedNode={selectedNode}
 							selectedButton={selectedButton}
 							highlightColours={highlightColours}
@@ -1522,7 +1613,8 @@ function MenuEditor({
 							onDisplayAspectChange={handleDisplayAspectChange}
 							availableFonts={availableFonts}
 						/>
-					</div>
+						</div>
+					)}
 				</div>
 			) : (
 				<div className="editor-body editor-body--map">

--- a/apps/spindle/src/pages/MenusPage.tsx
+++ b/apps/spindle/src/pages/MenusPage.tsx
@@ -3,13 +3,13 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { CSSProperties } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { save } from '@tauri-apps/plugin-dialog';
 import { useProjectStore } from '../store/project-store';
 import { useNavigation } from '../App';
-import { useDisplayDensity } from '../hooks/useDisplayDensity';
+import { useDisplayDensity, type DisplayDensity } from '../hooks/useDisplayDensity';
 import type {
 	AspectMode,
 	ButtonStyleMap,
@@ -98,7 +98,11 @@ export function MenusPage() {
 	const menuEditorMode = useProjectStore((s) => s.menuEditorMode);
 	const setMenuEditorMode = useProjectStore((s) => s.setMenuEditorMode);
 	const { consumePendingEntityId } = useNavigation();
-	const density = useDisplayDensity();
+	const menusContainerRef = useRef<HTMLDivElement>(null);
+	// Measured against the workspace container, not the window — the window
+	// also contains the app's own sidebar and padding, so window width
+	// overstates how much room the workspace actually has.
+	const density = useDisplayDensity(menusContainerRef);
 	// Below 'wide' the rail becomes an overlay, but starts open — picking a
 	// menu to work on is the first thing an author does, so it should not be
 	// hidden by default the way the inspector (a detail panel) is.
@@ -337,7 +341,7 @@ export function MenusPage() {
 	};
 
 	return (
-		<div className="menus" data-breakpoint={density.breakpoint}>
+		<div className="menus" data-breakpoint={density.breakpoint} ref={menusContainerRef}>
 			<div className="menus-content">
 				{railIsOverlay && railVisible && (
 					<button
@@ -580,12 +584,17 @@ export function MenusPage() {
 							onUpdate={(updater) => handleUpdateMenu(selectedEntry.menu.id, updater)}
 							onRemove={() => handleRemoveMenu(selectedEntry.menu.id)}
 							onAutoNav={() => autoGenerateMenuNav(selectedEntry.menu.id)}
+							density={density}
 							railIsOverlay={railIsOverlay}
 							railVisible={railVisible}
 							onOpenRail={() => setRailOpenOverlay(true)}
 						/>
 					) : (
-						<EmptyMenuWorkspace />
+						<EmptyMenuWorkspace
+							railIsOverlay={railIsOverlay}
+							railVisible={railVisible}
+							onOpenRail={() => setRailOpenOverlay(true)}
+						/>
 					)}
 				</div>
 			</div>
@@ -675,11 +684,29 @@ function MenuListItem({
 	);
 }
 
-function EmptyMenuWorkspace() {
+function EmptyMenuWorkspace({
+	railIsOverlay,
+	railVisible,
+	onOpenRail,
+}: {
+	railIsOverlay: boolean;
+	railVisible: boolean;
+	onOpenRail: () => void;
+}) {
 	return (
 		<section className="editor-area">
 			<div className="editor-toolbar card">
 				<div className="editor-toolbar__left">
+					{railIsOverlay && !railVisible && (
+						<button
+							type="button"
+							className="editor-toolbar__toggle"
+							onClick={onOpenRail}
+							title="Show menus rail"
+						>
+							☰ Menus
+						</button>
+					)}
 					<h2 className="editor-toolbar__title">Menu Workspace</h2>
 				</div>
 			</div>
@@ -716,6 +743,7 @@ function MenuEditor({
 	onUpdate,
 	onRemove,
 	onAutoNav,
+	density,
 	railIsOverlay,
 	railVisible,
 	onOpenRail,
@@ -726,6 +754,7 @@ function MenuEditor({
 	onUpdate: (updater: (m: Menu) => Menu) => void;
 	onRemove: () => void;
 	onAutoNav: () => void;
+	density: DisplayDensity;
 	railIsOverlay: boolean;
 	railVisible: boolean;
 	onOpenRail: () => void;
@@ -777,7 +806,6 @@ function MenuEditor({
 	const [activeTool, setActiveTool] = useState<'select' | 'button' | 'text' | 'image' | 'shape'>(
 		'select',
 	);
-	const density = useDisplayDensity();
 	// At wide widths the inspector is a persistent column; below that it becomes
 	// an overlay the author opens deliberately, since there isn't room for it
 	// alongside a useable canvas.

--- a/package.json
+++ b/package.json
@@ -8,17 +8,16 @@
 		"pnpm": "10.32.1"
 	},
 	"scripts": {
-		"build": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle build",
-		"build:plugins": "pnpm --filter tauri-plugin-display-awareness-api build",
+		"build": "pnpm --filter @liminal-hq/spindle build",
 		"ci:all": "pnpm validate",
-		"dev": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle dev",
+		"dev": "pnpm --filter @liminal-hq/spindle dev",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"release:version:check": "./scripts/check-release-versions.sh",
 		"release:version:prepare": "./scripts/prepare-release-version.sh",
 		"tauri": "pnpm --filter @liminal-hq/spindle tauri",
-		"test:js": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle test",
-		"test:js:ci": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle test:ci",
+		"test:js": "pnpm --filter @liminal-hq/spindle test",
+		"test:js:ci": "pnpm --filter @liminal-hq/spindle test:ci",
 		"test:rust": "cargo nextest run --workspace --locked",
 		"test:rust:ci": "mkdir -p test-results/rust && cargo nextest run --workspace --locked --config-file nextest.toml --profile ci",
 		"validate": "pnpm format:check && pnpm test:js:ci && pnpm build && cargo fmt --all -- --check && cargo clippy --workspace --all-targets --locked -- -D warnings && pnpm test:rust:ci"

--- a/package.json
+++ b/package.json
@@ -8,16 +8,17 @@
 		"pnpm": "10.32.1"
 	},
 	"scripts": {
-		"build": "pnpm --filter @liminal-hq/spindle build",
+		"build": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle build",
+		"build:plugins": "pnpm --filter tauri-plugin-display-awareness-api build",
 		"ci:all": "pnpm validate",
-		"dev": "pnpm --filter @liminal-hq/spindle dev",
+		"dev": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle dev",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"release:version:check": "./scripts/check-release-versions.sh",
 		"release:version:prepare": "./scripts/prepare-release-version.sh",
 		"tauri": "pnpm --filter @liminal-hq/spindle tauri",
-		"test:js": "pnpm --filter @liminal-hq/spindle test",
-		"test:js:ci": "pnpm --filter @liminal-hq/spindle test:ci",
+		"test:js": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle test",
+		"test:js:ci": "pnpm build:plugins && pnpm --filter @liminal-hq/spindle test:ci",
 		"test:rust": "cargo nextest run --workspace --locked",
 		"test:rust:ci": "mkdir -p test-results/rust && cargo nextest run --workspace --locked --config-file nextest.toml --profile ci",
 		"validate": "pnpm format:check && pnpm test:js:ci && pnpm build && cargo fmt --all -- --check && cargo clippy --workspace --all-targets --locked -- -D warnings && pnpm test:rust:ci"

--- a/plugins/tauri-plugin-display-awareness/.gitignore
+++ b/plugins/tauri-plugin-display-awareness/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/tauri-plugin-display-awareness/Cargo.toml
+++ b/plugins/tauri-plugin-display-awareness/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tauri-plugin-display-awareness"
+version = "0.1.0"
+authors = ["Liminal HQ, Scott Morris"]
+description = "Tauri plugin exposing logical display geometry, scale factor, and best-effort physical size, with change events for responsive UIs"
+edition = "2021"
+rust-version = "1.77.2"
+exclude = ["/examples", "/dist-js", "/guest-js", "/node_modules"]
+links = "tauri-plugin-display-awareness"
+
+[dependencies]
+tauri = { version = "2", features = [] }
+serde = { version = "1", features = ["derive"] }
+# Best-effort physical dimensions (mm). Cross-platform (Linux xcb/xrandr, Windows, macOS).
+# Values may be 0/absent when EDID is unavailable; treated as optional by consumers.
+display-info = "0.5"
+
+[build-dependencies]
+tauri-plugin = { version = "2", features = ["build"] }

--- a/plugins/tauri-plugin-display-awareness/README.md
+++ b/plugins/tauri-plugin-display-awareness/README.md
@@ -1,0 +1,47 @@
+# tauri-plugin-display-awareness
+
+Cross-platform monitor geometry for density-aware, responsive UIs.
+
+## Purpose
+
+Exposes per-monitor logical geometry (physical pixels divided by the OS
+scale factor), scale factor, position, and best-effort physical size in
+millimetres, plus an event fired when the active window's scale factor
+changes (e.g. dragged to a different monitor).
+
+This plugin is Spindle-agnostic — it has no dependency on
+`tauri-plugin-spindle-project` or any Spindle-specific types, and could be
+reused by any Tauri app that needs density-aware layout.
+
+Logical geometry is the primary signal: the OS scale factor already encodes
+the user's chosen UI density, so a responsive layout should key its
+breakpoints off logical width, not physical pixels. Physical millimetre size
+is reported best-effort via [`display-info`](https://crates.io/crates/display-info)
+(`null` when the OS/EDID does not report it) and is not used to override the
+OS scale.
+
+## Commands
+
+- `get_displays` — enumerate all connected displays.
+- `get_active_display` — the display the current window resides on (falls
+  back to the primary display, then the first enumerated one).
+
+## Events
+
+- `display://changed` — emitted on the window's `ScaleFactorChanged` event.
+
+## JavaScript bindings
+
+```ts
+import {
+	getDisplays,
+	getActiveDisplay,
+	onDisplayChanged,
+} from 'tauri-plugin-display-awareness-api';
+```
+
+## Platform support
+
+Linux (xcb/xrandr), Windows, and macOS via `display-info`. Physical
+millimetre size may be unavailable on some Wayland sessions, VMs, and
+panels with no EDID — treat `widthMm`/`heightMm` as optional.

--- a/plugins/tauri-plugin-display-awareness/build.rs
+++ b/plugins/tauri-plugin-display-awareness/build.rs
@@ -1,0 +1,5 @@
+const COMMANDS: &[&str] = &["get_displays", "get_active_display"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+}

--- a/plugins/tauri-plugin-display-awareness/guest-js/index.ts
+++ b/plugins/tauri-plugin-display-awareness/guest-js/index.ts
@@ -1,0 +1,39 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+/** Geometry for a single monitor, mirroring the plugin's `DisplayGeometry`. */
+export interface DisplayGeometry {
+	name: string;
+	isPrimary: boolean;
+	scale: number;
+	physicalWidth: number;
+	physicalHeight: number;
+	logicalWidth: number;
+	logicalHeight: number;
+	positionX: number;
+	positionY: number;
+	/** Best-effort physical size in millimetres; null when unavailable. */
+	widthMm: number | null;
+	heightMm: number | null;
+}
+
+/** Event name emitted on scale-factor change (see the plugin's `DISPLAY_CHANGED_EVENT`). */
+export const DISPLAY_CHANGED_EVENT = 'display://changed';
+
+/** Enumerate all connected displays with logical + best-effort physical geometry. */
+export async function getDisplays(): Promise<DisplayGeometry[]> {
+	return await invoke('plugin:display-awareness|get_displays');
+}
+
+/**
+ * Return the display the current window resides on, or null if the plugin is
+ * unavailable (e.g. outside a Tauri context) or no displays were found.
+ */
+export async function getActiveDisplay(): Promise<DisplayGeometry | null> {
+	return await invoke('plugin:display-awareness|get_active_display');
+}
+
+/** Subscribe to scale-factor-change notifications for the current window. */
+export async function onDisplayChanged(handler: () => void): Promise<UnlistenFn> {
+	return await listen(DISPLAY_CHANGED_EVENT, handler);
+}

--- a/plugins/tauri-plugin-display-awareness/package.json
+++ b/plugins/tauri-plugin-display-awareness/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "tauri-plugin-display-awareness-api",
+	"version": "0.1.0",
+	"author": "Liminal HQ, Scott Morris",
+	"description": "JS bindings for the display-awareness Tauri plugin.",
+	"type": "module",
+	"types": "./guest-js/index.ts",
+	"main": "./dist-js/index.cjs",
+	"module": "./dist-js/index.js",
+	"exports": {
+		"types": "./guest-js/index.ts",
+		"source": "./guest-js/index.ts",
+		"import": "./dist-js/index.js",
+		"require": "./dist-js/index.cjs",
+		"default": "./dist-js/index.js"
+	},
+	"files": [
+		"dist-js",
+		"README.md"
+	],
+	"scripts": {
+		"build": "rollup -c",
+		"prepublishOnly": "pnpm build",
+		"pretest": "pnpm build"
+	},
+	"dependencies": {
+		"@tauri-apps/api": "^2.0.0"
+	},
+	"devDependencies": {
+		"@rollup/plugin-typescript": "^12.0.0",
+		"rollup": "^4.9.6",
+		"typescript": "^5.3.3",
+		"tslib": "^2.6.2"
+	}
+}

--- a/plugins/tauri-plugin-display-awareness/package.json
+++ b/plugins/tauri-plugin-display-awareness/package.json
@@ -4,12 +4,11 @@
 	"author": "Liminal HQ, Scott Morris",
 	"description": "JS bindings for the display-awareness Tauri plugin.",
 	"type": "module",
-	"types": "./guest-js/index.ts",
+	"types": "./dist-js/index.d.ts",
 	"main": "./dist-js/index.cjs",
 	"module": "./dist-js/index.js",
 	"exports": {
-		"types": "./guest-js/index.ts",
-		"source": "./guest-js/index.ts",
+		"types": "./dist-js/index.d.ts",
 		"import": "./dist-js/index.js",
 		"require": "./dist-js/index.cjs",
 		"default": "./dist-js/index.js"

--- a/plugins/tauri-plugin-display-awareness/permissions/autogenerated/commands/get_active_display.toml
+++ b/plugins/tauri-plugin-display-awareness/permissions/autogenerated/commands/get_active_display.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-active-display"
+description = "Enables the get_active_display command without any pre-configured scope."
+commands.allow = ["get_active_display"]
+
+[[permission]]
+identifier = "deny-get-active-display"
+description = "Denies the get_active_display command without any pre-configured scope."
+commands.deny = ["get_active_display"]

--- a/plugins/tauri-plugin-display-awareness/permissions/autogenerated/commands/get_displays.toml
+++ b/plugins/tauri-plugin-display-awareness/permissions/autogenerated/commands/get_displays.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-displays"
+description = "Enables the get_displays command without any pre-configured scope."
+commands.allow = ["get_displays"]
+
+[[permission]]
+identifier = "deny-get-displays"
+description = "Denies the get_displays command without any pre-configured scope."
+commands.deny = ["get_displays"]

--- a/plugins/tauri-plugin-display-awareness/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-display-awareness/permissions/autogenerated/reference.md
@@ -15,6 +15,7 @@ Default permissions for the display-awareness plugin
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/plugins/tauri-plugin-display-awareness/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-display-awareness/permissions/autogenerated/reference.md
@@ -1,0 +1,70 @@
+## Default Permission
+
+Default permissions for the display-awareness plugin
+
+#### This default permission set includes the following:
+
+- `allow-get-displays`
+- `allow-get-active-display`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`display-awareness:allow-get-active-display`
+
+</td>
+<td>
+
+Enables the get_active_display command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`display-awareness:deny-get-active-display`
+
+</td>
+<td>
+
+Denies the get_active_display command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`display-awareness:allow-get-displays`
+
+</td>
+<td>
+
+Enables the get_displays command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`display-awareness:deny-get-displays`
+
+</td>
+<td>
+
+Denies the get_displays command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/plugins/tauri-plugin-display-awareness/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-display-awareness/permissions/autogenerated/reference.md
@@ -15,7 +15,6 @@ Default permissions for the display-awareness plugin
 <th>Description</th>
 </tr>
 
-
 <tr>
 <td>
 

--- a/plugins/tauri-plugin-display-awareness/permissions/default.toml
+++ b/plugins/tauri-plugin-display-awareness/permissions/default.toml
@@ -1,0 +1,6 @@
+[default]
+description = "Default permissions for the display-awareness plugin"
+permissions = [
+  "allow-get-displays",
+  "allow-get-active-display",
+]

--- a/plugins/tauri-plugin-display-awareness/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-display-awareness/permissions/schemas/schema.json
@@ -1,330 +1,291 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "PermissionFile",
-  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-  "type": "object",
-  "properties": {
-    "default": {
-      "description": "The default permission set for the plugin",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/DefaultPermission"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
-    "permission": {
-      "description": "A list of inlined permissions",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Permission"
-      }
-    }
-  },
-  "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        },
-        "platforms": {
-          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Target"
-          }
-        }
-      }
-    },
-    "Commands": {
-      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-      "type": "object",
-      "properties": {
-        "allow": {
-          "description": "Allowed command.",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "deny": {
-          "description": "Denied command, which takes priority.",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Scopes": {
-      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-      "type": "object",
-      "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
-          ]
-        },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      ]
-    },
-    "Number": {
-      "description": "A valid ACL number.",
-      "anyOf": [
-        {
-          "description": "Represents an [`i64`].",
-          "type": "integer",
-          "format": "int64"
-        },
-        {
-          "description": "Represents a [`f64`].",
-          "type": "number",
-          "format": "double"
-        }
-      ]
-    },
-    "Target": {
-      "description": "Platform target.",
-      "oneOf": [
-        {
-          "description": "MacOS.",
-          "type": "string",
-          "enum": [
-            "macOS"
-          ]
-        },
-        {
-          "description": "Windows.",
-          "type": "string",
-          "enum": [
-            "windows"
-          ]
-        },
-        {
-          "description": "Linux.",
-          "type": "string",
-          "enum": [
-            "linux"
-          ]
-        },
-        {
-          "description": "Android.",
-          "type": "string",
-          "enum": [
-            "android"
-          ]
-        },
-        {
-          "description": "iOS.",
-          "type": "string",
-          "enum": [
-            "iOS"
-          ]
-        }
-      ]
-    },
-    "PermissionKind": {
-      "type": "string",
-      "oneOf": [
-        {
-          "description": "Enables the get_active_display command without any pre-configured scope.",
-          "type": "string",
-          "const": "allow-get-active-display",
-          "markdownDescription": "Enables the get_active_display command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the get_active_display command without any pre-configured scope.",
-          "type": "string",
-          "const": "deny-get-active-display",
-          "markdownDescription": "Denies the get_active_display command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the get_displays command without any pre-configured scope.",
-          "type": "string",
-          "const": "allow-get-displays",
-          "markdownDescription": "Enables the get_displays command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the get_displays command without any pre-configured scope.",
-          "type": "string",
-          "const": "deny-get-displays",
-          "markdownDescription": "Denies the get_displays command without any pre-configured scope."
-        },
-        {
-          "description": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`",
-          "type": "string",
-          "const": "default",
-          "markdownDescription": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`"
-        }
-      ]
-    }
-  }
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "PermissionFile",
+	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+	"type": "object",
+	"properties": {
+		"default": {
+			"description": "The default permission set for the plugin",
+			"anyOf": [
+				{
+					"$ref": "#/definitions/DefaultPermission"
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"set": {
+			"description": "A list of permissions sets defined",
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/PermissionSet"
+			}
+		},
+		"permission": {
+			"description": "A list of inlined permissions",
+			"default": [],
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/Permission"
+			}
+		}
+	},
+	"definitions": {
+		"DefaultPermission": {
+			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+			"type": "object",
+			"required": ["permissions"],
+			"properties": {
+				"version": {
+					"description": "The version of the permission.",
+					"type": ["integer", "null"],
+					"format": "uint64",
+					"minimum": 1.0
+				},
+				"description": {
+					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+					"type": ["string", "null"]
+				},
+				"permissions": {
+					"description": "All permissions this set contains.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"PermissionSet": {
+			"description": "A set of direct permissions grouped together under a new name.",
+			"type": "object",
+			"required": ["description", "identifier", "permissions"],
+			"properties": {
+				"identifier": {
+					"description": "A unique identifier for the permission.",
+					"type": "string"
+				},
+				"description": {
+					"description": "Human-readable description of what the permission does.",
+					"type": "string"
+				},
+				"permissions": {
+					"description": "All permissions this set contains.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/PermissionKind"
+					}
+				}
+			}
+		},
+		"Permission": {
+			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+			"type": "object",
+			"required": ["identifier"],
+			"properties": {
+				"version": {
+					"description": "The version of the permission.",
+					"type": ["integer", "null"],
+					"format": "uint64",
+					"minimum": 1.0
+				},
+				"identifier": {
+					"description": "A unique identifier for the permission.",
+					"type": "string"
+				},
+				"description": {
+					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+					"type": ["string", "null"]
+				},
+				"commands": {
+					"description": "Allowed or denied commands when using this permission.",
+					"default": {
+						"allow": [],
+						"deny": []
+					},
+					"allOf": [
+						{
+							"$ref": "#/definitions/Commands"
+						}
+					]
+				},
+				"scope": {
+					"description": "Allowed or denied scoped when using this permission.",
+					"allOf": [
+						{
+							"$ref": "#/definitions/Scopes"
+						}
+					]
+				},
+				"platforms": {
+					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+					"type": ["array", "null"],
+					"items": {
+						"$ref": "#/definitions/Target"
+					}
+				}
+			}
+		},
+		"Commands": {
+			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+			"type": "object",
+			"properties": {
+				"allow": {
+					"description": "Allowed command.",
+					"default": [],
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"deny": {
+					"description": "Denied command, which takes priority.",
+					"default": [],
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"Scopes": {
+			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+			"type": "object",
+			"properties": {
+				"allow": {
+					"description": "Data that defines what is allowed by the scope.",
+					"type": ["array", "null"],
+					"items": {
+						"$ref": "#/definitions/Value"
+					}
+				},
+				"deny": {
+					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+					"type": ["array", "null"],
+					"items": {
+						"$ref": "#/definitions/Value"
+					}
+				}
+			}
+		},
+		"Value": {
+			"description": "All supported ACL values.",
+			"anyOf": [
+				{
+					"description": "Represents a null JSON value.",
+					"type": "null"
+				},
+				{
+					"description": "Represents a [`bool`].",
+					"type": "boolean"
+				},
+				{
+					"description": "Represents a valid ACL [`Number`].",
+					"allOf": [
+						{
+							"$ref": "#/definitions/Number"
+						}
+					]
+				},
+				{
+					"description": "Represents a [`String`].",
+					"type": "string"
+				},
+				{
+					"description": "Represents a list of other [`Value`]s.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/Value"
+					}
+				},
+				{
+					"description": "Represents a map of [`String`] keys to [`Value`]s.",
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/Value"
+					}
+				}
+			]
+		},
+		"Number": {
+			"description": "A valid ACL number.",
+			"anyOf": [
+				{
+					"description": "Represents an [`i64`].",
+					"type": "integer",
+					"format": "int64"
+				},
+				{
+					"description": "Represents a [`f64`].",
+					"type": "number",
+					"format": "double"
+				}
+			]
+		},
+		"Target": {
+			"description": "Platform target.",
+			"oneOf": [
+				{
+					"description": "MacOS.",
+					"type": "string",
+					"enum": ["macOS"]
+				},
+				{
+					"description": "Windows.",
+					"type": "string",
+					"enum": ["windows"]
+				},
+				{
+					"description": "Linux.",
+					"type": "string",
+					"enum": ["linux"]
+				},
+				{
+					"description": "Android.",
+					"type": "string",
+					"enum": ["android"]
+				},
+				{
+					"description": "iOS.",
+					"type": "string",
+					"enum": ["iOS"]
+				}
+			]
+		},
+		"PermissionKind": {
+			"type": "string",
+			"oneOf": [
+				{
+					"description": "Enables the get_active_display command without any pre-configured scope.",
+					"type": "string",
+					"const": "allow-get-active-display",
+					"markdownDescription": "Enables the get_active_display command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the get_active_display command without any pre-configured scope.",
+					"type": "string",
+					"const": "deny-get-active-display",
+					"markdownDescription": "Denies the get_active_display command without any pre-configured scope."
+				},
+				{
+					"description": "Enables the get_displays command without any pre-configured scope.",
+					"type": "string",
+					"const": "allow-get-displays",
+					"markdownDescription": "Enables the get_displays command without any pre-configured scope."
+				},
+				{
+					"description": "Denies the get_displays command without any pre-configured scope.",
+					"type": "string",
+					"const": "deny-get-displays",
+					"markdownDescription": "Denies the get_displays command without any pre-configured scope."
+				},
+				{
+					"description": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`",
+					"type": "string",
+					"const": "default",
+					"markdownDescription": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`"
+				}
+			]
+		}
+	}
 }

--- a/plugins/tauri-plugin-display-awareness/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-display-awareness/permissions/schemas/schema.json
@@ -1,291 +1,330 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "PermissionFile",
-	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-	"type": "object",
-	"properties": {
-		"default": {
-			"description": "The default permission set for the plugin",
-			"anyOf": [
-				{
-					"$ref": "#/definitions/DefaultPermission"
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"set": {
-			"description": "A list of permissions sets defined",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/PermissionSet"
-			}
-		},
-		"permission": {
-			"description": "A list of inlined permissions",
-			"default": [],
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/Permission"
-			}
-		}
-	},
-	"definitions": {
-		"DefaultPermission": {
-			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-			"type": "object",
-			"required": ["permissions"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"PermissionSet": {
-			"description": "A set of direct permissions grouped together under a new name.",
-			"type": "object",
-			"required": ["description", "identifier", "permissions"],
-			"properties": {
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does.",
-					"type": "string"
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/PermissionKind"
-					}
-				}
-			}
-		},
-		"Permission": {
-			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-			"type": "object",
-			"required": ["identifier"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"commands": {
-					"description": "Allowed or denied commands when using this permission.",
-					"default": {
-						"allow": [],
-						"deny": []
-					},
-					"allOf": [
-						{
-							"$ref": "#/definitions/Commands"
-						}
-					]
-				},
-				"scope": {
-					"description": "Allowed or denied scoped when using this permission.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Scopes"
-						}
-					]
-				},
-				"platforms": {
-					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Target"
-					}
-				}
-			}
-		},
-		"Commands": {
-			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Allowed command.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"deny": {
-					"description": "Denied command, which takes priority.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"Scopes": {
-			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Data that defines what is allowed by the scope.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				"deny": {
-					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			}
-		},
-		"Value": {
-			"description": "All supported ACL values.",
-			"anyOf": [
-				{
-					"description": "Represents a null JSON value.",
-					"type": "null"
-				},
-				{
-					"description": "Represents a [`bool`].",
-					"type": "boolean"
-				},
-				{
-					"description": "Represents a valid ACL [`Number`].",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Number"
-						}
-					]
-				},
-				{
-					"description": "Represents a [`String`].",
-					"type": "string"
-				},
-				{
-					"description": "Represents a list of other [`Value`]s.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				{
-					"description": "Represents a map of [`String`] keys to [`Value`]s.",
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			]
-		},
-		"Number": {
-			"description": "A valid ACL number.",
-			"anyOf": [
-				{
-					"description": "Represents an [`i64`].",
-					"type": "integer",
-					"format": "int64"
-				},
-				{
-					"description": "Represents a [`f64`].",
-					"type": "number",
-					"format": "double"
-				}
-			]
-		},
-		"Target": {
-			"description": "Platform target.",
-			"oneOf": [
-				{
-					"description": "MacOS.",
-					"type": "string",
-					"enum": ["macOS"]
-				},
-				{
-					"description": "Windows.",
-					"type": "string",
-					"enum": ["windows"]
-				},
-				{
-					"description": "Linux.",
-					"type": "string",
-					"enum": ["linux"]
-				},
-				{
-					"description": "Android.",
-					"type": "string",
-					"enum": ["android"]
-				},
-				{
-					"description": "iOS.",
-					"type": "string",
-					"enum": ["iOS"]
-				}
-			]
-		},
-		"PermissionKind": {
-			"type": "string",
-			"oneOf": [
-				{
-					"description": "Enables the get_active_display command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-get-active-display",
-					"markdownDescription": "Enables the get_active_display command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the get_active_display command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-get-active-display",
-					"markdownDescription": "Denies the get_active_display command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the get_displays command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-get-displays",
-					"markdownDescription": "Enables the get_displays command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the get_displays command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-get-displays",
-					"markdownDescription": "Denies the get_displays command without any pre-configured scope."
-				},
-				{
-					"description": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`",
-					"type": "string",
-					"const": "default",
-					"markdownDescription": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`"
-				}
-			]
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the get_active_display command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-active-display",
+          "markdownDescription": "Enables the get_active_display command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_active_display command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-active-display",
+          "markdownDescription": "Denies the get_active_display command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_displays command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-displays",
+          "markdownDescription": "Enables the get_displays command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_displays command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-displays",
+          "markdownDescription": "Denies the get_displays command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`"
+        }
+      ]
+    }
+  }
 }

--- a/plugins/tauri-plugin-display-awareness/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-display-awareness/permissions/schemas/schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the get_active_display command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-active-display",
+          "markdownDescription": "Enables the get_active_display command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_active_display command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-active-display",
+          "markdownDescription": "Denies the get_active_display command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_displays command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-displays",
+          "markdownDescription": "Enables the get_displays command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_displays command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-displays",
+          "markdownDescription": "Denies the get_displays command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the display-awareness plugin\n#### This default permission set includes:\n\n- `allow-get-displays`\n- `allow-get-active-display`"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/tauri-plugin-display-awareness/rollup.config.js
+++ b/plugins/tauri-plugin-display-awareness/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { cwd } from 'node:process';
+import typescript from '@rollup/plugin-typescript';
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'));
+
+export default {
+	input: 'guest-js/index.ts',
+	output: [
+		{
+			file: pkg.exports.import,
+			format: 'esm',
+		},
+		{
+			file: pkg.exports.require,
+			format: 'cjs',
+		},
+	],
+	plugins: [
+		typescript({
+			declaration: true,
+			declarationDir: dirname(pkg.exports.import),
+		}),
+	],
+	external: [
+		/^@tauri-apps\/api/,
+		...Object.keys(pkg.dependencies || {}),
+		...Object.keys(pkg.peerDependencies || {}),
+	],
+};

--- a/plugins/tauri-plugin-display-awareness/src/lib.rs
+++ b/plugins/tauri-plugin-display-awareness/src/lib.rs
@@ -1,13 +1,13 @@
 // Tauri plugin exposing display geometry for responsive, density-aware UIs.
 //
-// The primary signal is *logical* geometry (physical pixels ÷ scale factor),
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+// The primary signal is logical geometry (physical pixels / scale factor),
 // because the OS scale factor already encodes the user's chosen UI density.
 // Physical millimetre size is reported best-effort (it is unavailable on some
 // Wayland sessions, VMs, and panels with no EDID) and must be treated as
 // optional by consumers — never as a basis for overriding the OS scale.
-//
-// (c) Copyright 2026 Liminal HQ, Scott Morris
-// SPDX-License-Identifier: MIT
 
 use serde::Serialize;
 use tauri::{

--- a/plugins/tauri-plugin-display-awareness/src/lib.rs
+++ b/plugins/tauri-plugin-display-awareness/src/lib.rs
@@ -133,7 +133,8 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             let emitter = window.clone();
             window.on_window_event(move |event| {
                 if let WindowEvent::ScaleFactorChanged { .. } = event {
-                    let _ = emitter.emit(DISPLAY_CHANGED_EVENT, get_active_display(emitter.clone()));
+                    let _ =
+                        emitter.emit(DISPLAY_CHANGED_EVENT, get_active_display(emitter.clone()));
                 }
             });
         })

--- a/plugins/tauri-plugin-display-awareness/src/lib.rs
+++ b/plugins/tauri-plugin-display-awareness/src/lib.rs
@@ -1,0 +1,141 @@
+// Tauri plugin exposing display geometry for responsive, density-aware UIs.
+//
+// The primary signal is *logical* geometry (physical pixels ÷ scale factor),
+// because the OS scale factor already encodes the user's chosen UI density.
+// Physical millimetre size is reported best-effort (it is unavailable on some
+// Wayland sessions, VMs, and panels with no EDID) and must be treated as
+// optional by consumers — never as a basis for overriding the OS scale.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+use serde::Serialize;
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Emitter, Runtime, Window, WindowEvent,
+};
+
+/// Event emitted when the active window's scale factor changes (e.g. the window
+/// is dragged to a monitor with a different scale). Frontends should re-query
+/// [`get_active_display`] in response.
+pub const DISPLAY_CHANGED_EVENT: &str = "display://changed";
+
+/// Geometry for a single monitor.
+///
+/// `logical_*` fields are the OS-scale-corrected values a responsive layout
+/// should key its breakpoints off. `physical_*` are raw pixels; `*_mm` are
+/// best-effort physical dimensions (`None` when the OS could not report them).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplayGeometry {
+    pub name: String,
+    pub is_primary: bool,
+    pub scale: f64,
+    pub physical_width: u32,
+    pub physical_height: u32,
+    /// `physical_width / scale`, rounded.
+    pub logical_width: u32,
+    /// `physical_height / scale`, rounded.
+    pub logical_height: u32,
+    pub position_x: i32,
+    pub position_y: i32,
+    /// Best-effort physical size in millimetres; `None`/`0` when unavailable.
+    pub width_mm: Option<u32>,
+    pub height_mm: Option<u32>,
+}
+
+fn round_div(value: u32, scale: f64) -> u32 {
+    if scale <= 0.0 {
+        return value;
+    }
+    (value as f64 / scale).round() as u32
+}
+
+fn normalise_mm(value: i32) -> Option<u32> {
+    // display-info reports 0 when EDID is unavailable; surface that as None.
+    if value > 0 {
+        Some(value as u32)
+    } else {
+        None
+    }
+}
+
+/// Enumerate all connected displays with logical + best-effort physical geometry.
+#[tauri::command]
+fn get_displays() -> Vec<DisplayGeometry> {
+    let infos = display_info::DisplayInfo::all().unwrap_or_default();
+    infos
+        .into_iter()
+        .map(|d| {
+            let scale = d.scale_factor as f64;
+            DisplayGeometry {
+                name: d.name.clone(),
+                is_primary: d.is_primary,
+                scale,
+                physical_width: d.width,
+                physical_height: d.height,
+                logical_width: round_div(d.width, scale),
+                logical_height: round_div(d.height, scale),
+                position_x: d.x,
+                position_y: d.y,
+                width_mm: normalise_mm(d.width_mm),
+                height_mm: normalise_mm(d.height_mm),
+            }
+        })
+        .collect()
+}
+
+/// Return the display the given window currently resides on, falling back to the
+/// primary display. The reported `scale` prefers the window's live scale factor.
+#[tauri::command]
+fn get_active_display<R: Runtime>(window: Window<R>) -> Option<DisplayGeometry> {
+    let displays = get_displays();
+    if displays.is_empty() {
+        return None;
+    }
+
+    // Match by the window's outer position against each display's bounds.
+    let window_pos = window
+        .outer_position()
+        .ok()
+        .map(|p| (p.x, p.y))
+        .unwrap_or((0, 0));
+
+    let matched = displays.iter().find(|d| {
+        let within_x =
+            window_pos.0 >= d.position_x && window_pos.0 < d.position_x + d.physical_width as i32;
+        let within_y =
+            window_pos.1 >= d.position_y && window_pos.1 < d.position_y + d.physical_height as i32;
+        within_x && within_y
+    });
+
+    let mut chosen = matched
+        .or_else(|| displays.iter().find(|d| d.is_primary))
+        .or_else(|| displays.first())
+        .cloned()?;
+
+    // Prefer the window's live scale factor — it is authoritative for layout and
+    // can differ from the enumerated value mid-transition between monitors.
+    if let Ok(scale) = window.scale_factor() {
+        chosen.scale = scale;
+        chosen.logical_width = round_div(chosen.physical_width, scale);
+        chosen.logical_height = round_div(chosen.physical_height, scale);
+    }
+
+    Some(chosen)
+}
+
+/// Initialise the plugin.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("display-awareness")
+        .invoke_handler(tauri::generate_handler![get_displays, get_active_display])
+        .on_window_ready(|window| {
+            let emitter = window.clone();
+            window.on_window_event(move |event| {
+                if let WindowEvent::ScaleFactorChanged { .. } = event {
+                    let _ = emitter.emit(DISPLAY_CHANGED_EVENT, get_active_display(emitter.clone()));
+                }
+            });
+        })
+        .build()
+}

--- a/plugins/tauri-plugin-display-awareness/src/lib.rs
+++ b/plugins/tauri-plugin-display-awareness/src/lib.rs
@@ -25,7 +25,7 @@ pub const DISPLAY_CHANGED_EVENT: &str = "display://changed";
 /// `logical_*` fields are the OS-scale-corrected values a responsive layout
 /// should key its breakpoints off. `physical_*` are raw pixels; `*_mm` are
 /// best-effort physical dimensions (`None` when the OS could not report them).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DisplayGeometry {
     pub name: String,
@@ -85,22 +85,11 @@ fn get_displays() -> Vec<DisplayGeometry> {
         .collect()
 }
 
-/// Return the display the given window currently resides on, falling back to the
-/// primary display. The reported `scale` prefers the window's live scale factor.
-#[tauri::command]
-fn get_active_display<R: Runtime>(window: Window<R>) -> Option<DisplayGeometry> {
-    let displays = get_displays();
-    if displays.is_empty() {
-        return None;
-    }
-
-    // Match by the window's outer position against each display's bounds.
-    let window_pos = window
-        .outer_position()
-        .ok()
-        .map(|p| (p.x, p.y))
-        .unwrap_or((0, 0));
-
+/// Pick the display a window at `window_pos` resides on: the display whose
+/// bounds contain that point, falling back to the primary display, then to
+/// the first enumerated display, in that order. Pure and runtime-independent
+/// so it can be unit tested without a live `Window`.
+fn choose_display(displays: &[DisplayGeometry], window_pos: (i32, i32)) -> Option<DisplayGeometry> {
     let matched = displays.iter().find(|d| {
         let within_x =
             window_pos.0 >= d.position_x && window_pos.0 < d.position_x + d.physical_width as i32;
@@ -109,10 +98,25 @@ fn get_active_display<R: Runtime>(window: Window<R>) -> Option<DisplayGeometry> 
         within_x && within_y
     });
 
-    let mut chosen = matched
+    matched
         .or_else(|| displays.iter().find(|d| d.is_primary))
         .or_else(|| displays.first())
-        .cloned()?;
+        .cloned()
+}
+
+/// Return the display the given window currently resides on, falling back to the
+/// primary display. The reported `scale` prefers the window's live scale factor.
+#[tauri::command]
+fn get_active_display<R: Runtime>(window: Window<R>) -> Option<DisplayGeometry> {
+    let displays = get_displays();
+
+    let window_pos = window
+        .outer_position()
+        .ok()
+        .map(|p| (p.x, p.y))
+        .unwrap_or((0, 0));
+
+    let mut chosen = choose_display(&displays, window_pos)?;
 
     // Prefer the window's live scale factor — it is authoritative for layout and
     // can differ from the enumerated value mid-transition between monitors.
@@ -139,4 +143,101 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             });
         })
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn display(name: &str, is_primary: bool, x: i32, y: i32, w: u32, h: u32) -> DisplayGeometry {
+        DisplayGeometry {
+            name: name.to_string(),
+            is_primary,
+            scale: 1.0,
+            physical_width: w,
+            physical_height: h,
+            logical_width: w,
+            logical_height: h,
+            position_x: x,
+            position_y: y,
+            width_mm: None,
+            height_mm: None,
+        }
+    }
+
+    #[test]
+    fn round_div_divides_and_rounds() {
+        assert_eq!(round_div(1920, 2.0), 960);
+        // 1000 / 3 = 333.33... rounds to 333.
+        assert_eq!(round_div(1000, 3.0), 333);
+        // 1000 / 1.5 = 666.67 rounds up to 667.
+        assert_eq!(round_div(1000, 1.5), 667);
+    }
+
+    #[test]
+    fn round_div_returns_value_unchanged_for_non_positive_scale() {
+        assert_eq!(round_div(1920, 0.0), 1920);
+        assert_eq!(round_div(1920, -1.0), 1920);
+    }
+
+    #[test]
+    fn normalise_mm_treats_positive_values_as_present() {
+        assert_eq!(normalise_mm(620), Some(620));
+        assert_eq!(normalise_mm(1), Some(1));
+    }
+
+    #[test]
+    fn normalise_mm_treats_zero_and_negative_as_absent() {
+        // display-info reports 0 when EDID doesn't supply a physical size.
+        assert_eq!(normalise_mm(0), None);
+        assert_eq!(normalise_mm(-1), None);
+    }
+
+    #[test]
+    fn choose_display_returns_none_for_empty_list() {
+        assert_eq!(choose_display(&[], (0, 0)), None);
+    }
+
+    #[test]
+    fn choose_display_matches_the_display_containing_the_window() {
+        let primary = display("primary", true, 0, 0, 1920, 1080);
+        let secondary = display("secondary", false, 1920, 0, 1280, 720);
+        let displays = [primary.clone(), secondary.clone()];
+
+        // A point inside the second display's bounds should match it, even
+        // though the primary display is listed first.
+        assert_eq!(choose_display(&displays, (2000, 100)), Some(secondary));
+        assert_eq!(choose_display(&displays, (100, 100)), Some(primary));
+    }
+
+    #[test]
+    fn choose_display_falls_back_to_primary_when_window_position_matches_none() {
+        let primary = display("primary", true, 0, 0, 1920, 1080);
+        let secondary = display("secondary", false, 1920, 0, 1280, 720);
+        let displays = [secondary, primary.clone()];
+
+        // (5000, 5000) is outside both displays' bounds.
+        assert_eq!(choose_display(&displays, (5000, 5000)), Some(primary));
+    }
+
+    #[test]
+    fn choose_display_falls_back_to_first_display_when_none_is_primary() {
+        let first = display("first", false, 0, 0, 1920, 1080);
+        let second = display("second", false, 1920, 0, 1280, 720);
+        let displays = [first.clone(), second];
+
+        assert_eq!(choose_display(&displays, (5000, 5000)), Some(first));
+    }
+
+    #[test]
+    fn choose_display_bounds_are_exclusive_on_the_far_edge() {
+        let only = display("only", true, 0, 0, 1920, 1080);
+        let displays = [only.clone()];
+
+        // The bottom-right corner (1920, 1080) is one pixel past the display's
+        // bounds on both axes and should not match directly, but still falls
+        // back to the (sole) primary display.
+        assert_eq!(choose_display(&displays, (1919, 1079)), Some(only.clone()));
+        assert_eq!(choose_display(&displays, (1920, 1080)), Some(only));
+    }
 }

--- a/plugins/tauri-plugin-display-awareness/tsconfig.json
+++ b/plugins/tauri-plugin-display-awareness/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "es2021",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"skipLibCheck": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noImplicitAny": true,
+		"noEmit": true
+	},
+	"include": ["guest-js/*.ts"],
+	"exclude": ["dist-js", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
+      tauri-plugin-display-awareness-api:
+        specifier: workspace:*
+        version: link:../../plugins/tauri-plugin-display-awareness
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -80,6 +83,25 @@ importers:
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@25.5.0)(happy-dom@20.8.4)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0))
+
+  plugins/tauri-plugin-display-awareness:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.60.0)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.60.0
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
 
 packages:
   '@adobe/css-tools@4.4.4':
@@ -598,6 +620,34 @@ packages:
       {
         integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
       }
+
+  '@rollup/plugin-typescript@12.3.0':
+    resolution:
+      {
+        integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==,
+      }
+    engines: { node: '>=14.0.0' }
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
+  '@rollup/pluginutils@5.4.0':
+    resolution:
+      {
+        integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==,
+      }
+    engines: { node: '>=14.0.0' }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     resolution:
@@ -1353,6 +1403,13 @@ packages:
       }
     engines: { node: '>=0.12' }
 
+  es-errors@1.3.0:
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: '>= 0.4' }
+
   es-module-lexer@2.0.0:
     resolution:
       {
@@ -1373,6 +1430,12 @@ packages:
         integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
       }
     engines: { node: '>=6' }
+
+  estree-walker@2.0.2:
+    resolution:
+      {
+        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
+      }
 
   estree-walker@3.0.3:
     resolution:
@@ -1407,6 +1470,12 @@ packages:
     engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+      }
+
   gensync@1.0.0-beta.2:
     resolution:
       {
@@ -1421,6 +1490,13 @@ packages:
       }
     engines: { node: '>=20.0.0' }
 
+  hasown@2.0.4:
+    resolution:
+      {
+        integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
+      }
+    engines: { node: '>= 0.4' }
+
   html-encoding-sniffer@6.0.0:
     resolution:
       {
@@ -1434,6 +1510,13 @@ packages:
         integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==,
       }
     engines: { node: '>=8' }
+
+  is-core-module@2.16.2:
+    resolution:
+      {
+        integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==,
+      }
+    engines: { node: '>= 0.4' }
 
   is-potential-custom-element-name@1.0.1:
     resolution:
@@ -1553,6 +1636,12 @@ packages:
         integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==,
       }
 
+  path-parse@1.0.7:
+    resolution:
+      {
+        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+      }
+
   pathe@2.0.3:
     resolution:
       {
@@ -1643,6 +1732,14 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
+  resolve@1.22.12:
+    resolution:
+      {
+        integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==,
+      }
+    engines: { node: '>= 0.4' }
+    hasBin: true
+
   rollup@4.60.0:
     resolution:
       {
@@ -1719,6 +1816,13 @@ packages:
       }
     engines: { node: '>=8' }
 
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution:
+      {
+        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+      }
+    engines: { node: '>= 0.4' }
+
   symbol-tree@3.2.4:
     resolution:
       {
@@ -1778,6 +1882,12 @@ packages:
         integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==,
       }
     engines: { node: '>=20' }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   typescript@5.8.3:
     resolution:
@@ -2271,6 +2381,23 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rollup/plugin-typescript@12.3.0(rollup@4.60.0)(tslib@2.8.1)(typescript@5.8.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.60.0)
+      resolve: 1.22.12
+      typescript: 5.8.3
+    optionalDependencies:
+      rollup: 4.60.0
+      tslib: 2.8.1
+
+  '@rollup/pluginutils@5.4.0(rollup@4.60.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.60.0
+
   '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
@@ -2658,6 +2785,8 @@ snapshots:
 
   entities@7.0.1: {}
 
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
 
   esbuild@0.27.4:
@@ -2691,6 +2820,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2703,6 +2834,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -2718,6 +2851,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
@@ -2726,6 +2863,10 @@ snapshots:
     optional: true
 
   indent-string@4.0.0: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-potential-custom-element-name@1.0.1:
     optional: true
@@ -2796,6 +2937,8 @@ snapshots:
       entities: 6.0.1
     optional: true
 
+  path-parse@1.0.7: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2837,6 +2980,13 @@ snapshots:
 
   require-from-string@2.0.2:
     optional: true
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   rollup@4.60.0:
     dependencies:
@@ -2896,6 +3046,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   symbol-tree@3.2.4:
     optional: true
 
@@ -2927,6 +3079,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  tslib@2.8.1: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
## Summary

### User-facing changes
- **Menu workspace adapts to narrow windows.** Below a "wide" breakpoint (driven by the window's true logical width, not raw pixel count, so high-DPI displays are handled correctly), the menus rail becomes a dismissable overlay and the inspector narrows the canvas's own column in place rather than floating over it — the canvas never gets covered by panel content while either is open.
- **Canvas scrolling actually works again.** The DVD menu canvas was overflowing its scroll container with no way to reach the clipped top, and its scrollbar was being visually clipped out of existence by a parent's `overflow: hidden` with zero margin between the two. Both are fixed: the whole 720x{height} canvas is reachable by scroll, and the scrollbar renders.
- **The rail's Navigation Map is now collapsible**, matching the existing Templates / Generate Menus accordion panels, instead of always claiming a fixed chunk of rail height.
- **Fixed two flex-layout sizing bugs** in the rail that caused expanded panel content (e.g. Generate Menus) to be silently clipped or pushed off-screen with no way to reach it, regardless of window size.
- **Generate Menus now defaults collapsed**, matching Templates, instead of force-expanding and crowding the menu list above it.

### Platform / plugin
- New `tauri-plugin-display-awareness` plugin (Spindle-agnostic, lives alongside `tauri-plugin-spindle-project`) exposing per-monitor logical geometry, scale factor, and best-effort physical size in millimetres, plus a `display://changed` event for monitor/scale changes. Backs the new `useDisplayDensity` hook that drives the responsive breakpoints.
- Registered the Tauri MCP Bridge plugin for debug builds, enabling automated UI inspection/testing during development; inert in release builds.

## Test plan
- [x] `cargo build -p tauri-plugin-display-awareness` and full `cargo build -p spindle` — both clean
- [x] `tsc --noEmit` and `vite build` — clean after every change in this branch
- [x] `vitest run` — all 61 existing tests pass, no regressions
- [x] Verified live via the Tauri MCP Bridge + manual review: rail/inspector overlay and push-narrow behaviour, canvas scroll reachability and scrollbar rendering, Navigation Map collapse/expand, Generate Menus default-collapsed, and the rail sizing fix, at both a HiDPI "medium" window size and a maximised "wide" window size
- [ ] Not verified on Windows/macOS — `display-info` (used for the best-effort physical-size field) is cross-platform per its published support matrix, but only exercised on Linux/Wayland here
