### PR TITLE
Share one disc-capacity estimate between Overview and Planner

### DIFF
--- a/apps/spindle/src/pages/OverviewPage.tsx
+++ b/apps/spindle/src/pages/OverviewPage.tsx
@@ -6,7 +6,8 @@
 import { useProjectStore } from '../store/project-store';
 import { useNavigation } from '../App';
 import { NoProjectState } from '../components/NoProjectState';
-import { CAPACITY_LABELS, CAPACITY_BYTES } from '../types/project';
+import { CAPACITY_LABELS } from '../types/project';
+import { estimateDiscCapacity, formatBytes } from '../utils/capacity';
 import type {
 	VideoStandard,
 	CapacityTarget,
@@ -47,28 +48,19 @@ export function OverviewPage() {
 		0,
 	);
 
-	const capacityBytes = CAPACITY_BYTES[disc.capacityTarget];
 	const errorCount = validationIssues.filter((i) => i.severity === 'error').length;
 	const warningCount = validationIssues.filter((i) => i.severity === 'warning').length;
 
-	// Estimate encoded disc size from title durations.
-	// Uses ~6 Mbps video + ~192 kbps per audio track as a rough DVD budget.
-	const estimatedBytes = disc.titlesets
-		.flatMap((ts) => ts.titles)
-		.reduce((total, title) => {
-			const asset = project.assets.find((a) => a.id === title.sourceAssetId);
-			const dur = asset?.durationSecs ?? 0;
-			const audioBps = title.audioMappings.length * 192_000;
-			return total + Math.round((dur * (6_000_000 + audioBps)) / 8);
-		}, 0);
-	const usedFraction = Math.min(estimatedBytes / capacityBytes, 1);
-	const barPct = `${(usedFraction * 100).toFixed(1)}%`;
-	const barClass =
-		usedFraction > 0.95
-			? 'capacity-bar__segment--danger'
-			: usedFraction > 0.8
-				? 'capacity-bar__segment--warn'
-				: '';
+	// Same budget-aware estimate the Planner page uses, so the two pages never
+	// disagree about whether a project fits on its target disc.
+	const { capacityBytes, estimatedOutputBytes, usagePct, isOverCapacity } =
+		estimateDiscCapacity(project);
+	const barPct = `${Math.min(usagePct, 100).toFixed(1)}%`;
+	const barClass = isOverCapacity
+		? 'capacity-bar__segment--danger'
+		: usagePct > 80
+			? 'capacity-bar__segment--warn'
+			: '';
 
 	return (
 		<div className="overview">
@@ -118,8 +110,8 @@ export function OverviewPage() {
 						</span>
 					) : (
 						<span className="text-muted">
-							~{formatBytes(estimatedBytes)} estimated &middot;{' '}
-							{formatBytes(capacityBytes - estimatedBytes)} remaining
+							~{formatBytes(estimatedOutputBytes)} estimated &middot;{' '}
+							{formatBytes(capacityBytes - estimatedOutputBytes)} remaining
 						</span>
 					)}
 				</div>
@@ -321,12 +313,6 @@ function StatCard({ label, value }: { label: string; value: number; icon: string
 			<div className="overview__stat-label text-muted">{label}</div>
 		</div>
 	);
-}
-
-function formatBytes(bytes: number): string {
-	if (bytes >= 1_000_000_000) return `${(bytes / 1_000_000_000).toFixed(1)} GB`;
-	if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`;
-	return `${bytes} B`;
 }
 
 function firstPlayToString(action: PlaybackAction | null): string {

--- a/apps/spindle/src/pages/OverviewPage.tsx
+++ b/apps/spindle/src/pages/OverviewPage.tsx
@@ -53,7 +53,7 @@ export function OverviewPage() {
 
 	// Same budget-aware estimate the Planner page uses, so the two pages never
 	// disagree about whether a project fits on its target disc.
-	const { capacityBytes, estimatedOutputBytes, usagePct, isOverCapacity } =
+	const { capacityBytes, usableBytes, estimatedOutputBytes, usagePct, isOverCapacity } =
 		estimateDiscCapacity(project);
 	const barPct = `${Math.min(usagePct, 100).toFixed(1)}%`;
 	const barClass = isOverCapacity
@@ -111,7 +111,7 @@ export function OverviewPage() {
 					) : (
 						<span className="text-muted">
 							~{formatBytes(estimatedOutputBytes)} estimated &middot;{' '}
-							{formatBytes(capacityBytes - estimatedOutputBytes)} remaining
+							{formatBytes(usableBytes - estimatedOutputBytes)} remaining
 						</span>
 					)}
 				</div>

--- a/apps/spindle/src/pages/PlannerPage.tsx
+++ b/apps/spindle/src/pages/PlannerPage.tsx
@@ -5,13 +5,16 @@
 
 import { useProjectStore } from '../store/project-store';
 import { NoProjectState } from '../components/NoProjectState';
-import { CAPACITY_LABELS, CAPACITY_BYTES } from '../types/project';
+import { CAPACITY_LABELS } from '../types/project';
 import type { Title, Asset, Menu } from '../types/project';
+import {
+	estimateDiscCapacity,
+	formatBytes,
+	DVD_MAX_VIDEO_RATE_BPS,
+	STILL_MENU_BYTES,
+	MOTION_MENU_BITRATE,
+} from '../utils/capacity';
 import './PlannerPage.css';
-
-// DVD-Video spec limits (ISO/IEC 13818-1)
-const DVD_MAX_MUX_RATE_BPS = 10_080_000; // 10.08 Mbps total mux rate
-const DVD_MAX_VIDEO_RATE_BPS = 9_800_000; // 9.8 Mbps max video ES
 
 export function PlannerPage() {
 	const project = useProjectStore((s) => s.project);
@@ -33,7 +36,6 @@ export function PlannerPage() {
 	}
 
 	const disc = project.disc;
-	const capacityBytes = CAPACITY_BYTES[disc.capacityTarget];
 
 	// Gather all titles with their assets
 	const titlesWithAssets: { title: Title; asset: Asset | null }[] = disc.titlesets.flatMap((ts) =>
@@ -43,50 +45,27 @@ export function PlannerPage() {
 		})),
 	);
 
-	// Calculate total content size estimate
-	const totalDurationSecs = titlesWithAssets.reduce(
-		(sum, { asset }) => sum + (asset?.durationSecs ?? 0),
-		0,
-	);
-
-	// Gather all menus with their scope
+	// Gather all menus with their scope, for the per-menu breakdown table below.
 	const allMenus: { menu: Menu; scope: string }[] = [
 		...disc.globalMenus.map((m) => ({ menu: m, scope: 'Global' })),
 		...disc.titlesets.flatMap((ts) => ts.menus.map((m) => ({ menu: m, scope: ts.name }))),
 	];
 
-	// Estimate menu sizes: still menus are ~1-2 MB (MPEG-2 still + highlights),
-	// motion menus use their duration at a moderate bitrate.
-	const STILL_MENU_BYTES = 1_500_000; // ~1.5 MB per still menu
-	const MOTION_MENU_BITRATE = 5_000_000; // 5 Mbps for motion menus
-	const estimatedMenuBytes = allMenus.reduce((sum, { menu }) => {
-		if (menu.backgroundMode === 'motion' && menu.motionDurationSecs) {
-			return sum + (MOTION_MENU_BITRATE * menu.motionDurationSecs) / 8;
-		}
-		return sum + STILL_MENU_BYTES;
-	}, 0);
-
-	// Safety margin and overhead
-	const safetyMarginBytes = project.buildSettings.safetyMarginBytes;
-	const estimatedOverheadBytes = 50_000_000 + estimatedMenuBytes; // IFOs, NAV packs + menus
-	const usableBytes = capacityBytes - safetyMarginBytes - estimatedOverheadBytes;
 	// Note: usagePct and isOverCapacity use estimated output size (bitrate × duration),
 	// not source size, because source files will be re-encoded to DVD-compliant MPEG-2.
 	// Source size is only shown as a reference point.
-
-	// Per-title bitrate budget — capped to DVD spec limits
-	const rawBitsPerSecond = totalDurationSecs > 0 ? (usableBytes * 8) / totalDurationSecs : 0;
-	const maxVideoBitrate = Math.min(rawBitsPerSecond, DVD_MAX_VIDEO_RATE_BPS);
-	const availableBitsPerSecond = maxVideoBitrate;
-	const isCapacityConstrained = rawBitsPerSecond < DVD_MAX_VIDEO_RATE_BPS;
-
-	// Estimated output size at the budgeted rate
-	const estimatedOutputBytes =
-		totalDurationSecs > 0
-			? (Math.min(rawBitsPerSecond, DVD_MAX_MUX_RATE_BPS) * totalDurationSecs) / 8
-			: 0;
-	const usagePct = estimatedOutputBytes > 0 ? (estimatedOutputBytes / capacityBytes) * 100 : 0;
-	const isOverCapacity = estimatedOutputBytes > usableBytes;
+	const {
+		totalDurationSecs,
+		estimatedMenuBytes,
+		safetyMarginBytes,
+		estimatedOverheadBytes,
+		usableBytes,
+		availableBitsPerSecond,
+		isCapacityConstrained,
+		estimatedOutputBytes,
+		usagePct,
+		isOverCapacity,
+	} = estimateDiscCapacity(project);
 
 	return (
 		<div className="planner">
@@ -279,13 +258,6 @@ export function PlannerPage() {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
-
-function formatBytes(bytes: number): string {
-	if (bytes >= 1_000_000_000) return `${(bytes / 1_000_000_000).toFixed(2)} GB`;
-	if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`;
-	if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`;
-	return `${bytes} B`;
-}
 
 function formatDuration(seconds: number): string {
 	const h = Math.floor(seconds / 3600);

--- a/apps/spindle/src/utils/capacity.ts
+++ b/apps/spindle/src/utils/capacity.ts
@@ -61,6 +61,10 @@ export function estimateDiscCapacity(project: SpindleProjectFile): CapacityEstim
 	const estimatedOverheadBytes = 50_000_000 + estimatedMenuBytes; // IFOs, NAV packs + menus
 	const usableBytes = capacityBytes - safetyMarginBytes - estimatedOverheadBytes;
 
+	// NOTE: this budgeted rate is advisory only — the build pipeline currently
+	// encodes at a fixed bitrate regardless of what's computed here, so a
+	// capacity-constrained project can still produce an output larger than this
+	// estimate predicts. Tracked separately as liminal-hq/spindle#43.
 	const rawBitsPerSecond = totalDurationSecs > 0 ? (usableBytes * 8) / totalDurationSecs : 0;
 	const availableBitsPerSecond = Math.min(rawBitsPerSecond, DVD_MAX_VIDEO_RATE_BPS);
 	const isCapacityConstrained = rawBitsPerSecond < DVD_MAX_VIDEO_RATE_BPS;

--- a/apps/spindle/src/utils/capacity.ts
+++ b/apps/spindle/src/utils/capacity.ts
@@ -1,0 +1,99 @@
+// Shared disc-capacity estimation: a single budget-aware calculation used by
+// both the Overview and Planner pages, so they never disagree about whether
+// a project fits on its target disc.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { CAPACITY_BYTES } from '../types/project';
+import type { SpindleProjectFile } from '../types/project';
+
+// DVD-Video spec limits (ISO/IEC 13818-1)
+const DVD_MAX_MUX_RATE_BPS = 10_080_000; // 10.08 Mbps total mux rate
+export const DVD_MAX_VIDEO_RATE_BPS = 9_800_000; // 9.8 Mbps max video ES
+
+// Menu size estimate constants: still menus are ~1-2 MB (MPEG-2 still + highlights),
+// motion menus use their duration at a moderate bitrate.
+export const STILL_MENU_BYTES = 1_500_000; // ~1.5 MB per still menu
+export const MOTION_MENU_BITRATE = 5_000_000; // 5 Mbps for motion menus
+
+export interface CapacityEstimate {
+	capacityBytes: number;
+	totalDurationSecs: number;
+	estimatedMenuBytes: number;
+	safetyMarginBytes: number;
+	estimatedOverheadBytes: number;
+	usableBytes: number;
+	/** Average video bitrate available within budget, capped to DVD spec limits. */
+	availableBitsPerSecond: number;
+	/** True when the disc's capacity (not the DVD spec) is the binding constraint. */
+	isCapacityConstrained: boolean;
+	/** Estimated encoded size at the budgeted rate — not source file size, since
+	 * source files are re-encoded to DVD-compliant MPEG-2 before authoring. */
+	estimatedOutputBytes: number;
+	usagePct: number;
+	isOverCapacity: boolean;
+}
+
+/** Estimate encoded disc size and bitrate budget from total title duration,
+ * the disc's capacity target, and authored menus — shared by Overview and
+ * Planner so both pages report the same answer to "does this fit?" */
+export function estimateDiscCapacity(project: SpindleProjectFile): CapacityEstimate {
+	const disc = project.disc;
+	const capacityBytes = CAPACITY_BYTES[disc.capacityTarget];
+
+	const totalDurationSecs = disc.titlesets
+		.flatMap((ts) => ts.titles)
+		.reduce((sum, title) => {
+			const asset = project.assets.find((a) => a.id === title.sourceAssetId);
+			return sum + (asset?.durationSecs ?? 0);
+		}, 0);
+
+	const allMenus = [...disc.globalMenus, ...disc.titlesets.flatMap((ts) => ts.menus)];
+	const estimatedMenuBytes = allMenus.reduce((sum, menu) => {
+		if (menu.backgroundMode === 'motion' && menu.motionDurationSecs) {
+			return sum + (MOTION_MENU_BITRATE * menu.motionDurationSecs) / 8;
+		}
+		return sum + STILL_MENU_BYTES;
+	}, 0);
+
+	const safetyMarginBytes = project.buildSettings.safetyMarginBytes;
+	const estimatedOverheadBytes = 50_000_000 + estimatedMenuBytes; // IFOs, NAV packs + menus
+	const usableBytes = capacityBytes - safetyMarginBytes - estimatedOverheadBytes;
+
+	const rawBitsPerSecond = totalDurationSecs > 0 ? (usableBytes * 8) / totalDurationSecs : 0;
+	const availableBitsPerSecond = Math.min(rawBitsPerSecond, DVD_MAX_VIDEO_RATE_BPS);
+	const isCapacityConstrained = rawBitsPerSecond < DVD_MAX_VIDEO_RATE_BPS;
+
+	const estimatedOutputBytes =
+		totalDurationSecs > 0
+			? (Math.min(rawBitsPerSecond, DVD_MAX_MUX_RATE_BPS) * totalDurationSecs) / 8
+			: 0;
+	const usagePct = estimatedOutputBytes > 0 ? (estimatedOutputBytes / capacityBytes) * 100 : 0;
+	const isOverCapacity = estimatedOutputBytes > usableBytes;
+
+	return {
+		capacityBytes,
+		totalDurationSecs,
+		estimatedMenuBytes,
+		safetyMarginBytes,
+		estimatedOverheadBytes,
+		usableBytes,
+		availableBitsPerSecond,
+		isCapacityConstrained,
+		estimatedOutputBytes,
+		usagePct,
+		isOverCapacity,
+	};
+}
+
+/** Format a byte count as a human-readable size, handling negative values
+ * (e.g. "remaining" figures once a project goes over budget). */
+export function formatBytes(bytes: number): string {
+	const sign = bytes < 0 ? '-' : '';
+	const abs = Math.abs(bytes);
+	if (abs >= 1_000_000_000) return `${sign}${(abs / 1_000_000_000).toFixed(1)} GB`;
+	if (abs >= 1_000_000) return `${sign}${(abs / 1_000_000).toFixed(1)} MB`;
+	if (abs >= 1_000) return `${sign}${(abs / 1_000).toFixed(1)} KB`;
+	return `${sign}${abs} B`;
+}


### PR DESCRIPTION
## Summary

- **Fixed a calculation-consistency bug**: the Overview page's disc-capacity bar used a flat, hardcoded 6 Mbps video + 192 kbps/audio-track estimate per title, independent of how many titles share the disc. The Planner page instead derives a capacity-aware, duration-weighted budget bitrate. The two pages could disagree by roughly 2x on the same project — for an 8-episode test project, Overview claimed ~16.1 GB (impossible on a DVD-9) while Planner's ~8.40 GB matched the actual built disc size.

### Frontend

- Extracted Planner's capacity/bitrate-budget calculation into a new shared `utils/capacity.ts` (`estimateDiscCapacity`), used by both Overview and Planner so they can no longer drift apart.
- Fixed `formatBytes` to handle negative byte counts (an over-budget "remaining" figure previously rendered as an unscaled raw integer, e.g. `-7624468778 B`, instead of `-7.6 GB`).

## Test plan

- [x] `tsc && vite build` — clean
- [x] `pnpm test:js` — 71 passed
- [x] `prettier --check` on changed files — clean
- [x] Verified live against a real 8-episode test project: Overview and Planner now both report the same `8.40 GB` / `98.8%` / over-capacity status (previously Overview alone reported `16.1 GB` / 100% danger bar)
- [x] Verified the negative-bytes formatting fix directly: `formatBytes(-7624468778)` → `"-7.6 GB"` (previously `"-7624468778 B"`)

Closes #38
