### PR TITLE
feat(plugin): adopt the guest-js convention for tauri-plugin-spindle-project

### DIFF
--- a/apps/spindle/package.json
+++ b/apps/spindle/package.json
@@ -4,15 +4,15 @@
 	"version": "0.3.0",
 	"type": "module",
 	"scripts": {
-		"predev": "pnpm --filter tauri-plugin-display-awareness-api build",
+		"predev": "pnpm --filter tauri-plugin-display-awareness-api --filter tauri-plugin-spindle-project-api build",
 		"dev": "vite",
-		"prebuild": "pnpm --filter tauri-plugin-display-awareness-api build",
+		"prebuild": "pnpm --filter tauri-plugin-display-awareness-api --filter tauri-plugin-spindle-project-api build",
 		"build": "tsc && vite build",
 		"preview": "vite preview",
 		"tauri": "tauri",
-		"pretest": "pnpm --filter tauri-plugin-display-awareness-api build",
+		"pretest": "pnpm --filter tauri-plugin-display-awareness-api --filter tauri-plugin-spindle-project-api build",
 		"test": "vitest run",
-		"pretest:ci": "pnpm --filter tauri-plugin-display-awareness-api build",
+		"pretest:ci": "pnpm --filter tauri-plugin-display-awareness-api --filter tauri-plugin-spindle-project-api build",
 		"test:ci": "mkdir -p ../../test-results/spindle && vitest run --reporter=default --reporter=junit --outputFile.junit=../../test-results/spindle/junit.xml",
 		"test:watch": "vitest"
 	},
@@ -29,6 +29,7 @@
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"tauri-plugin-display-awareness-api": "workspace:*",
+		"tauri-plugin-spindle-project-api": "workspace:*",
 		"zustand": "^5.0.12"
 	},
 	"devDependencies": {

--- a/apps/spindle/src/App.tsx
+++ b/apps/spindle/src/App.tsx
@@ -4,10 +4,9 @@
 // SPDX-License-Identifier: MIT
 
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { listen } from '@tauri-apps/api/event';
+import { onBuildProgress } from 'tauri-plugin-spindle-project-api';
 import { useProjectStore } from './store/project-store';
 import { useAppSettingsStore } from './store/app-settings-store';
-import type { BuildProgress } from './types/project';
 import { Topbar } from './components/Topbar';
 import { Sidebar } from './components/Sidebar';
 import { Statusbar } from './components/Statusbar';
@@ -93,8 +92,7 @@ function App() {
 
 	// Build progress event listener
 	useEffect(() => {
-		const unlisten = listen<BuildProgress>('spindle://build-progress', (event) => {
-			const progress = event.payload;
+		const unlisten = onBuildProgress((progress) => {
 			useProjectStore.setState({
 				buildProgress: progress,
 				buildLog:

--- a/apps/spindle/src/pages/MenusPage.tsx
+++ b/apps/spindle/src/pages/MenusPage.tsx
@@ -5,8 +5,8 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { CSSProperties } from 'react';
-import { invoke } from '@tauri-apps/api/core';
 import { save } from '@tauri-apps/plugin-dialog';
+import { exportMenuRenderPreview, listAvailableFonts } from 'tauri-plugin-spindle-project-api';
 import { useProjectStore } from '../store/project-store';
 import { useNavigation } from '../App';
 import { useDisplayDensity, type DisplayDensity } from '../hooks/useDisplayDensity';
@@ -769,11 +769,7 @@ function MenuEditor({
 		});
 		if (!outputPath) return;
 		try {
-			await invoke('plugin:spindle-project|export_menu_render_preview', {
-				project,
-				menuId: menu.id,
-				outputPath,
-			});
+			await exportMenuRenderPreview(project, menu.id, outputPath);
 		} catch (err) {
 			console.error('[MenusPage] export_menu_render_preview failed', err);
 		}
@@ -820,7 +816,7 @@ function MenuEditor({
 	// Best-effort: if the command fails, fall back to the hardcoded list (undefined).
 	useEffect(() => {
 		let cancelled = false;
-		invoke<FontEntry[]>('plugin:spindle-project|list_available_fonts', { project })
+		listAvailableFonts(project)
 			.then((fonts) => {
 				if (!cancelled) setAvailableFonts(fonts);
 			})

--- a/apps/spindle/src/pages/SettingsPage.tsx
+++ b/apps/spindle/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { confirm, save } from '@tauri-apps/plugin-dialog';
+import { exportDiagnostics } from 'tauri-plugin-spindle-project-api';
 import { useProjectStore } from '../store/project-store';
 import { useAppSettingsStore } from '../store/app-settings-store';
 import './SettingsPage.css';
@@ -61,10 +62,7 @@ export function SettingsPage() {
 
 	const handleExportDiagnostics = async () => {
 		try {
-			const json = await invoke<string>('plugin:spindle-project|export_diagnostics', {
-				project: project ?? null,
-				buildLog,
-				validationIssues,
+			const json = await exportDiagnostics(project ?? null, buildLog, validationIssues, {
 				skipSidecar: devSkipSidecar,
 				skipUnsupportedStreams: devSkipUnsupportedStreams,
 				quantizeOverlayPalette: devQuantizeOverlayPalette,

--- a/apps/spindle/src/store/project-store.ts
+++ b/apps/spindle/src/store/project-store.ts
@@ -7,6 +7,21 @@ import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
 import { open, save, confirm } from '@tauri-apps/plugin-dialog';
 import { BaseDirectory, readFile } from '@tauri-apps/plugin-fs';
+import {
+	createProject as createProjectCommand,
+	parseProject,
+	serialiseProject,
+	validateProject as validateProjectCommand,
+	inspectAsset,
+	extractVideoThumbnail,
+	extractImageThumbnail,
+	generateBuildPlan as generateBuildPlanCommand,
+	executeBuild as executeBuildCommand,
+	cancelBuild as cancelBuildCommand,
+	autoGenerateMenuNav as autoGenerateMenuNavCommand,
+	checkToolchain as checkToolchainCommand,
+	getCacheDir,
+} from 'tauri-plugin-spindle-project-api';
 import { useAppSettingsStore } from './app-settings-store';
 import type {
 	SpindleProjectFile,
@@ -176,22 +191,15 @@ async function extractAssetThumbnail(
 	}
 
 	try {
-		const thumbDir = await invoke<string>('plugin:spindle-project|get_cache_dir');
+		const thumbDir = await getCacheDir();
 		const thumbPath = `${thumbDir}/thumb_${asset.id}.jpg`;
 
 		if (isVideo) {
 			const durationSecs = asset.durationSecs ?? 0;
 			const seekTo = chooseThumbnailTimestamp(durationSecs);
-			await invoke('plugin:spindle-project|extract_video_thumbnail', {
-				sourcePath: asset.sourcePath,
-				outputPath: thumbPath,
-				timestampSecs: seekTo,
-			});
+			await extractVideoThumbnail(asset.sourcePath, thumbPath, seekTo);
 		} else {
-			await invoke('plugin:spindle-project|extract_image_thumbnail', {
-				sourcePath: asset.sourcePath,
-				outputPath: thumbPath,
-			});
+			await extractImageThumbnail(asset.sourcePath, thumbPath);
 		}
 
 		return { thumbnailPath: thumbPath, thumbnailError: null };
@@ -283,9 +291,7 @@ async function backfillAssetFormatTitles(project: SpindleProjectFile): Promise<v
 
 	for (const asset of stale) {
 		try {
-			const inspected = await invoke<Asset>('plugin:spindle-project|inspect_asset', {
-				path: asset.sourcePath,
-			});
+			const inspected = await inspectAsset(asset.sourcePath);
 
 			const { project: current } = useProjectStore.getState();
 			if (!current) return;
@@ -386,9 +392,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 	createProject: async (req) => {
 		set({ isLoading: true });
 		try {
-			const project = await invoke<SpindleProjectFile>('plugin:spindle-project|create_project', {
-				payload: req,
-			});
+			const project = await createProjectCommand(req);
 			set({
 				project,
 				filePath: null,
@@ -426,9 +430,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		try {
 			console.info('[project-store] Opening project', { path: selected });
 			const json = await invoke<string>('read_text_file', { path: selected });
-			const project = await invoke<SpindleProjectFile>('plugin:spindle-project|parse_project', {
-				json,
-			});
+			const project = await parseProject(json);
 			console.info('[project-store] Opened project', {
 				path: selected,
 				...projectTraceSummary(project),
@@ -466,9 +468,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				path: filePath,
 				...projectTraceSummary(updated),
 			});
-			const json = await invoke<string>('plugin:spindle-project|serialise_project', {
-				project: updated,
-			});
+			const json = await serialiseProject(updated);
 			await invoke('write_text_file', { path: filePath, contents: json });
 			set({ project: updated, isDirty: false });
 			console.info('[project-store] Saved project', {
@@ -513,9 +513,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				path: selected,
 				...projectTraceSummary(updated),
 			});
-			const json = await invoke<string>('plugin:spindle-project|serialise_project', {
-				project: updated,
-			});
+			const json = await serialiseProject(updated);
 			await invoke('write_text_file', { path: selected, contents: json });
 			set({ project: updated, filePath: selected, isDirty: false });
 			console.info('[project-store] Saved project as', {
@@ -563,9 +561,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		const { project } = get();
 		if (!project) return;
 
-		const issues = await invoke<ValidationIssue[]>('plugin:spindle-project|validate_project', {
-			project,
-		});
+		const issues = await validateProjectCommand(project);
 		set({ validationIssues: issues });
 	},
 
@@ -625,9 +621,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		// Trigger inspection and thumbnail extraction for each new asset
 		for (const asset of newAssets) {
 			try {
-				const inspected = await invoke<Asset>('plugin:spindle-project|inspect_asset', {
-					path: asset.sourcePath,
-				});
+				const inspected = await inspectAsset(asset.sourcePath);
 				// Merge inspection results, preserving the ID we assigned
 				const { project: current } = get();
 				if (!current) break;
@@ -725,9 +719,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
 		// Re-inspect the relinked file
 		try {
-			const inspected = await invoke<Asset>('plugin:spindle-project|inspect_asset', {
-				path: newPath,
-			});
+			const inspected = await inspectAsset(newPath);
 			const { project: current } = get();
 			if (!current) return;
 			const currentAsset = current.assets.find((a) => a.id === assetId);
@@ -786,9 +778,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				quantizeOverlayPalette,
 				...projectTraceSummary(project),
 			});
-			const plan = await invoke<BuildPlan>('plugin:spindle-project|generate_build_plan', {
-				project,
-				outputDirectory: outputDir,
+			const plan = await generateBuildPlanCommand(project, outputDir, {
 				skipSidecar,
 				skipUnsupportedStreams,
 				quantizeOverlayPalette,
@@ -839,9 +829,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		});
 
 		try {
-			const result = await invoke<BuildResult>('plugin:spindle-project|execute_build', {
-				project,
-				outputDirectory: outputDir,
+			const result = await executeBuildCommand(project, outputDir, {
 				skipSidecar,
 				skipUnsupportedStreams,
 				quantizeOverlayPalette,
@@ -872,7 +860,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
 	cancelBuild: async () => {
 		try {
-			await invoke('plugin:spindle-project|cancel_build');
+			await cancelBuildCommand();
 			set((state) => ({
 				buildLog: [...state.buildLog, 'Cancellation requested…'],
 			}));
@@ -933,9 +921,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
 		if (!foundMenu) return;
 
-		const updated = await invoke<Menu>('plugin:spindle-project|auto_generate_menu_nav', {
-			menu: foundMenu,
-		});
+		const updated = await autoGenerateMenuNavCommand(foundMenu);
 
 		get().updateProject((p) => {
 			if (scope === 'global') {
@@ -1109,9 +1095,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 	checkToolchain: async () => {
 		try {
 			const skipSidecar = useAppSettingsStore.getState().devSkipSidecar;
-			const statuses = await invoke<ToolchainStatus[]>('plugin:spindle-project|check_toolchain', {
-				skipSidecar,
-			});
+			const statuses = await checkToolchainCommand(skipSidecar);
 			set({ toolchain: statuses });
 		} catch {
 			// Toolchain check is best-effort

--- a/apps/spindle/src/types/project.ts
+++ b/apps/spindle/src/types/project.ts
@@ -1,664 +1,93 @@
-// TypeScript types mirroring the Rust project schema from tauri-plugin-spindle-project.
+// App-specific helpers around the project domain model owned by
+// tauri-plugin-spindle-project-api.
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-// ── Enums ───────────────────────────────────────────────────────────────────
-
-export type DiscFamily = 'dvd-video';
-export type VideoStandard = 'NTSC' | 'PAL';
-export type CapacityTarget = 'DVD5' | 'DVD9';
-export type CopyMode = 'copy' | 're-encode';
-export type AudioOutputTarget = 'AC3' | 'LPCM' | 'MP2' | 'DTS';
-export type AllocationStrategy = 'equal-share' | 'duration-weighted' | 'priority-weighted';
-export type CompatibilityAssessment =
-	| 'remux-compatible'
-	| 'transform-compatible'
-	| 're-encode-required'
-	| 'unsupported';
-export type SubtitleType = 'bitmap' | 'text' | 'unknown';
-export type IssueSeverity = 'info' | 'warning' | 'error';
-
-export type VideoRaster = 'full-d1' | '704-wide' | 'half-d1' | 'quarter-d1';
-export type AspectMode = 'four-by-three' | 'sixteen-by-nine';
-
-// ── Playback Action ─────────────────────────────────────────────────────────
-
-export type PlaybackAction =
-	| { type: 'playTitle'; titleId: string }
-	| { type: 'playChapter'; titleId: string; chapterId: string }
-	| { type: 'showMenu'; menuId: string }
-	| { type: 'setAudioStream'; streamIndex: number }
-	| { type: 'setSubtitleStream'; streamIndex: number | null }
-	| { type: 'sequence'; actions: PlaybackAction[] }
-	| { type: 'stop' }
-	| { type: 'return' }
-	| { type: 'playNextInTitleset' }
-	| { type: 'playAllInTitleset' };
-
-// ── Top-Level Project ───────────────────────────────────────────────────────
-
-export interface SpindleProjectFile {
-	schemaVersion: number;
-	project: ProjectMeta;
-	disc: Disc;
-	assets: Asset[];
-	buildSettings: BuildSettings;
-}
-
-export interface ProjectMeta {
-	id: string;
-	name: string;
-	createdAt: string;
-	modifiedAt: string;
-}
-
-// ── Disc ────────────────────────────────────────────────────────────────────
-
-export interface Disc {
-	family: DiscFamily;
-	standard: VideoStandard;
-	capacityTarget: CapacityTarget;
-	firstPlayAction: PlaybackAction | null;
-	titlesets: Titleset[];
-	globalMenus: Menu[];
-}
-
-export interface Titleset {
-	id: string;
-	name: string;
-	titles: Title[];
-	menus: Menu[];
-}
-
-// ── Title ───────────────────────────────────────────────────────────────────
-
-export interface Title {
-	id: string;
-	name: string;
-	sourceAssetId: string | null;
-	videoMapping: VideoTrackMapping | null;
-	videoOutputProfile: VideoOutputProfile | null;
-	audioMappings: AudioTrackMapping[];
-	subtitleMappings: SubtitleTrackMapping[];
-	chapters: ChapterPoint[];
-	endAction: PlaybackAction | null;
-	orderIndex: number;
-}
-
-// ── Track Mappings ──────────────────────────────────────────────────────────
-
-export interface VideoTrackMapping {
-	sourceStreamIndex: number;
-	copyMode: CopyMode;
-}
-
-export interface AudioTrackMapping {
-	id: string;
-	sourceStreamIndex: number;
-	outputTarget: AudioOutputTarget;
-	copyMode: CopyMode;
-	label: string;
-	language: string;
-	orderIndex: number;
-	isDefault: boolean;
-}
-
-export interface SubtitleTrackMapping {
-	id: string;
-	sourceStreamIndex: number;
-	label: string;
-	language: string;
-	orderIndex: number;
-	isDefault: boolean;
-	isForced: boolean;
-}
-
-// ── Output Profiles ─────────────────────────────────────────────────────────
-
-export interface VideoOutputProfile {
-	raster: VideoRaster;
-	aspect: AspectMode;
-}
-
-// ── Chapters ────────────────────────────────────────────────────────────────
-
-export interface ChapterPoint {
-	id: string;
-	name: string;
-	timestampSecs: number;
-	orderIndex: number;
-}
-
-/** A chapter point detected in a source media file during inspection. */
-export interface SourceChapter {
-	startSecs: number;
-	endSecs: number;
-	title: string | null;
-}
-
-// ── Menus ───────────────────────────────────────────────────────────────────
-
-export type MenuEditorMode = 'editor' | 'map' | 'design' | 'bind' | 'remote' | 'compile';
-export type BackgroundMode = 'still' | 'motion';
-export type HighlightMode = 'static' | 'animated';
-
-export interface Menu {
-	id: string;
-	name: string;
-	backgroundAssetId: string | null;
-	buttons: MenuButton[];
-	defaultButtonId: string | null;
-	/** DVD subpicture highlight palette colours. */
-	highlightColours: MenuHighlightColours;
-	/** Whether the background is a still frame or looping video (Stage 2). */
-	backgroundMode: BackgroundMode;
-	/** Duration of the motion loop in seconds (motion menus only). */
-	motionDurationSecs: number | null;
-	/** Optional audio asset for motion menu background music. */
-	motionAudioAssetId: string | null;
-	/** Number of times to loop before timeout action (0 = infinite, motion only). */
-	motionLoopCount: number;
-	/** Action when a motion menu times out after looping. */
-	timeoutAction: PlaybackAction | null;
-	/** The new authored scene document that replaces the flat button model. */
-	authoredDocument?: MenuDocument | null;
-}
-
-/** A structured menu document that separates authored intent from target compilation. */
-export interface MenuDocument {
-	id: string;
-	name: string;
-	domain: MenuDomain;
-	scene: MenuScene;
-	interaction: MenuInteractionGraph;
-	timing: MenuTiming;
-	highlightColours: MenuHighlightColours;
-	backgroundMode: BackgroundMode;
-	themeRef: string | null;
-	generationMeta: MenuGenerationMeta | null;
-	compilePolicy: MenuCompilePolicy;
-}
-
-/** Menu domain indicates whether it belongs to the Video Manager (VMGM) or a Titleset. */
-export type MenuDomain = 'vmgm' | 'titleset';
-
-/** The visual scene graph for the menu. */
-export interface MenuScene {
-	designSize: MenuSize;
-	background: SceneBackground;
-	nodes: SceneNode[];
-	guides: SceneGuide[];
-}
-
-export interface MenuSize {
-	width: number;
-	height: number;
-}
-
-export interface SceneBackground {
-	assetId: string | null;
-	colour: string | null;
-}
-
-// ── Button & Text Style ─────────────────────────────────────────────────────
-
-export type ButtonShadowType = 'none' | 'box-shadow' | 'outer-glow' | 'inner-glow';
-
-/** Per-state visual appearance for a button node (authored layer only). */
-export interface ButtonStateStyle {
-	bgFill: string;
-	borderColour: string;
-	borderWidth: number;
-	borderRadius: number;
-	paddingH: number;
-	paddingV: number;
-	shadowType: ButtonShadowType;
-	shadowColour: string;
-	shadowBlur: number;
-	shadowSpread: number;
-}
-
-/** The three interactive states for a button. */
-export interface ButtonStyleMap {
-	normal: ButtonStateStyle;
-	focus: ButtonStateStyle;
-	activate: ButtonStateStyle;
-}
-
-/** Typography style shared by button labels and standalone text nodes. */
-export interface TextStyle {
-	fontFamily: string;
-	fontSize: number;
-	fontWeight: 'normal' | 'bold';
-	fontItalic: boolean;
-	textDecoration: 'none' | 'underline';
-	textAlign: 'left' | 'center' | 'right';
-	colour: string;
-	lineHeight: number;
-	letterSpacing: number;
-}
-
-/** A node within the authored menu scene graph. */
-export type SceneNode =
-	| { type: 'group'; id: string; name: string; children: SceneNode[] }
-	| {
-			type: 'text';
-			id: string;
-			content: string;
-			x: number;
-			y: number;
-			width: number;
-			height: number;
-			fontSize?: number;
-			colour?: string;
-			fontFamily?: string;
-			fontWeight?: 'normal' | 'bold';
-			fontItalic?: boolean;
-			textDecoration?: 'none' | 'underline';
-			textAlign?: 'left' | 'center' | 'right';
-			lineHeight?: number;
-			letterSpacing?: number;
-	  }
-	| {
-			type: 'image';
-			id: string;
-			assetId: string;
-			x: number;
-			y: number;
-			width: number;
-			height: number;
-	  }
-	| {
-			type: 'shape';
-			id: string;
-			x: number;
-			y: number;
-			width: number;
-			height: number;
-			fill?: string;
-	  }
-	| { type: 'video'; id: string; assetId: string; x: number; y: number }
-	| {
-			type: 'button';
-			id: string;
-			label: string;
-			x: number;
-			y: number;
-			width: number;
-			height: number;
-			highlightMode?: HighlightMode;
-			highlightKeyframes?: HighlightKeyframe[];
-			videoAssetId?: string | null;
-			/** Per-state visual appearance (authored layer). */
-			buttonStyle?: ButtonStyleMap;
-			/** Label typography. */
-			labelStyle?: TextStyle;
-	  }
-	| { type: 'componentInstance'; id: string; componentId: string }
-	| { type: 'generatedCollection'; id: string; source: string };
-
-export interface SceneGuide {
-	orientation: 'horizontal' | 'vertical';
-	position: number;
-}
-
-/** The interaction graph defining remote-driven behaviour. */
-export interface MenuInteractionGraph {
-	defaultFocusId: string | null;
-	nodes: FocusNode[];
-	timeoutAction: PlaybackAction | null;
-}
-
-export interface FocusNode {
-	nodeId: string;
-	navUp: string | null;
-	navDown: string | null;
-	navLeft: string | null;
-	navRight: string | null;
-	action: PlaybackAction | null;
-}
-
-/** Timing and motion rules for the menu. */
-export interface MenuTiming {
-	introStartSecs: number;
-	introDurationSecs: number;
-	loopStartSecs: number;
-	loopDurationSecs: number;
-	loopCount: number; // 0 = infinite
-}
-
-/** Metadata for generated menus. */
-export interface MenuGenerationMeta {
-	generatorId: string;
-	lastGeneratedAt: string;
-}
-
-/** Format-specific compilation rules and safe-area policies. */
-export interface MenuCompilePolicy {
-	displayAspect: AspectMode;
-	safeAreaMode: 'action-safe' | 'title-safe' | 'none';
-	paletteStrategy: 'auto' | 'manual';
-}
-
-/** DVD subpicture highlight palette for button overlays. */
-export interface MenuHighlightColours {
-	/** CSS hex colour shown when a button is selected/focused. */
-	selectColour: string;
-	/** Opacity of the select highlight (0.0–1.0). */
-	selectOpacity: number;
-	/** CSS hex colour shown briefly when a button is activated/pressed. */
-	activateColour: string;
-	/** Opacity of the activate highlight (0.0–1.0). */
-	activateOpacity: number;
-}
-
-export interface MenuButton {
-	id: string;
-	label: string;
-	bounds: ButtonBounds;
-	action: PlaybackAction | null;
-	navUp: string | null;
-	navDown: string | null;
-	navLeft: string | null;
-	navRight: string | null;
-	/** Whether button highlights are static or animated (Stage 2). */
-	highlightMode: HighlightMode;
-	/** Animated highlight keyframes (Stage 2). */
-	highlightKeyframes: HighlightKeyframe[];
-	/** Video asset composited into the menu background at this button's bounds (Stage 2). */
-	videoAssetId: string | null;
-}
-
-export interface HighlightKeyframe {
-	timestampSecs: number;
-	selectColour: string | null;
-	selectOpacity: number | null;
-	activateColour: string | null;
-	activateOpacity: number | null;
-}
-
-export interface ButtonBounds {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-}
-
-// ── Assets ──────────────────────────────────────────────────────────────────
-
-export interface Asset {
-	id: string;
-	fileName: string;
-	sourcePath: string;
-	fileSizeBytes: number | null;
-	durationSecs: number | null;
-	containerFormat: string | null;
-	videoStreams: VideoStreamInfo[];
-	audioStreams: AudioStreamInfo[];
-	subtitleStreams: SubtitleStreamInfo[];
-	compatibility: CompatibilityAssessment | null;
-	fingerprint: string | null;
-	/** Detailed per-stream compatibility breakdown. */
-	compatibilityDetail: CompatibilityDetail | null;
-	warnings: AssetWarning[];
-	thumbnailPath: string | null;
-	thumbnailError: string | null;
-	/** Chapter markers detected in the source media file. */
-	sourceChapters: SourceChapter[];
-	/** Container-level title tag from source media metadata (e.g. MKV/MP4 title). */
-	formatTitle: string | null;
-}
-
-export interface AssetWarning {
-	code: string;
-	message: string;
-}
-
-export interface VideoStreamInfo {
-	index: number;
-	codec: string;
-	width: number;
-	height: number;
-	frameRate: number | null;
-	aspectRatio: string | null;
-	scanType: string | null;
-	bitrateBps: number | null;
-	title: string | null;
-	/** OETF transfer characteristics, e.g. "smpte2084" (HDR10), "arib-std-b67" (HLG). */
-	colorTransfer: string | null;
-	/** Colour primaries, e.g. "bt2020" (HDR), "bt709" (SDR). */
-	colorPrimaries: string | null;
-	/** Dolby Vision profile when ffprobe exposes DOVI side data. */
-	dolbyVisionProfile: number | null;
-}
-
-export interface AudioStreamInfo {
-	index: number;
-	codec: string;
-	channels: number;
-	sampleRate: number;
-	language: string | null;
-	bitrateBps: number | null;
-	title: string | null;
-}
-
-export interface SubtitleStreamInfo {
-	index: number;
-	codec: string;
-	language: string | null;
-	subtitleType: SubtitleType;
-	title: string | null;
-}
-
-// ── Compatibility Detail ────────────────────────────────────────────────
-
-/** Per-stream compatibility breakdown explaining why the overall assessment was given. */
-export interface CompatibilityDetail {
-	overall: CompatibilityAssessment;
-	video: VideoCompatibility | null;
-	audioStreams: AudioStreamCompatibility[];
-	container: ContainerCompatibility;
-}
-
-export interface VideoCompatibility {
-	codec: PropertyCheck;
-	resolution: PropertyCheck;
-	frameRate: PropertyCheck;
-}
-
-export interface AudioStreamCompatibility {
-	streamIndex: number;
-	codec: PropertyCheck;
-}
-
-export interface ContainerCompatibility {
-	format: PropertyCheck;
-}
-
-/** A single property compatibility check result. */
-export interface PropertyCheck {
-	value: string;
-	dvdRequires: string;
-	action: string;
-	compatible: boolean;
-}
-
-// ── Build Settings ──────────────────────────────────────────────────────────
-
-export interface BuildSettings {
-	outputDirectory: string | null;
-	generateIso: boolean;
-	safetyMarginBytes: number;
-	allocationStrategy: AllocationStrategy;
-	subtitleRenderMode?: 'one-pass' | 'two-pass';
-}
-
-// ── Validation ──────────────────────────────────────────────────────────────
-
-export interface ValidationIssue {
-	severity: IssueSeverity;
-	code: string;
-	message: string;
-	context: string | null;
-	/** Entity type for navigation: "title", "menu", "titleset", "disc", "build". */
-	entityType?: string | null;
-	/** Human-readable name of the affected entity. */
-	entityName?: string | null;
-	/** Actionable guidance on how to resolve the issue. */
-	suggestedFix?: string | null;
-}
-
-// ── Build Pipeline ──────────────────────────────────────────────────────────
-
-export interface BuildPlan {
-	jobs: BuildJob[];
-	outputDirectory: string;
-	workingDirectory: string;
-	dvdauthorXml: string;
-	summary: BuildSummary;
-}
-
-export interface BuildSummary {
-	totalJobs: number;
-	transcodeJobs: number;
-	titlesCount: number;
-	menusCount: number;
-	generateIso: boolean;
-	estimatedCommands: string[];
-}
-
-export type BuildJob =
-	| { type: 'prepareWorkspace'; directories: string[] }
-	| {
-			type: 'transcodeTitle';
-			titleId: string;
-			titleName: string;
-			sourcePath: string;
-			outputPath: string;
-			command: string[];
-			label: string;
-			/** Source asset duration in seconds, used for step-progress estimation. */
-			durationSecs: number | null;
-	  }
-	| {
-			type: 'renderMenu';
-			menuId: string;
-			menuName: string;
-			outputPath: string;
-			command: string[];
-			label: string;
-	  }
-	| {
-			type: 'composeMenuHighlights';
-			menuId: string;
-			menuName: string;
-			inputPath: string;
-			outputPath: string;
-			spumuxXml: string;
-			command: string[];
-			label: string;
-	  }
-	| {
-			type: 'linkTitle';
-			titleId: string;
-			titleName: string;
-			sourcePath: string;
-			linkPath: string;
-			label: string;
-	  }
-	| {
-			type: 'extractSubtitles';
-			titleId: string;
-			titleName: string;
-			sourcePath: string;
-			outputPath: string;
-			command: string[];
-			label: string;
-	  }
-	| {
-			type: 'renderTextSubtitles';
-			titleId: string;
-			titleName: string;
-			sourcePath: string;
-			sourceStreamIndex: number;
-			inputPath: string;
-			outputPath: string;
-			subtitlePath: string;
-			prepareCommand: string[];
-			spumuxXml: string;
-			command: string[];
-			label: string;
-			renderMode: 'one-pass' | 'two-pass';
-			fontFamily: string;
-	  }
-	| {
-			type: 'authorDvd';
-			xmlPath: string;
-			outputPath: string;
-			command: string[];
-			label: string;
-	  }
-	| {
-			type: 'createIso';
-			sourcePath: string;
-			outputPath: string;
-			command: string[];
-			label: string;
-	  };
-
-export interface BuildProgress {
-	jobIndex: number;
-	totalJobs: number;
-	currentLabel: string;
-	status: 'starting' | 'running' | 'complete' | 'failed';
-	output: string | null;
-	/** Short name for the active sub-operation (e.g. "FFmpeg transcode"). */
-	stepLabel?: string | null;
-	/** Estimated completion of the current sub-operation, clamped to 0–100. */
-	stepPercent?: number | null;
-	/** Freeform detail such as media timestamp or encoding phase. */
-	stepDetail?: string | null;
-	/** Lifecycle state of the sub-operation. */
-	stepStatus?: 'starting' | 'running' | 'complete' | 'failed' | null;
-}
-
-export interface BuildResult {
-	success: boolean;
-	outputDirectory: string;
-	isoPath: string | null;
-	logLines: string[];
-	failedJobIndex: number | null;
-	errorMessage: string | null;
-}
-
-export interface ToolchainStatus {
-	name: string;
-	purpose: string;
-	available: boolean;
-	version: string | null;
-}
-
-// ── Font Enumeration ────────────────────────────────────────────────────────
-
-/** Where a font family came from in the Skia renderer's resolution priority chain. */
-export type FontSource = 'project-asset' | 'app-sidecar' | 'system';
-
-/** A font family available to the Skia renderer, with its source tier. */
-export interface FontEntry {
-	/** Display name shown in the UI (e.g. "DejaVu Sans"). */
-	family: string;
-	/** Where this font came from. */
-	source: FontSource;
-}
-
-// ── Command Payloads ────────────────────────────────────────────────────────
-
-export interface CreateProjectRequest {
-	name: string;
-	standard: VideoStandard;
-	capacityTarget: CapacityTarget;
-}
+// The domain model types (SpindleProjectFile, Menu, Asset, BuildPlan, etc.)
+// are owned by the plugin's guest-js package, since they mirror the Rust
+// structs the plugin's commands actually serialise. Re-exporting them here
+// keeps existing imports from '../types/project' working without every
+// caller needing to know the model moved.
+export type {
+	DiscFamily,
+	VideoStandard,
+	CapacityTarget,
+	CopyMode,
+	AudioOutputTarget,
+	AllocationStrategy,
+	CompatibilityAssessment,
+	SubtitleType,
+	IssueSeverity,
+	VideoRaster,
+	AspectMode,
+	PlaybackAction,
+	SpindleProjectFile,
+	ProjectMeta,
+	Disc,
+	Titleset,
+	Title,
+	VideoTrackMapping,
+	AudioTrackMapping,
+	SubtitleTrackMapping,
+	VideoOutputProfile,
+	ChapterPoint,
+	SourceChapter,
+	MenuEditorMode,
+	BackgroundMode,
+	HighlightMode,
+	Menu,
+	MenuDocument,
+	MenuDomain,
+	MenuScene,
+	MenuSize,
+	SceneBackground,
+	ButtonShadowType,
+	ButtonStateStyle,
+	ButtonStyleMap,
+	TextStyle,
+	SceneNode,
+	SceneGuide,
+	MenuInteractionGraph,
+	FocusNode,
+	MenuTiming,
+	MenuGenerationMeta,
+	MenuCompilePolicy,
+	MenuHighlightColours,
+	MenuButton,
+	HighlightKeyframe,
+	ButtonBounds,
+	Asset,
+	AssetWarning,
+	VideoStreamInfo,
+	AudioStreamInfo,
+	SubtitleStreamInfo,
+	CompatibilityDetail,
+	VideoCompatibility,
+	AudioStreamCompatibility,
+	ContainerCompatibility,
+	PropertyCheck,
+	BuildSettings,
+	ValidationIssue,
+	BuildPlan,
+	BuildSummary,
+	BuildJob,
+	BuildProgress,
+	BuildResult,
+	ToolchainStatus,
+	FontSource,
+	FontEntry,
+	CreateProjectRequest,
+} from 'tauri-plugin-spindle-project-api';
+
+import type {
+	AspectMode,
+	CapacityTarget,
+	MenuCompilePolicy,
+	MenuDomain,
+	MenuHighlightColours,
+	SpindleProjectFile,
+} from 'tauri-plugin-spindle-project-api';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/plugins/tauri-plugin-spindle-project/README.md
+++ b/plugins/tauri-plugin-spindle-project/README.md
@@ -182,72 +182,63 @@ cargo test -p tauri-plugin-spindle-project execute_build_plan_smoke_authors_titl
 
 That smoke test requires `ffmpeg`, `spumux`, and `dvdauthor` to be available on `PATH`.
 
-## Frontend usage
+## JavaScript bindings
 
-The plugin is invoked through Tauri core APIs:
+The plugin ships typed bindings in `tauri-plugin-spindle-project-api`, following the
+same `guest-js` convention as `tauri-plugin-display-awareness`. App code should
+import from the package rather than calling `invoke` with raw command strings:
 
 ```ts
-import { invoke } from '@tauri-apps/api/core';
+import { createProject, parseProject, serialiseProject } from 'tauri-plugin-spindle-project-api';
 
-const project = await invoke('plugin:spindle-project|create_project', {
-	payload: {
-		name: 'Wedding DVD',
-		standard: 'NTSC',
-		capacityTarget: 'DVD5',
-	},
+const project = await createProject({
+	name: 'Wedding DVD',
+	standard: 'NTSC',
+	capacityTarget: 'DVD5',
 });
 ```
 
 Parsing and saving typically look like this:
 
 ```ts
-const parsed = await invoke('plugin:spindle-project|parse_project', { json });
-
-const serialised = await invoke('plugin:spindle-project|serialise_project', {
-	project: parsed,
-});
+const parsed = await parseProject(json);
+const serialised = await serialiseProject(parsed);
 ```
 
 Validation and asset inspection use the same pattern:
 
 ```ts
-const issues = await invoke('plugin:spindle-project|validate_project', {
-	project,
-});
-
-const asset = await invoke('plugin:spindle-project|inspect_asset', {
-	path: '/media/clip.mpg',
-});
+const issues = await validateProject(project);
+const asset = await inspectAsset('/media/clip.mpg');
 ```
 
-Build planning and execution use the same `invoke` entry point:
+Build planning and execution share a `BuildOptions` argument:
 
 ```ts
-const plan = await invoke('plugin:spindle-project|generate_build_plan', {
-	project,
-	outputDirectory: '/tmp/spindle-output',
+const options = {
 	skipSidecar: false,
 	skipUnsupportedStreams: false,
-});
+	quantizeOverlayPalette: false,
+};
 
-const result = await invoke('plugin:spindle-project|execute_build', {
-	project,
-	outputDirectory: '/tmp/spindle-output',
-	skipSidecar: false,
-	skipUnsupportedStreams: false,
+const plan = await generateBuildPlan(project, '/tmp/spindle-output', options);
+const result = await executeBuild(project, '/tmp/spindle-output', options);
+```
+
+Subscribe to build progress instead of listening for the raw event name directly:
+
+```ts
+import { onBuildProgress } from 'tauri-plugin-spindle-project-api';
+
+const unlisten = await onBuildProgress((progress) => {
+	console.log(progress.currentLabel, progress.status);
 });
 ```
 
 Diagnostics export records the same developer-option context:
 
 ```ts
-const diagnostics = await invoke('plugin:spindle-project|export_diagnostics', {
-	project,
-	buildLog,
-	validationIssues,
-	skipSidecar: false,
-	skipUnsupportedStreams: false,
-});
+const diagnostics = await exportDiagnostics(project, buildLog, validationIssues, options);
 ```
 
 ## Types and schema notes

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -1,0 +1,808 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+// ── Enums ───────────────────────────────────────────────────────────────────
+
+export type DiscFamily = 'dvd-video';
+export type VideoStandard = 'NTSC' | 'PAL';
+export type CapacityTarget = 'DVD5' | 'DVD9';
+export type CopyMode = 'copy' | 're-encode';
+export type AudioOutputTarget = 'AC3' | 'LPCM' | 'MP2' | 'DTS';
+export type AllocationStrategy = 'equal-share' | 'duration-weighted' | 'priority-weighted';
+export type CompatibilityAssessment =
+	| 'remux-compatible'
+	| 'transform-compatible'
+	| 're-encode-required'
+	| 'unsupported';
+export type SubtitleType = 'bitmap' | 'text' | 'unknown';
+export type IssueSeverity = 'info' | 'warning' | 'error';
+
+export type VideoRaster = 'full-d1' | '704-wide' | 'half-d1' | 'quarter-d1';
+export type AspectMode = 'four-by-three' | 'sixteen-by-nine';
+
+// ── Playback Action ─────────────────────────────────────────────────────────
+
+export type PlaybackAction =
+	| { type: 'playTitle'; titleId: string }
+	| { type: 'playChapter'; titleId: string; chapterId: string }
+	| { type: 'showMenu'; menuId: string }
+	| { type: 'setAudioStream'; streamIndex: number }
+	| { type: 'setSubtitleStream'; streamIndex: number | null }
+	| { type: 'sequence'; actions: PlaybackAction[] }
+	| { type: 'stop' }
+	| { type: 'return' }
+	| { type: 'playNextInTitleset' }
+	| { type: 'playAllInTitleset' };
+
+// ── Top-Level Project ───────────────────────────────────────────────────────
+
+export interface SpindleProjectFile {
+	schemaVersion: number;
+	project: ProjectMeta;
+	disc: Disc;
+	assets: Asset[];
+	buildSettings: BuildSettings;
+}
+
+export interface ProjectMeta {
+	id: string;
+	name: string;
+	createdAt: string;
+	modifiedAt: string;
+}
+
+// ── Disc ────────────────────────────────────────────────────────────────────
+
+export interface Disc {
+	family: DiscFamily;
+	standard: VideoStandard;
+	capacityTarget: CapacityTarget;
+	firstPlayAction: PlaybackAction | null;
+	titlesets: Titleset[];
+	globalMenus: Menu[];
+}
+
+export interface Titleset {
+	id: string;
+	name: string;
+	titles: Title[];
+	menus: Menu[];
+}
+
+// ── Title ───────────────────────────────────────────────────────────────────
+
+export interface Title {
+	id: string;
+	name: string;
+	sourceAssetId: string | null;
+	videoMapping: VideoTrackMapping | null;
+	videoOutputProfile: VideoOutputProfile | null;
+	audioMappings: AudioTrackMapping[];
+	subtitleMappings: SubtitleTrackMapping[];
+	chapters: ChapterPoint[];
+	endAction: PlaybackAction | null;
+	orderIndex: number;
+}
+
+// ── Track Mappings ──────────────────────────────────────────────────────────
+
+export interface VideoTrackMapping {
+	sourceStreamIndex: number;
+	copyMode: CopyMode;
+}
+
+export interface AudioTrackMapping {
+	id: string;
+	sourceStreamIndex: number;
+	outputTarget: AudioOutputTarget;
+	copyMode: CopyMode;
+	label: string;
+	language: string;
+	orderIndex: number;
+	isDefault: boolean;
+}
+
+export interface SubtitleTrackMapping {
+	id: string;
+	sourceStreamIndex: number;
+	label: string;
+	language: string;
+	orderIndex: number;
+	isDefault: boolean;
+	isForced: boolean;
+}
+
+// ── Output Profiles ─────────────────────────────────────────────────────────
+
+export interface VideoOutputProfile {
+	raster: VideoRaster;
+	aspect: AspectMode;
+}
+
+// ── Chapters ────────────────────────────────────────────────────────────────
+
+export interface ChapterPoint {
+	id: string;
+	name: string;
+	timestampSecs: number;
+	orderIndex: number;
+}
+
+/** A chapter point detected in a source media file during inspection. */
+export interface SourceChapter {
+	startSecs: number;
+	endSecs: number;
+	title: string | null;
+}
+
+// ── Menus ───────────────────────────────────────────────────────────────────
+
+export type MenuEditorMode = 'editor' | 'map' | 'design' | 'bind' | 'remote' | 'compile';
+export type BackgroundMode = 'still' | 'motion';
+export type HighlightMode = 'static' | 'animated';
+
+export interface Menu {
+	id: string;
+	name: string;
+	backgroundAssetId: string | null;
+	buttons: MenuButton[];
+	defaultButtonId: string | null;
+	/** DVD subpicture highlight palette colours. */
+	highlightColours: MenuHighlightColours;
+	/** Whether the background is a still frame or looping video (Stage 2). */
+	backgroundMode: BackgroundMode;
+	/** Duration of the motion loop in seconds (motion menus only). */
+	motionDurationSecs: number | null;
+	/** Optional audio asset for motion menu background music. */
+	motionAudioAssetId: string | null;
+	/** Number of times to loop before timeout action (0 = infinite, motion only). */
+	motionLoopCount: number;
+	/** Action when a motion menu times out after looping. */
+	timeoutAction: PlaybackAction | null;
+	/** The new authored scene document that replaces the flat button model. */
+	authoredDocument?: MenuDocument | null;
+}
+
+/** A structured menu document that separates authored intent from target compilation. */
+export interface MenuDocument {
+	id: string;
+	name: string;
+	domain: MenuDomain;
+	scene: MenuScene;
+	interaction: MenuInteractionGraph;
+	timing: MenuTiming;
+	highlightColours: MenuHighlightColours;
+	backgroundMode: BackgroundMode;
+	themeRef: string | null;
+	generationMeta: MenuGenerationMeta | null;
+	compilePolicy: MenuCompilePolicy;
+}
+
+/** Menu domain indicates whether it belongs to the Video Manager (VMGM) or a Titleset. */
+export type MenuDomain = 'vmgm' | 'titleset';
+
+/** The visual scene graph for the menu. */
+export interface MenuScene {
+	designSize: MenuSize;
+	background: SceneBackground;
+	nodes: SceneNode[];
+	guides: SceneGuide[];
+}
+
+export interface MenuSize {
+	width: number;
+	height: number;
+}
+
+export interface SceneBackground {
+	assetId: string | null;
+	colour: string | null;
+}
+
+// ── Button & Text Style ─────────────────────────────────────────────────────
+
+export type ButtonShadowType = 'none' | 'box-shadow' | 'outer-glow' | 'inner-glow';
+
+/** Per-state visual appearance for a button node (authored layer only). */
+export interface ButtonStateStyle {
+	bgFill: string;
+	borderColour: string;
+	borderWidth: number;
+	borderRadius: number;
+	paddingH: number;
+	paddingV: number;
+	shadowType: ButtonShadowType;
+	shadowColour: string;
+	shadowBlur: number;
+	shadowSpread: number;
+}
+
+/** The three interactive states for a button. */
+export interface ButtonStyleMap {
+	normal: ButtonStateStyle;
+	focus: ButtonStateStyle;
+	activate: ButtonStateStyle;
+}
+
+/** Typography style shared by button labels and standalone text nodes. */
+export interface TextStyle {
+	fontFamily: string;
+	fontSize: number;
+	fontWeight: 'normal' | 'bold';
+	fontItalic: boolean;
+	textDecoration: 'none' | 'underline';
+	textAlign: 'left' | 'center' | 'right';
+	colour: string;
+	lineHeight: number;
+	letterSpacing: number;
+}
+
+/** A node within the authored menu scene graph. */
+export type SceneNode =
+	| { type: 'group'; id: string; name: string; children: SceneNode[] }
+	| {
+			type: 'text';
+			id: string;
+			content: string;
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+			fontSize?: number;
+			colour?: string;
+			fontFamily?: string;
+			fontWeight?: 'normal' | 'bold';
+			fontItalic?: boolean;
+			textDecoration?: 'none' | 'underline';
+			textAlign?: 'left' | 'center' | 'right';
+			lineHeight?: number;
+			letterSpacing?: number;
+	  }
+	| {
+			type: 'image';
+			id: string;
+			assetId: string;
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+	  }
+	| {
+			type: 'shape';
+			id: string;
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+			fill?: string;
+	  }
+	| { type: 'video'; id: string; assetId: string; x: number; y: number }
+	| {
+			type: 'button';
+			id: string;
+			label: string;
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+			highlightMode?: HighlightMode;
+			highlightKeyframes?: HighlightKeyframe[];
+			videoAssetId?: string | null;
+			/** Per-state visual appearance (authored layer). */
+			buttonStyle?: ButtonStyleMap;
+			/** Label typography. */
+			labelStyle?: TextStyle;
+	  }
+	| { type: 'componentInstance'; id: string; componentId: string }
+	| { type: 'generatedCollection'; id: string; source: string };
+
+export interface SceneGuide {
+	orientation: 'horizontal' | 'vertical';
+	position: number;
+}
+
+/** The interaction graph defining remote-driven behaviour. */
+export interface MenuInteractionGraph {
+	defaultFocusId: string | null;
+	nodes: FocusNode[];
+	timeoutAction: PlaybackAction | null;
+}
+
+export interface FocusNode {
+	nodeId: string;
+	navUp: string | null;
+	navDown: string | null;
+	navLeft: string | null;
+	navRight: string | null;
+	action: PlaybackAction | null;
+}
+
+/** Timing and motion rules for the menu. */
+export interface MenuTiming {
+	introStartSecs: number;
+	introDurationSecs: number;
+	loopStartSecs: number;
+	loopDurationSecs: number;
+	loopCount: number; // 0 = infinite
+}
+
+/** Metadata for generated menus. */
+export interface MenuGenerationMeta {
+	generatorId: string;
+	lastGeneratedAt: string;
+}
+
+/** Format-specific compilation rules and safe-area policies. */
+export interface MenuCompilePolicy {
+	displayAspect: AspectMode;
+	safeAreaMode: 'action-safe' | 'title-safe' | 'none';
+	paletteStrategy: 'auto' | 'manual';
+}
+
+/** DVD subpicture highlight palette for button overlays. */
+export interface MenuHighlightColours {
+	/** CSS hex colour shown when a button is selected/focused. */
+	selectColour: string;
+	/** Opacity of the select highlight (0.0-1.0). */
+	selectOpacity: number;
+	/** CSS hex colour shown briefly when a button is activated/pressed. */
+	activateColour: string;
+	/** Opacity of the activate highlight (0.0-1.0). */
+	activateOpacity: number;
+}
+
+export interface MenuButton {
+	id: string;
+	label: string;
+	bounds: ButtonBounds;
+	action: PlaybackAction | null;
+	navUp: string | null;
+	navDown: string | null;
+	navLeft: string | null;
+	navRight: string | null;
+	/** Whether button highlights are static or animated (Stage 2). */
+	highlightMode: HighlightMode;
+	/** Animated highlight keyframes (Stage 2). */
+	highlightKeyframes: HighlightKeyframe[];
+	/** Video asset composited into the menu background at this button's bounds (Stage 2). */
+	videoAssetId: string | null;
+}
+
+export interface HighlightKeyframe {
+	timestampSecs: number;
+	selectColour: string | null;
+	selectOpacity: number | null;
+	activateColour: string | null;
+	activateOpacity: number | null;
+}
+
+export interface ButtonBounds {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+// ── Assets ──────────────────────────────────────────────────────────────────
+
+export interface Asset {
+	id: string;
+	fileName: string;
+	sourcePath: string;
+	fileSizeBytes: number | null;
+	durationSecs: number | null;
+	containerFormat: string | null;
+	videoStreams: VideoStreamInfo[];
+	audioStreams: AudioStreamInfo[];
+	subtitleStreams: SubtitleStreamInfo[];
+	compatibility: CompatibilityAssessment | null;
+	fingerprint: string | null;
+	/** Detailed per-stream compatibility breakdown. */
+	compatibilityDetail: CompatibilityDetail | null;
+	warnings: AssetWarning[];
+	thumbnailPath: string | null;
+	thumbnailError: string | null;
+	/** Chapter markers detected in the source media file. */
+	sourceChapters: SourceChapter[];
+	/** Container-level title tag from source media metadata (e.g. MKV/MP4 title). */
+	formatTitle: string | null;
+}
+
+export interface AssetWarning {
+	code: string;
+	message: string;
+}
+
+export interface VideoStreamInfo {
+	index: number;
+	codec: string;
+	width: number;
+	height: number;
+	frameRate: number | null;
+	aspectRatio: string | null;
+	scanType: string | null;
+	bitrateBps: number | null;
+	title: string | null;
+	/** OETF transfer characteristics, e.g. "smpte2084" (HDR10), "arib-std-b67" (HLG). */
+	colorTransfer: string | null;
+	/** Colour primaries, e.g. "bt2020" (HDR), "bt709" (SDR). */
+	colorPrimaries: string | null;
+	/** Dolby Vision profile when ffprobe exposes DOVI side data. */
+	dolbyVisionProfile: number | null;
+}
+
+export interface AudioStreamInfo {
+	index: number;
+	codec: string;
+	channels: number;
+	sampleRate: number;
+	language: string | null;
+	bitrateBps: number | null;
+	title: string | null;
+}
+
+export interface SubtitleStreamInfo {
+	index: number;
+	codec: string;
+	language: string | null;
+	subtitleType: SubtitleType;
+	title: string | null;
+}
+
+// ── Compatibility Detail ────────────────────────────────────────────────
+
+/** Per-stream compatibility breakdown explaining why the overall assessment was given. */
+export interface CompatibilityDetail {
+	overall: CompatibilityAssessment;
+	video: VideoCompatibility | null;
+	audioStreams: AudioStreamCompatibility[];
+	container: ContainerCompatibility;
+}
+
+export interface VideoCompatibility {
+	codec: PropertyCheck;
+	resolution: PropertyCheck;
+	frameRate: PropertyCheck;
+}
+
+export interface AudioStreamCompatibility {
+	streamIndex: number;
+	codec: PropertyCheck;
+}
+
+export interface ContainerCompatibility {
+	format: PropertyCheck;
+}
+
+/** A single property compatibility check result. */
+export interface PropertyCheck {
+	value: string;
+	dvdRequires: string;
+	action: string;
+	compatible: boolean;
+}
+
+// ── Build Settings ──────────────────────────────────────────────────────────
+
+export interface BuildSettings {
+	outputDirectory: string | null;
+	generateIso: boolean;
+	safetyMarginBytes: number;
+	allocationStrategy: AllocationStrategy;
+	subtitleRenderMode?: 'one-pass' | 'two-pass';
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+export interface ValidationIssue {
+	severity: IssueSeverity;
+	code: string;
+	message: string;
+	context: string | null;
+	/** Entity type for navigation: "title", "menu", "titleset", "disc", "build". */
+	entityType?: string | null;
+	/** Human-readable name of the affected entity. */
+	entityName?: string | null;
+	/** Actionable guidance on how to resolve the issue. */
+	suggestedFix?: string | null;
+}
+
+// ── Build Pipeline ──────────────────────────────────────────────────────────
+
+export interface BuildPlan {
+	jobs: BuildJob[];
+	outputDirectory: string;
+	workingDirectory: string;
+	dvdauthorXml: string;
+	summary: BuildSummary;
+}
+
+export interface BuildSummary {
+	totalJobs: number;
+	transcodeJobs: number;
+	titlesCount: number;
+	menusCount: number;
+	generateIso: boolean;
+	estimatedCommands: string[];
+}
+
+export type BuildJob =
+	| { type: 'prepareWorkspace'; directories: string[] }
+	| {
+			type: 'transcodeTitle';
+			titleId: string;
+			titleName: string;
+			sourcePath: string;
+			outputPath: string;
+			command: string[];
+			label: string;
+			/** Source asset duration in seconds, used for step-progress estimation. */
+			durationSecs: number | null;
+	  }
+	| {
+			type: 'renderMenu';
+			menuId: string;
+			menuName: string;
+			outputPath: string;
+			command: string[];
+			label: string;
+	  }
+	| {
+			type: 'composeMenuHighlights';
+			menuId: string;
+			menuName: string;
+			inputPath: string;
+			outputPath: string;
+			spumuxXml: string;
+			command: string[];
+			label: string;
+	  }
+	| {
+			type: 'linkTitle';
+			titleId: string;
+			titleName: string;
+			sourcePath: string;
+			linkPath: string;
+			label: string;
+	  }
+	| {
+			type: 'extractSubtitles';
+			titleId: string;
+			titleName: string;
+			sourcePath: string;
+			outputPath: string;
+			command: string[];
+			label: string;
+	  }
+	| {
+			type: 'renderTextSubtitles';
+			titleId: string;
+			titleName: string;
+			sourcePath: string;
+			sourceStreamIndex: number;
+			inputPath: string;
+			outputPath: string;
+			subtitlePath: string;
+			prepareCommand: string[];
+			spumuxXml: string;
+			command: string[];
+			label: string;
+			renderMode: 'one-pass' | 'two-pass';
+			fontFamily: string;
+	  }
+	| {
+			type: 'authorDvd';
+			xmlPath: string;
+			outputPath: string;
+			command: string[];
+			label: string;
+	  }
+	| {
+			type: 'createIso';
+			sourcePath: string;
+			outputPath: string;
+			command: string[];
+			label: string;
+	  };
+
+export interface BuildProgress {
+	jobIndex: number;
+	totalJobs: number;
+	currentLabel: string;
+	status: 'starting' | 'running' | 'complete' | 'failed';
+	output: string | null;
+	/** Short name for the active sub-operation (e.g. "FFmpeg transcode"). */
+	stepLabel?: string | null;
+	/** Estimated completion of the current sub-operation, clamped to 0-100. */
+	stepPercent?: number | null;
+	/** Freeform detail such as media timestamp or encoding phase. */
+	stepDetail?: string | null;
+	/** Lifecycle state of the sub-operation. */
+	stepStatus?: 'starting' | 'running' | 'complete' | 'failed' | null;
+}
+
+export interface BuildResult {
+	success: boolean;
+	outputDirectory: string;
+	isoPath: string | null;
+	logLines: string[];
+	failedJobIndex: number | null;
+	errorMessage: string | null;
+}
+
+export interface ToolchainStatus {
+	name: string;
+	purpose: string;
+	available: boolean;
+	version: string | null;
+}
+
+// ── Font Enumeration ────────────────────────────────────────────────────────
+
+/** Where a font family came from in the Skia renderer's resolution priority chain. */
+export type FontSource = 'project-asset' | 'app-sidecar' | 'system';
+
+/** A font family available to the Skia renderer, with its source tier. */
+export interface FontEntry {
+	/** Display name shown in the UI (e.g. "DejaVu Sans"). */
+	family: string;
+	/** Where this font came from. */
+	source: FontSource;
+}
+
+// ── Command Payloads ────────────────────────────────────────────────────────
+
+export interface CreateProjectRequest {
+	name: string;
+	standard: VideoStandard;
+	capacityTarget: CapacityTarget;
+}
+
+// ── Build Progress Event ────────────────────────────────────────────────────
+
+/** Event name emitted on build progress (see `execute_build`). */
+export const BUILD_PROGRESS_EVENT = 'spindle://build-progress';
+
+/** Subscribe to build-progress notifications for the current window. */
+export async function onBuildProgress(
+	handler: (progress: BuildProgress) => void,
+): Promise<UnlistenFn> {
+	return await listen<BuildProgress>(BUILD_PROGRESS_EVENT, (event) => handler(event.payload));
+}
+
+// ── Commands ─────────────────────────────────────────────────────────────────
+
+/** Create a new default project with the given settings. */
+export async function createProject(payload: CreateProjectRequest): Promise<SpindleProjectFile> {
+	return await invoke('plugin:spindle-project|create_project', { payload });
+}
+
+/** Parse and validate a project file from its JSON content string. */
+export async function parseProject(json: string): Promise<SpindleProjectFile> {
+	return await invoke('plugin:spindle-project|parse_project', { json });
+}
+
+/** Serialise a project to its JSON string for saving via tauri-plugin-fs. */
+export async function serialiseProject(project: SpindleProjectFile): Promise<string> {
+	return await invoke('plugin:spindle-project|serialise_project', { project });
+}
+
+/** Validate a project and return any issues found. */
+export async function validateProject(project: SpindleProjectFile): Promise<ValidationIssue[]> {
+	return await invoke('plugin:spindle-project|validate_project', { project });
+}
+
+/** Inspect a media file and return its metadata as an Asset. */
+export async function inspectAsset(path: string): Promise<Asset> {
+	return await invoke('plugin:spindle-project|inspect_asset', { path });
+}
+
+/** Extract a thumbnail from a video asset at a given timestamp. */
+export async function extractVideoThumbnail(
+	sourcePath: string,
+	outputPath: string,
+	timestampSecs: number,
+): Promise<void> {
+	await invoke('plugin:spindle-project|extract_video_thumbnail', {
+		sourcePath,
+		outputPath,
+		timestampSecs,
+	});
+}
+
+/** Extract a scaled-down JPEG thumbnail from a still image asset. */
+export async function extractImageThumbnail(sourcePath: string, outputPath: string): Promise<void> {
+	await invoke('plugin:spindle-project|extract_image_thumbnail', { sourcePath, outputPath });
+}
+
+/** Options shared by build-plan generation and build execution. */
+export interface BuildOptions {
+	skipSidecar: boolean;
+	skipUnsupportedStreams: boolean;
+	quantizeOverlayPalette: boolean;
+}
+
+/** Generate a build plan without executing it (dry-run / preview). */
+export async function generateBuildPlan(
+	project: SpindleProjectFile,
+	outputDirectory: string,
+	options: BuildOptions,
+): Promise<BuildPlan> {
+	return await invoke('plugin:spindle-project|generate_build_plan', {
+		project,
+		outputDirectory,
+		skipSidecar: options.skipSidecar,
+		skipUnsupportedStreams: options.skipUnsupportedStreams,
+		quantizeOverlayPalette: options.quantizeOverlayPalette,
+	});
+}
+
+/** Execute a build plan, emitting progress events (see `onBuildProgress`). */
+export async function executeBuild(
+	project: SpindleProjectFile,
+	outputDirectory: string,
+	options: BuildOptions,
+): Promise<BuildResult> {
+	return await invoke('plugin:spindle-project|execute_build', {
+		project,
+		outputDirectory,
+		skipSidecar: options.skipSidecar,
+		skipUnsupportedStreams: options.skipUnsupportedStreams,
+		quantizeOverlayPalette: options.quantizeOverlayPalette,
+	});
+}
+
+/** Cancel a running build. */
+export async function cancelBuild(): Promise<void> {
+	await invoke('plugin:spindle-project|cancel_build');
+}
+
+/** Auto-generate directional navigation for a menu's buttons based on geometry. */
+export async function autoGenerateMenuNav(menu: Menu): Promise<Menu> {
+	return await invoke('plugin:spindle-project|auto_generate_menu_nav', { menu });
+}
+
+/** Check which external tools are available on the system PATH. */
+export async function checkToolchain(skipSidecar: boolean): Promise<ToolchainStatus[]> {
+	return await invoke('plugin:spindle-project|check_toolchain', { skipSidecar });
+}
+
+/** Export a DAR-corrected render preview PNG for the given menu. */
+export async function exportMenuRenderPreview(
+	project: SpindleProjectFile,
+	menuId: string,
+	outputPath: string,
+): Promise<void> {
+	await invoke('plugin:spindle-project|export_menu_render_preview', {
+		project,
+		menuId,
+		outputPath,
+	});
+}
+
+/** List all font families available to the Skia renderer for the given project. */
+export async function listAvailableFonts(project: SpindleProjectFile): Promise<FontEntry[]> {
+	return await invoke('plugin:spindle-project|list_available_fonts', { project });
+}
+
+/** Return the application cache directory for storing thumbnails and other transient data. */
+export async function getCacheDir(): Promise<string> {
+	return await invoke('plugin:spindle-project|get_cache_dir');
+}
+
+/** Export a diagnostics bundle as a JSON string for troubleshooting. */
+export async function exportDiagnostics(
+	project: SpindleProjectFile | null,
+	buildLog: string[],
+	validationIssues: ValidationIssue[],
+	options: BuildOptions,
+): Promise<string> {
+	return await invoke('plugin:spindle-project|export_diagnostics', {
+		project,
+		buildLog,
+		validationIssues,
+		skipSidecar: options.skipSidecar,
+		skipUnsupportedStreams: options.skipUnsupportedStreams,
+		quantizeOverlayPalette: options.quantizeOverlayPalette,
+	});
+}

--- a/plugins/tauri-plugin-spindle-project/package.json
+++ b/plugins/tauri-plugin-spindle-project/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "tauri-plugin-spindle-project-api",
+	"version": "0.1.0",
+	"author": "Liminal HQ, Scott Morris",
+	"description": "JS bindings for the spindle-project Tauri plugin.",
+	"type": "module",
+	"types": "./dist-js/index.d.ts",
+	"main": "./dist-js/index.cjs",
+	"module": "./dist-js/index.js",
+	"exports": {
+		"types": "./dist-js/index.d.ts",
+		"import": "./dist-js/index.js",
+		"require": "./dist-js/index.cjs",
+		"default": "./dist-js/index.js"
+	},
+	"files": [
+		"dist-js",
+		"README.md"
+	],
+	"scripts": {
+		"build": "rollup -c",
+		"prepublishOnly": "pnpm build",
+		"pretest": "pnpm build"
+	},
+	"dependencies": {
+		"@tauri-apps/api": "^2.0.0"
+	},
+	"devDependencies": {
+		"@rollup/plugin-typescript": "^12.0.0",
+		"rollup": "^4.9.6",
+		"typescript": "^5.3.3",
+		"tslib": "^2.6.2"
+	}
+}

--- a/plugins/tauri-plugin-spindle-project/rollup.config.js
+++ b/plugins/tauri-plugin-spindle-project/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { cwd } from 'node:process';
+import typescript from '@rollup/plugin-typescript';
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'));
+
+export default {
+	input: 'guest-js/index.ts',
+	output: [
+		{
+			file: pkg.exports.import,
+			format: 'esm',
+		},
+		{
+			file: pkg.exports.require,
+			format: 'cjs',
+		},
+	],
+	plugins: [
+		typescript({
+			declaration: true,
+			declarationDir: dirname(pkg.exports.import),
+		}),
+	],
+	external: [
+		/^@tauri-apps\/api/,
+		...Object.keys(pkg.dependencies || {}),
+		...Object.keys(pkg.peerDependencies || {}),
+	],
+};

--- a/plugins/tauri-plugin-spindle-project/tsconfig.json
+++ b/plugins/tauri-plugin-spindle-project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "es2021",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"skipLibCheck": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noImplicitAny": true,
+		"noEmit": true
+	},
+	"include": ["guest-js/*.ts"],
+	"exclude": ["dist-js", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       tauri-plugin-display-awareness-api:
         specifier: workspace:*
         version: link:../../plugins/tauri-plugin-display-awareness
+      tauri-plugin-spindle-project-api:
+        specifier: workspace:*
+        version: link:../../plugins/tauri-plugin-spindle-project
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -85,6 +88,25 @@ importers:
         version: 4.1.0(@types/node@25.5.0)(happy-dom@20.8.4)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0))
 
   plugins/tauri-plugin-display-awareness:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.60.0)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.60.0
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  plugins/tauri-plugin-spindle-project:
     dependencies:
       '@tauri-apps/api':
         specifier: ^2.0.0


### PR DESCRIPTION
## Summary

### Adopts the guest-js convention for `tauri-plugin-spindle-project`

- Added `guest-js/index.ts`, `package.json` (`tauri-plugin-spindle-project-api`), `rollup.config.js`, and `tsconfig.json` to `tauri-plugin-spindle-project`, mirroring the setup `tauri-plugin-display-awareness` got in #31.
- Replaced every raw `invoke('plugin:spindle-project|...')` call in `project-store.ts`, `MenusPage.tsx`, and `SettingsPage.tsx` with typed binding functions from the new package, and replaced the raw `listen('spindle://build-progress', ...)` in `App.tsx` with an `onBuildProgress` wrapper.
- `generateBuildPlan`, `executeBuild`, and `exportDiagnostics` now take a single `BuildOptions` argument instead of three positional booleans, since every call site already threaded the same three flags through together.

### Moves the project domain model into the plugin

- `SpindleProjectFile`, `Menu`, `Asset`, `BuildPlan`, and the rest of the domain types moved from `apps/spindle/src/types/project.ts` into the plugin's `guest-js`, since they mirror the Rust structs the plugin's commands serialise — the plugin is now the source of truth, same as `tauri-plugin-display-awareness` owning `DisplayGeometry`.
- `apps/spindle/src/types/project.ts` re-exports them from `tauri-plugin-spindle-project-api` so existing imports across the app keep working unchanged, and now holds only the app-specific helpers (`createDefaultProject`, `inferDefaultMenuDisplayAspect`, `createDefaultMenuCompilePolicy`, the colour/capacity constants).

### Wires the new package into the build

- `apps/spindle/package.json` gained `tauri-plugin-spindle-project-api` as a `workspace:*` dependency and added it to the existing `predev`/`prebuild`/`pretest`/`pretest:ci` lifecycle hooks alongside `tauri-plugin-display-awareness-api`.

Closes #32.

## Test plan

- [x] `pnpm test:js` — all 71 existing JS tests pass unchanged (they exercise the new bindings indirectly through the already-mocked `@tauri-apps/api/core` `invoke`)
- [x] `npx tsc --noEmit` — clean across the app
- [x] `pnpm build` from a clean checkout (`dist-js` removed) — both plugins' guest-js build via the `prebuild` hook before `vite build`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` and `cargo fmt --all -- --check` — clean (no Rust changes in this PR)
- [x] `pnpm format:check` — clean
