### PR TITLE
Declare a VMGM video format even when a disc has no global menus

### DIFF
--- a/plugins/tauri-plugin-spindle-project/src/build/authoring.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring.rs
@@ -41,20 +41,23 @@ pub(crate) fn generate_dvdauthor_xml(
     if has_global_menus || has_first_play {
         xml.push_str("  <vmgm>\n");
 
-        if has_global_menus {
-            let vmgm_aspect =
-                menu_section_aspect(project, &project.disc.global_menus, MenuDomain::Vmgm)?;
-            append_menu_section(
-                &mut xml,
-                format_str,
-                aspect_str(vmgm_aspect),
-                &project.disc.global_menus,
-                MenuDomain::Vmgm,
-                &project.disc,
-                project,
-                menus_dir,
-            )?;
-        }
+        // dvdauthor requires a video format declaration for the VMGM domain even when
+        // it has no authored menu content of its own (e.g. a disc whose only VMGM-level
+        // need is a first-play jump, with all real menus living at the titleset level).
+        // `append_menu_section` already handles an empty `menus` slice safely, writing
+        // just `<menus><video .../></menus>` with no PGC content.
+        let vmgm_aspect =
+            menu_section_aspect(project, &project.disc.global_menus, MenuDomain::Vmgm)?;
+        append_menu_section(
+            &mut xml,
+            format_str,
+            aspect_str(vmgm_aspect),
+            &project.disc.global_menus,
+            MenuDomain::Vmgm,
+            &project.disc,
+            project,
+            menus_dir,
+        )?;
 
         if let Some(ref action) = project.disc.first_play_action {
             xml.push_str("    <fpc>\n");
@@ -711,6 +714,38 @@ mod tests {
             "dvdauthor XML must declare aspect ratio\n{}",
             plan.dvdauthor_xml
         );
+    }
+
+    #[test]
+    fn dvdauthor_xml_declares_vmgm_video_format_with_first_play_but_no_global_menus() {
+        // Regression test: a disc with a first-play action but no global/VMGM-level
+        // menus (the common case where all real menus live at the titleset level)
+        // must still declare a video format inside <vmgm>, otherwise dvdauthor fails
+        // at the final table-of-contents step with "no video format specified for VMGM".
+        let mut project = test_project();
+        assert!(project.disc.global_menus.is_empty());
+        project.disc.first_play_action = Some(PlaybackAction::PlayTitle {
+            title_id: "title-1".to_string(),
+        });
+
+        let plan = generate_build_plan(&project, "/tmp/dvd_output", false).unwrap();
+
+        let vmgm_start = plan
+            .dvdauthor_xml
+            .find("<vmgm>")
+            .expect("dvdauthor XML must contain a <vmgm> block");
+        let vmgm_end = plan
+            .dvdauthor_xml
+            .find("</vmgm>")
+            .expect("dvdauthor XML must close the <vmgm> block");
+        let vmgm_block = &plan.dvdauthor_xml[vmgm_start..vmgm_end];
+
+        assert!(
+            vmgm_block.contains("<video format=\"ntsc\" aspect=\"16:9\" />"),
+            "<vmgm> must declare a video format even with no global menus\n{}",
+            plan.dvdauthor_xml
+        );
+        assert!(vmgm_block.contains("<fpc>"));
     }
 
     #[test]

--- a/plugins/tauri-plugin-spindle-project/src/build/executor.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor.rs
@@ -1075,6 +1075,87 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires ffmpeg, spumux, and dvdauthor on PATH"]
+    fn execute_build_plan_smoke_authors_disc_with_first_play_but_no_global_menus() {
+        // Regression test for a disc whose VMGM has a first-play action but no
+        // global menus of its own (all real menus, if any, live at the titleset
+        // level) — the exact shape that previously made the real `dvdauthor`
+        // binary fail at the final table-of-contents step with
+        // "no video format specified for VMGM", even though the generated XML
+        // looked fine to the fast in-process unit tests.
+        let Some(ffmpeg_bin) = find_tool_on_path("ffmpeg") else {
+            eprintln!("Skipping smoke test because `ffmpeg` is not available on PATH.");
+            return;
+        };
+        if find_tool_on_path("dvdauthor").is_none() {
+            eprintln!("Skipping smoke test because `dvdauthor` is not available on PATH.");
+            return;
+        }
+
+        let output_dir = unique_temp_dir("build-smoke-vmgm-no-menus");
+        let source_path = output_dir.join("source.mp4");
+        fs::create_dir_all(&output_dir).unwrap();
+
+        let ffmpeg_status = Command::new(ffmpeg_bin)
+            .args([
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=black:s=640x360:d=1.5",
+                "-f",
+                "lavfi",
+                "-i",
+                "anullsrc=r=48000:cl=stereo",
+                "-shortest",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+            ])
+            .arg(&source_path)
+            .status()
+            .expect("ffmpeg should launch for smoke test fixture generation");
+        assert!(
+            ffmpeg_status.success(),
+            "ffmpeg fixture generation failed with status {ffmpeg_status}"
+        );
+
+        let mut project = test_project();
+        project.assets[0].source_path = source_path.display().to_string();
+        project.assets[0].file_name = "source.mp4".to_string();
+        project.assets[0].duration_secs = Some(1.5);
+        // First-play action set, but `global_menus` is left empty — no VMGM-level
+        // menus at all, only the titleset's title.
+        project.disc.first_play_action = Some(PlaybackAction::PlayTitle {
+            title_id: "title-1".to_string(),
+        });
+        assert!(project.disc.global_menus.is_empty());
+
+        let plan = generate_build_plan(&project, output_dir.to_str().unwrap(), true).unwrap();
+        let result = execute_build_plan(&plan, |_| {});
+
+        if !result.success {
+            panic!(
+                "expected smoke build to succeed\n{}",
+                result.log_lines.join("\n")
+            );
+        }
+
+        assert!(
+            output_dir.join("DVD_DISC/VIDEO_TS/VIDEO_TS.IFO").exists(),
+            "expected VIDEO_TS.IFO in authored output for a disc with a first-play \
+             action but no global menus"
+        );
+
+        fs::remove_dir_all(&output_dir).unwrap();
+    }
+
+    #[test]
     #[ignore = "requires ffmpeg, ffprobe, spumux, and dvdauthor on PATH"]
     fn execute_build_plan_smoke_authors_text_subtitle_stream() {
         let Some(ffmpeg_bin) = find_tool_on_path("ffmpeg") else {

--- a/plugins/tauri-plugin-spindle-project/src/build/executor.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor.rs
@@ -1129,6 +1129,10 @@ mod tests {
         project.assets[0].source_path = source_path.display().to_string();
         project.assets[0].file_name = "source.mp4".to_string();
         project.assets[0].duration_secs = Some(1.5);
+        // Trim the fixture's default chapter list to fit the 1.5s source — the
+        // default second chapter sits at 300s, well past this short fixture.
+        project.disc.titlesets[0].titles[0].chapters =
+            vec![project.disc.titlesets[0].titles[0].chapters[0].clone()];
         // First-play action set, but `global_menus` is left empty — no VMGM-level
         // menus at all, only the titleset's title.
         project.disc.first_play_action = Some(PlaybackAction::PlayTitle {


### PR DESCRIPTION
## Summary

- **Fixed a build-breaking authoring bug**: discs with a first-play action but no global/VMGM-level menus (the common shape — a project whose real menus all live at the titleset level) failed `dvdauthor`'s final table-of-contents step with `ERR: no video format specified for VMGM`, after all transcoding had already completed. The generated `<vmgm>` block only declared a video format when global menus existed; it now always declares one, reusing the existing menu-section helper which already handles an empty menu list safely.

### Build pipeline

- `<vmgm>` now always emits a `<video format=... aspect=... />` declaration, matching what `<vmgm>` with global menus already produced.

## Test plan

- [x] `cargo fmt --check -p tauri-plugin-spindle-project`
- [x] `cargo clippy -p tauri-plugin-spindle-project --all-targets -- -D warnings`
- [x] `cargo test -p tauri-plugin-spindle-project` — 166 passed, 0 failed, 3 ignored (including new regression test `dvdauthor_xml_declares_vmgm_video_format_with_first_play_but_no_global_menus`)
- [x] Added a real-`dvdauthor` opt-in smoke test, `execute_build_plan_smoke_authors_disc_with_first_play_but_no_global_menus`, mirroring the existing titleset-menu smoke test but with no global menus and a `PlayTitle` first-play action — verified it reproduces the exact `ERR: no video format specified for VMGM` failure against the pre-fix code (`cargo test --release -- --ignored execute_build_plan_smoke_authors_disc_with_first_play_but_no_global_menus`), and passes with the fix
- [x] Manually reproduced the original failure end-to-end: authored an 8-episode test project (first-play action, no global menus, all menus at titleset level), ran the unpatched `dvdauthor -x` and got the exact `ERR: no video format specified for VMGM` failure with exit code 1; applying the equivalent `<video>` element by hand and re-running produced a complete, valid `VIDEO_TS/` (including `VIDEO_TS.IFO`/`.BUP`, previously missing) — confirmed via `ffprobe` that the muxed title VOBs are valid DVD-Video MPEG-2 content.

Closes #39
