### PR TITLE
Make the disc-capacity budget the build pipeline's actual encode rate

### DIFF
--- a/apps/spindle/src/pages/OverviewPage.tsx
+++ b/apps/spindle/src/pages/OverviewPage.tsx
@@ -7,7 +7,7 @@ import { useProjectStore } from '../store/project-store';
 import { useNavigation } from '../App';
 import { NoProjectState } from '../components/NoProjectState';
 import { CAPACITY_LABELS } from '../types/project';
-import { estimateDiscCapacity, formatBytes } from '../utils/capacity';
+import { formatBytes, useDiscCapacityEstimate } from '../utils/capacity';
 import type {
 	VideoStandard,
 	CapacityTarget,
@@ -21,6 +21,7 @@ export function OverviewPage() {
 	const project = useProjectStore((s) => s.project);
 	const updateProject = useProjectStore((s) => s.updateProject);
 	const validationIssues = useProjectStore((s) => s.validationIssues);
+	const capacity = useDiscCapacityEstimate(project);
 
 	if (!project) {
 		return (
@@ -51,16 +52,16 @@ export function OverviewPage() {
 	const errorCount = validationIssues.filter((i) => i.severity === 'error').length;
 	const warningCount = validationIssues.filter((i) => i.severity === 'warning').length;
 
-	// Same budget-aware estimate the Planner page uses, so the two pages never
-	// disagree about whether a project fits on its target disc.
-	const { capacityBytes, usableBytes, estimatedOutputBytes, usagePct, isOverCapacity } =
-		estimateDiscCapacity(project);
-	const barPct = `${Math.min(usagePct, 100).toFixed(1)}%`;
-	const barClass = isOverCapacity
-		? 'capacity-bar__segment--danger'
-		: usagePct > 80
-			? 'capacity-bar__segment--warn'
-			: '';
+	// Same budget-aware estimate the Planner page and the build pipeline use,
+	// so none of them disagree about whether a project fits on its target disc.
+	const barPct = capacity ? `${Math.min(capacity.usagePct, 100).toFixed(1)}%` : '0%';
+	const barClass = !capacity
+		? ''
+		: capacity.isOverCapacity
+			? 'capacity-bar__segment--danger'
+			: capacity.usagePct > 80
+				? 'capacity-bar__segment--warn'
+				: '';
 
 	return (
 		<div className="overview">
@@ -104,14 +105,16 @@ export function OverviewPage() {
 					/>
 				</div>
 				<div className="overview__capacity-legend">
-					{titleCount === 0 ? (
+					{!capacity ? (
+						<span className="text-muted">Calculating&hellip;</span>
+					) : titleCount === 0 ? (
 						<span className="text-muted">
-							No titles added yet &middot; {formatBytes(capacityBytes)} available
+							No titles added yet &middot; {formatBytes(capacity.capacityBytes)} available
 						</span>
 					) : (
 						<span className="text-muted">
-							~{formatBytes(estimatedOutputBytes)} estimated &middot;{' '}
-							{formatBytes(usableBytes - estimatedOutputBytes)} remaining
+							~{formatBytes(capacity.estimatedOutputBytes)} estimated &middot;{' '}
+							{formatBytes(capacity.usableBytes - capacity.estimatedOutputBytes)} remaining
 						</span>
 					)}
 				</div>

--- a/apps/spindle/src/pages/PlannerPage.tsx
+++ b/apps/spindle/src/pages/PlannerPage.tsx
@@ -8,8 +8,8 @@ import { NoProjectState } from '../components/NoProjectState';
 import { CAPACITY_LABELS } from '../types/project';
 import type { Title, Asset, Menu } from '../types/project';
 import {
-	estimateDiscCapacity,
 	formatBytes,
+	useDiscCapacityEstimate,
 	DVD_MAX_VIDEO_RATE_BPS,
 	STILL_MENU_BYTES,
 	MOTION_MENU_BITRATE,
@@ -18,6 +18,7 @@ import './PlannerPage.css';
 
 export function PlannerPage() {
 	const project = useProjectStore((s) => s.project);
+	const capacity = useDiscCapacityEstimate(project);
 
 	if (!project) {
 		return (
@@ -51,6 +52,18 @@ export function PlannerPage() {
 		...disc.titlesets.flatMap((ts) => ts.menus.map((m) => ({ menu: m, scope: ts.name }))),
 	];
 
+	if (!capacity) {
+		return (
+			<div className="planner">
+				<div className="page-header">
+					<h1 className="page-title">Disc Planner</h1>
+					<span className="badge badge--neutral">{CAPACITY_LABELS[disc.capacityTarget]}</span>
+				</div>
+				<p className="text-muted">Calculating disc capacity&hellip;</p>
+			</div>
+		);
+	}
+
 	// Note: usagePct and isOverCapacity use estimated output size (bitrate × duration),
 	// not source size, because source files will be re-encoded to DVD-compliant MPEG-2.
 	// Source size is only shown as a reference point.
@@ -65,7 +78,11 @@ export function PlannerPage() {
 		estimatedOutputBytes,
 		usagePct,
 		isOverCapacity,
-	} = estimateDiscCapacity(project);
+		titleBitrates,
+	} = capacity;
+	const titleBitrateById = new Map(
+		titleBitrates.map((alloc) => [alloc.titleId, alloc.bitsPerSecond]),
+	);
 
 	return (
 		<div className="planner">
@@ -167,6 +184,7 @@ export function PlannerPage() {
 								const sourceSize = asset?.fileSizeBytes ?? 0;
 								const durationPct =
 									totalDurationSecs > 0 ? (duration / totalDurationSecs) * 100 : 0;
+								const titleRate = titleBitrateById.get(title.id);
 
 								return (
 									<div key={title.id} className="planner__title-row">
@@ -179,6 +197,9 @@ export function PlannerPage() {
 										<div className="planner__title-stats">
 											<span>{formatDuration(duration)}</span>
 											<span>{formatBytes(sourceSize)}</span>
+											{titleRate != null && (
+												<span className="text-muted">{formatBitrate(titleRate)} video</span>
+											)}
 											<span className="text-muted">{durationPct.toFixed(1)}% of disc</span>
 										</div>
 										<div className="planner__title-bar">

--- a/apps/spindle/src/utils/capacity.ts
+++ b/apps/spindle/src/utils/capacity.ts
@@ -1,94 +1,50 @@
-// Shared disc-capacity estimation: a single budget-aware calculation used by
-// both the Overview and Planner pages, so they never disagree about whether
-// a project fits on its target disc.
+// Shared disc-capacity estimation hook: a thin wrapper around the plugin's
+// `estimateDiscCapacity` command, the single source of truth used by both
+// the Overview and Planner pages and the build pipeline itself, so none of
+// them can disagree about whether a project fits on its target disc.
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-import { CAPACITY_BYTES } from '../types/project';
-import type { SpindleProjectFile } from '../types/project';
+import { useEffect, useState } from 'react';
+import { estimateDiscCapacity } from 'tauri-plugin-spindle-project-api';
+import type { CapacityEstimate, SpindleProjectFile } from 'tauri-plugin-spindle-project-api';
 
-// DVD-Video spec limits (ISO/IEC 13818-1)
-const DVD_MAX_MUX_RATE_BPS = 10_080_000; // 10.08 Mbps total mux rate
-export const DVD_MAX_VIDEO_RATE_BPS = 9_800_000; // 9.8 Mbps max video ES
+export type { CapacityEstimate, TitleBitrateAllocation } from 'tauri-plugin-spindle-project-api';
 
-// Menu size estimate constants: still menus are ~1-2 MB (MPEG-2 still + highlights),
-// motion menus use their duration at a moderate bitrate.
-export const STILL_MENU_BYTES = 1_500_000; // ~1.5 MB per still menu
-export const MOTION_MENU_BITRATE = 5_000_000; // 5 Mbps for motion menus
+// Display-only constants mirroring plugins/tauri-plugin-spindle-project/src/build/capacity.rs.
+// These aren't part of the fit/budget calculation itself (that's 100% computed
+// in Rust via `estimateDiscCapacity` above) — they only label informational
+// breakdown rows in the Planner UI. Keep in sync if the Rust values change.
+export const DVD_MAX_VIDEO_RATE_BPS = 9_800_000;
+export const STILL_MENU_BYTES = 1_500_000;
+export const MOTION_MENU_BITRATE = 5_000_000;
 
-export interface CapacityEstimate {
-	capacityBytes: number;
-	totalDurationSecs: number;
-	estimatedMenuBytes: number;
-	safetyMarginBytes: number;
-	estimatedOverheadBytes: number;
-	usableBytes: number;
-	/** Average video bitrate available within budget, capped to DVD spec limits. */
-	availableBitsPerSecond: number;
-	/** True when the disc's capacity (not the DVD spec) is the binding constraint. */
-	isCapacityConstrained: boolean;
-	/** Estimated encoded size at the budgeted rate — not source file size, since
-	 * source files are re-encoded to DVD-compliant MPEG-2 before authoring. */
-	estimatedOutputBytes: number;
-	usagePct: number;
-	isOverCapacity: boolean;
-}
+/** Live disc-capacity estimate for the given project, recomputed by the Rust
+ * backend whenever the project changes. Returns `null` until the first
+ * estimate has loaded (e.g. on initial mount). */
+export function useDiscCapacityEstimate(
+	project: SpindleProjectFile | null,
+): CapacityEstimate | null {
+	const [estimate, setEstimate] = useState<CapacityEstimate | null>(null);
 
-/** Estimate encoded disc size and bitrate budget from total title duration,
- * the disc's capacity target, and authored menus — shared by Overview and
- * Planner so both pages report the same answer to "does this fit?" */
-export function estimateDiscCapacity(project: SpindleProjectFile): CapacityEstimate {
-	const disc = project.disc;
-	const capacityBytes = CAPACITY_BYTES[disc.capacityTarget];
-
-	const totalDurationSecs = disc.titlesets
-		.flatMap((ts) => ts.titles)
-		.reduce((sum, title) => {
-			const asset = project.assets.find((a) => a.id === title.sourceAssetId);
-			return sum + (asset?.durationSecs ?? 0);
-		}, 0);
-
-	const allMenus = [...disc.globalMenus, ...disc.titlesets.flatMap((ts) => ts.menus)];
-	const estimatedMenuBytes = allMenus.reduce((sum, menu) => {
-		if (menu.backgroundMode === 'motion' && menu.motionDurationSecs) {
-			return sum + (MOTION_MENU_BITRATE * menu.motionDurationSecs) / 8;
+	useEffect(() => {
+		if (!project) {
+			setEstimate(null);
+			return;
 		}
-		return sum + STILL_MENU_BYTES;
-	}, 0);
 
-	const safetyMarginBytes = project.buildSettings.safetyMarginBytes;
-	const estimatedOverheadBytes = 50_000_000 + estimatedMenuBytes; // IFOs, NAV packs + menus
-	const usableBytes = capacityBytes - safetyMarginBytes - estimatedOverheadBytes;
+		let cancelled = false;
+		estimateDiscCapacity(project).then((result) => {
+			if (!cancelled) setEstimate(result);
+		});
 
-	// NOTE: this budgeted rate is advisory only — the build pipeline currently
-	// encodes at a fixed bitrate regardless of what's computed here, so a
-	// capacity-constrained project can still produce an output larger than this
-	// estimate predicts. Tracked separately as liminal-hq/spindle#43.
-	const rawBitsPerSecond = totalDurationSecs > 0 ? (usableBytes * 8) / totalDurationSecs : 0;
-	const availableBitsPerSecond = Math.min(rawBitsPerSecond, DVD_MAX_VIDEO_RATE_BPS);
-	const isCapacityConstrained = rawBitsPerSecond < DVD_MAX_VIDEO_RATE_BPS;
+		return () => {
+			cancelled = true;
+		};
+	}, [project]);
 
-	const estimatedOutputBytes =
-		totalDurationSecs > 0
-			? (Math.min(rawBitsPerSecond, DVD_MAX_MUX_RATE_BPS) * totalDurationSecs) / 8
-			: 0;
-	const usagePct = estimatedOutputBytes > 0 ? (estimatedOutputBytes / capacityBytes) * 100 : 0;
-	const isOverCapacity = estimatedOutputBytes > usableBytes;
-
-	return {
-		capacityBytes,
-		totalDurationSecs,
-		estimatedMenuBytes,
-		safetyMarginBytes,
-		estimatedOverheadBytes,
-		usableBytes,
-		availableBitsPerSecond,
-		isCapacityConstrained,
-		estimatedOutputBytes,
-		usagePct,
-		isOverCapacity,
-	};
+	return estimate;
 }
 
 /** Format a byte count as a human-readable size, handling negative values

--- a/plugins/tauri-plugin-spindle-project/build.rs
+++ b/plugins/tauri-plugin-spindle-project/build.rs
@@ -3,6 +3,7 @@ const COMMANDS: &[&str] = &[
     "parse_project",
     "serialise_project",
     "validate_project",
+    "estimate_disc_capacity",
     "inspect_asset",
     "extract_video_thumbnail",
     "extract_image_thumbnail",

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -721,9 +721,7 @@ export async function validateProject(project: SpindleProjectFile): Promise<Vali
 
 /** Estimate disc-capacity usage and the per-title bitrate budget the build
  * pipeline will actually encode at. */
-export async function estimateDiscCapacity(
-	project: SpindleProjectFile,
-): Promise<CapacityEstimate> {
+export async function estimateDiscCapacity(project: SpindleProjectFile): Promise<CapacityEstimate> {
 	return await invoke('plugin:spindle-project|estimate_disc_capacity', { project });
 }
 

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -482,6 +482,33 @@ export interface PropertyCheck {
 	compatible: boolean;
 }
 
+// ── Disc Capacity ────────────────────────────────────────────────────────────
+
+/** Per-title average video bitrate after distributing the disc-wide budget
+ * according to `BuildSettings.allocationStrategy`. */
+export interface TitleBitrateAllocation {
+	titleId: string;
+	bitsPerSecond: number;
+}
+
+/** Disc-capacity usage and the per-title bitrate budget the build pipeline
+ * actually encodes at — the single source of truth shared by the
+ * Overview/Planner UI and the build pipeline. */
+export interface CapacityEstimate {
+	capacityBytes: number;
+	totalDurationSecs: number;
+	estimatedMenuBytes: number;
+	safetyMarginBytes: number;
+	estimatedOverheadBytes: number;
+	usableBytes: number;
+	availableBitsPerSecond: number;
+	isCapacityConstrained: boolean;
+	estimatedOutputBytes: number;
+	usagePct: number;
+	isOverCapacity: boolean;
+	titleBitrates: TitleBitrateAllocation[];
+}
+
 // ── Build Settings ──────────────────────────────────────────────────────────
 
 export interface BuildSettings {
@@ -690,6 +717,14 @@ export async function serialiseProject(project: SpindleProjectFile): Promise<str
 /** Validate a project and return any issues found. */
 export async function validateProject(project: SpindleProjectFile): Promise<ValidationIssue[]> {
 	return await invoke('plugin:spindle-project|validate_project', { project });
+}
+
+/** Estimate disc-capacity usage and the per-title bitrate budget the build
+ * pipeline will actually encode at. */
+export async function estimateDiscCapacity(
+	project: SpindleProjectFile,
+): Promise<CapacityEstimate> {
+	return await invoke('plugin:spindle-project|estimate_disc_capacity', { project });
 }
 
 /** Inspect a media file and return its metadata as an Asset. */

--- a/plugins/tauri-plugin-spindle-project/permissions/autogenerated/commands/estimate_disc_capacity.toml
+++ b/plugins/tauri-plugin-spindle-project/permissions/autogenerated/commands/estimate_disc_capacity.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-estimate-disc-capacity"
+description = "Enables the estimate_disc_capacity command without any pre-configured scope."
+commands.allow = ["estimate_disc_capacity"]
+
+[[permission]]
+identifier = "deny-estimate-disc-capacity"
+description = "Denies the estimate_disc_capacity command without any pre-configured scope."
+commands.deny = ["estimate_disc_capacity"]

--- a/plugins/tauri-plugin-spindle-project/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-spindle-project/permissions/autogenerated/reference.md
@@ -8,6 +8,7 @@ Default permissions for the spindle-project plugin
 - `allow-parse-project`
 - `allow-serialise-project`
 - `allow-validate-project`
+- `allow-estimate-disc-capacity`
 - `allow-inspect-asset`
 - `allow-extract-video-thumbnail`
 - `allow-extract-image-thumbnail`
@@ -130,6 +131,32 @@ Enables the create_project command without any pre-configured scope.
 <td>
 
 Denies the create_project command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`spindle-project:allow-estimate-disc-capacity`
+
+</td>
+<td>
+
+Enables the estimate_disc_capacity command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`spindle-project:deny-estimate-disc-capacity`
+
+</td>
+<td>
+
+Denies the estimate_disc_capacity command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/tauri-plugin-spindle-project/permissions/default.toml
+++ b/plugins/tauri-plugin-spindle-project/permissions/default.toml
@@ -5,6 +5,7 @@ permissions = [
   "allow-parse-project",
   "allow-serialise-project",
   "allow-validate-project",
+  "allow-estimate-disc-capacity",
   "allow-inspect-asset",
   "allow-extract-video-thumbnail",
   "allow-extract-image-thumbnail",

--- a/plugins/tauri-plugin-spindle-project/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-spindle-project/permissions/schemas/schema.json
@@ -343,6 +343,18 @@
           "markdownDescription": "Denies the create_project command without any pre-configured scope."
         },
         {
+          "description": "Enables the estimate_disc_capacity command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-estimate-disc-capacity",
+          "markdownDescription": "Enables the estimate_disc_capacity command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the estimate_disc_capacity command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-estimate-disc-capacity",
+          "markdownDescription": "Denies the estimate_disc_capacity command without any pre-configured scope."
+        },
+        {
           "description": "Enables the execute_build command without any pre-configured scope.",
           "type": "string",
           "const": "allow-execute-build",
@@ -487,10 +499,10 @@
           "markdownDescription": "Denies the validate_project command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`",
+          "description": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-estimate-disc-capacity`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`"
+          "markdownDescription": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-estimate-disc-capacity`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`"
         }
       ]
     }

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -180,8 +180,21 @@ fn estimate_title_audio_bitrate_bps(title: &Title, asset: Option<&Asset>) -> f64
                 AudioOutputTarget::Ac3 => 448_000.0,
                 AudioOutputTarget::Mp2 => 384_000.0,
                 AudioOutputTarget::Dts => 768_000.0,
-                // Stereo 16-bit/48kHz PCM; LPCM has no fixed rate of its own.
-                AudioOutputTarget::Lpcm => 1_536_000.0,
+                // LPCM is uncompressed and has no fixed rate of its own —
+                // `build_ffmpeg_transcode_command` never forces `-ac`, so the
+                // encode keeps the source channel count. Derive the real rate
+                // from it instead of assuming stereo (16-bit/48kHz).
+                AudioOutputTarget::Lpcm => {
+                    let channels = asset
+                        .and_then(|a| {
+                            a.audio_streams
+                                .iter()
+                                .find(|s| s.index == mapping.source_stream_index)
+                        })
+                        .map(|stream| stream.channels)
+                        .unwrap_or(2);
+                    16.0 * 48_000.0 * channels as f64
+                }
             },
             // Copied as-is: use the source stream's known bitrate, or fall
             // back to the heaviest re-encode target (AC3) if unknown.
@@ -357,6 +370,35 @@ mod tests {
         assert!(
             usable_video_bytes_implied < estimate.usable_bytes,
             "expected audio to be reserved out of the usable budget before deriving the video rate"
+        );
+    }
+
+    #[test]
+    fn lpcm_audio_reservation_scales_with_source_channel_count() {
+        // Regression test: a 5.1 source re-encoded to LPCM keeps all 6
+        // channels (build_ffmpeg_transcode_command never forces `-ac`), so
+        // assuming stereo would reserve roughly a third of the real bytes.
+        let mut stereo_project = test_project();
+        stereo_project.assets[0].duration_secs = Some(3600.0);
+        stereo_project.assets[0].audio_streams[0].channels = 2;
+        stereo_project.disc.titlesets[0].titles[0].audio_mappings[0].output_target =
+            AudioOutputTarget::Lpcm;
+
+        let mut surround_project = test_project();
+        surround_project.assets[0].duration_secs = Some(3600.0);
+        surround_project.assets[0].audio_streams[0].channels = 6;
+        surround_project.disc.titlesets[0].titles[0].audio_mappings[0].output_target =
+            AudioOutputTarget::Lpcm;
+
+        let stereo_estimate = estimate_disc_capacity(&stereo_project);
+        let surround_estimate = estimate_disc_capacity(&surround_project);
+
+        assert!(
+            surround_estimate.available_bits_per_second < stereo_estimate.available_bits_per_second,
+            "expected a 5.1 LPCM source to reserve more audio bytes (leaving a smaller video budget) \
+             than a stereo one, got surround={} stereo={}",
+            surround_estimate.available_bits_per_second,
+            stereo_estimate.available_bits_per_second
         );
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -78,6 +78,22 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
 
     let total_duration_secs: f64 = titles_with_duration.iter().map(|(_, d)| d).sum();
 
+    // Audio is muxed alongside video at the same rates `build_ffmpeg_transcode_command`
+    // requests, so it must be reserved out of the budget before any of it is
+    // handed to video — otherwise the disc can be reported as fitting while the
+    // build encodes the full video budget *plus* audio and overflows the target.
+    let total_audio_bytes: f64 = titles_with_duration
+        .iter()
+        .filter(|(_, duration)| *duration > 0.0)
+        .map(|(title, duration)| {
+            let asset = title
+                .source_asset_id
+                .as_deref()
+                .and_then(|id| project.assets.iter().find(|a| a.id == id));
+            (estimate_title_audio_bitrate_bps(title, asset) * duration) / 8.0
+        })
+        .sum();
+
     let all_menus: Vec<&Menu> = disc
         .global_menus
         .iter()
@@ -99,10 +115,12 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
     let estimated_overhead_bytes = 50_000_000.0 + estimated_menu_bytes;
     let usable_bytes = capacity_bytes - safety_margin_bytes - estimated_overhead_bytes;
 
-    // NOTE: this budgeted rate is advisory only until it's fed into the build —
-    // see liminal-hq/spindle#43.
+    // `available_bits_per_second` is the video-only budget: audio is reserved
+    // out of `usable_bytes` first, since the build muxes it in on top of
+    // whatever rate `title_bitrates` hands to `-b:v`.
+    let usable_video_bytes = (usable_bytes - total_audio_bytes).max(0.0);
     let raw_bits_per_second = if total_duration_secs > 0.0 {
-        (usable_bytes * 8.0) / total_duration_secs
+        (usable_video_bytes * 8.0) / total_duration_secs
     } else {
         0.0
     };
@@ -110,7 +128,8 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
     let is_capacity_constrained = raw_bits_per_second < DVD_MAX_VIDEO_RATE_BPS;
 
     let estimated_output_bytes = if total_duration_secs > 0.0 {
-        (raw_bits_per_second.min(DVD_MAX_MUX_RATE_BPS) * total_duration_secs) / 8.0
+        let video_bps = raw_bits_per_second.min(DVD_MAX_MUX_RATE_BPS);
+        ((video_bps * total_duration_secs) / 8.0) + total_audio_bytes
     } else {
         0.0
     };
@@ -142,6 +161,41 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
         is_over_capacity,
         title_bitrates,
     }
+}
+
+/// Estimate the total audio bitrate `build_ffmpeg_transcode_command` will
+/// actually request for this title, mirroring its re-encode targets and its
+/// silent-fallback track so the capacity budget can reserve real bytes for it
+/// instead of treating the whole disc as video.
+fn estimate_title_audio_bitrate_bps(title: &Title, asset: Option<&Asset>) -> f64 {
+    if title.audio_mappings.is_empty() {
+        return 192_000.0; // matches the anullsrc fallback track's `-b:a 192k`.
+    }
+
+    title
+        .audio_mappings
+        .iter()
+        .map(|mapping| match mapping.copy_mode {
+            CopyMode::ReEncode => match mapping.output_target {
+                AudioOutputTarget::Ac3 => 448_000.0,
+                AudioOutputTarget::Mp2 => 384_000.0,
+                AudioOutputTarget::Dts => 768_000.0,
+                // Stereo 16-bit/48kHz PCM; LPCM has no fixed rate of its own.
+                AudioOutputTarget::Lpcm => 1_536_000.0,
+            },
+            // Copied as-is: use the source stream's known bitrate, or fall
+            // back to the heaviest re-encode target (AC3) if unknown.
+            CopyMode::Copy => asset
+                .and_then(|a| {
+                    a.audio_streams
+                        .iter()
+                        .find(|s| s.index == mapping.source_stream_index)
+                })
+                .and_then(|stream| stream.bitrate_bps)
+                .map(|bps| bps as f64)
+                .unwrap_or(448_000.0),
+        })
+        .sum()
 }
 
 /// Distribute the disc-wide average bitrate budget across titles.
@@ -284,6 +338,42 @@ mod tests {
         assert_eq!(
             unknown_rate, 0.0,
             "unknown-duration titles must not receive a capacity-derived bitrate"
+        );
+    }
+
+    #[test]
+    fn video_budget_reserves_bytes_for_audio_instead_of_assuming_video_takes_the_whole_disc() {
+        // Regression test: the default test title has an AC3 (448 kbps)
+        // audio mapping. If the video budget didn't reserve for it,
+        // available_bits_per_second would equal the full usable-byte rate;
+        // it must instead be lower by roughly the audio share.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+
+        let estimate = estimate_disc_capacity(&project);
+        let usable_video_bytes_implied =
+            (estimate.available_bits_per_second * estimate.total_duration_secs) / 8.0;
+
+        assert!(
+            usable_video_bytes_implied < estimate.usable_bytes,
+            "expected audio to be reserved out of the usable budget before deriving the video rate"
+        );
+    }
+
+    #[test]
+    fn estimated_output_bytes_includes_audio_not_just_video() {
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+
+        let estimate = estimate_disc_capacity(&project);
+        let video_only_bytes =
+            (estimate.available_bits_per_second * estimate.total_duration_secs) / 8.0;
+
+        assert!(
+            estimate.estimated_output_bytes > video_only_bytes,
+            "estimated_output_bytes ({}) should account for muxed audio on top of video ({})",
+            estimate.estimated_output_bytes,
+            video_only_bytes
         );
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -165,39 +165,46 @@ fn allocate_title_bitrates(
             .collect();
     }
 
-    match strategy {
-        AllocationStrategy::DurationWeighted | AllocationStrategy::PriorityWeighted => {
-            // Every title gets the same average rate; bytes naturally scale
-            // with each title's own duration.
-            titles_with_duration
-                .iter()
-                .map(|(title, _)| TitleBitrateAllocation {
-                    title_id: title.id.clone(),
-                    bits_per_second: available_bits_per_second,
-                })
-                .collect()
-        }
-        AllocationStrategy::EqualShare => {
-            // Every title gets the same total byte budget regardless of
-            // duration, so short titles get a higher per-second rate.
-            let total_budget_bits = available_bits_per_second * total_duration_secs;
-            let share_bits = total_budget_bits / titles_with_duration.len() as f64;
-            titles_with_duration
-                .iter()
-                .map(|(title, duration)| {
-                    let bits_per_second = if *duration > 0.0 {
-                        (share_bits / duration).min(DVD_MAX_VIDEO_RATE_BPS)
-                    } else {
-                        available_bits_per_second
-                    };
-                    TitleBitrateAllocation {
-                        title_id: title.id.clone(),
-                        bits_per_second,
+    // Clamp to the encoder's actual ceiling (not just the looser DVD spec
+    // limit), so the exported rate matches what `build_ffmpeg_transcode_command`
+    // will really request — otherwise Planner/the command can report a rate
+    // (e.g. the DVD spec's 9.8 Mbps) above what the generated `-b:v` ends up
+    // being (clamped to the encoder's 9.0 Mbps ceiling).
+    let capped_rate = available_bits_per_second.min(super::ffmpeg::MAX_VIDEO_RATE_BPS);
+
+    titles_with_duration
+        .iter()
+        .map(|(title, duration)| {
+            // Unknown-duration titles aren't counted in `total_duration_secs`
+            // or the disc-level byte estimate at all, so handing them a
+            // capacity-derived rate would let the build encode real,
+            // unaccounted-for bytes while the estimate still claims the
+            // project fits. Leave them at 0 so the encoder falls back to its
+            // own safe default instead of silently riding on the budget.
+            let bits_per_second = if *duration <= 0.0 {
+                0.0
+            } else {
+                match strategy {
+                    // Every title gets the same average rate; bytes naturally
+                    // scale with each title's own duration.
+                    AllocationStrategy::DurationWeighted | AllocationStrategy::PriorityWeighted => {
+                        capped_rate
                     }
-                })
-                .collect()
-        }
-    }
+                    // Every title gets the same total byte budget regardless
+                    // of duration, so short titles get a higher per-second rate.
+                    AllocationStrategy::EqualShare => {
+                        let total_budget_bits = available_bits_per_second * total_duration_secs;
+                        let share_bits = total_budget_bits / titles_with_duration.len() as f64;
+                        (share_bits / duration).min(capped_rate)
+                    }
+                }
+            };
+            TitleBitrateAllocation {
+                title_id: title.id.clone(),
+                bits_per_second,
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -216,7 +223,67 @@ mod tests {
         assert_eq!(estimate.title_bitrates.len(), 1);
         assert_eq!(
             estimate.title_bitrates[0].bits_per_second,
-            estimate.available_bits_per_second
+            estimate
+                .available_bits_per_second
+                .min(super::super::ffmpeg::MAX_VIDEO_RATE_BPS)
+        );
+    }
+
+    #[test]
+    fn title_bitrates_are_clamped_to_the_encoder_ceiling_not_just_the_dvd_spec_limit() {
+        // Regression test: the DVD spec ceiling (9.8 Mbps) is looser than the
+        // encoder's actual `-maxrate` ceiling (9.0 Mbps), so a rate exported
+        // here must not exceed what `build_ffmpeg_transcode_command` will
+        // really request, or Planner/the command report a number the build
+        // doesn't honour.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+
+        let estimate = estimate_disc_capacity(&project);
+
+        assert!(estimate.available_bits_per_second > super::super::ffmpeg::MAX_VIDEO_RATE_BPS);
+        for alloc in &estimate.title_bitrates {
+            assert!(
+                alloc.bits_per_second <= super::super::ffmpeg::MAX_VIDEO_RATE_BPS,
+                "title {} got {} bps, above the encoder ceiling of {}",
+                alloc.title_id,
+                alloc.bits_per_second,
+                super::super::ffmpeg::MAX_VIDEO_RATE_BPS
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_duration_titles_do_not_get_a_capacity_derived_bitrate() {
+        // Regression test: a title whose asset has no known duration isn't
+        // counted in total_duration_secs or the disc-level byte estimate, so
+        // handing it a positive budgeted rate would let the build encode
+        // real, unaccounted-for bytes while the estimate still claims the
+        // disc fits.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+
+        let mut second_title = project.disc.titlesets[0].titles[0].clone();
+        second_title.id = "title-unknown-duration".to_string();
+        project.disc.titlesets[0].titles.push(second_title);
+
+        let mut unknown_asset = project.assets[0].clone();
+        unknown_asset.id = "asset-unknown".to_string();
+        unknown_asset.duration_secs = None;
+        project.assets.push(unknown_asset);
+        project.disc.titlesets[0].titles[1].source_asset_id = Some("asset-unknown".to_string());
+
+        let estimate = estimate_disc_capacity(&project);
+
+        let unknown_rate = estimate
+            .title_bitrates
+            .iter()
+            .find(|a| a.title_id == "title-unknown-duration")
+            .expect("expected an allocation entry for the unknown-duration title")
+            .bits_per_second;
+        assert_eq!(
+            unknown_rate, 0.0,
+            "unknown-duration titles must not receive a capacity-derived bitrate"
         );
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -267,6 +267,16 @@ fn allocate_title_bitrates(
     // being (clamped to the encoder's 9.0 Mbps ceiling).
     let capped_rate = available_bits_per_second.min(super::ffmpeg::MAX_VIDEO_RATE_BPS);
 
+    // Unknown-duration titles get 0 bps below and aren't counted in
+    // `total_duration_secs`/the byte estimate at all, so they shouldn't
+    // dilute `equal-share`'s per-title divisor either — otherwise a single
+    // such title would unnecessarily lower every known-duration title's rate.
+    let budgeted_title_count = titles_with_duration
+        .iter()
+        .filter(|(_, duration, _)| *duration > 0.0)
+        .count()
+        .max(1) as f64;
+
     titles_with_duration
         .iter()
         .map(|(title, duration, audio_bps)| {
@@ -289,7 +299,7 @@ fn allocate_title_bitrates(
                     // of duration, so short titles get a higher per-second rate.
                     AllocationStrategy::EqualShare => {
                         let total_budget_bits = available_bits_per_second * total_duration_secs;
-                        let share_bits = total_budget_bits / titles_with_duration.len() as f64;
+                        let share_bits = total_budget_bits / budgeted_title_count;
                         (share_bits / duration).min(capped_rate)
                     }
                 };
@@ -593,6 +603,37 @@ mod tests {
             short_rate > long_rate,
             "expected the 60s title to get a higher rate than the 3600s title under equal-share, \
              got short={short_rate} long={long_rate}"
+        );
+    }
+
+    #[test]
+    fn equal_share_does_not_dilute_known_titles_for_unknown_duration_ones() {
+        // Regression test: an unknown-duration title gets 0 bps and is
+        // excluded from total_duration_secs/the byte estimate entirely, so
+        // it shouldn't shrink equal-share's per-title divisor either —
+        // otherwise adding such a title would unnecessarily lower every
+        // known-duration title's rate for no real reason.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+        project.build_settings.allocation_strategy = AllocationStrategy::EqualShare;
+        let baseline_rate = estimate_disc_capacity(&project).title_bitrates[0].bits_per_second;
+
+        let mut unknown_title = project.disc.titlesets[0].titles[0].clone();
+        unknown_title.id = "title-unknown-duration".to_string();
+        unknown_title.source_asset_id = None;
+        project.disc.titlesets[0].titles.push(unknown_title);
+
+        let estimate = estimate_disc_capacity(&project);
+        let known_rate = estimate
+            .title_bitrates
+            .iter()
+            .find(|a| a.title_id == "title-1")
+            .unwrap()
+            .bits_per_second;
+
+        assert_eq!(
+            known_rate, baseline_rate,
+            "adding an unknown-duration title should not change the known title's rate"
         );
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -1,0 +1,260 @@
+// Disc-capacity budget estimation — the single source of truth for "does this
+// project fit", shared between the build pipeline (which uses the per-title
+// bitrate to drive ffmpeg) and the frontend (Overview/Planner, via the
+// `estimate_disc_capacity` command).
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+
+use crate::models::*;
+
+/// DVD-Video spec limits (ISO/IEC 13818-1).
+const DVD_MAX_MUX_RATE_BPS: f64 = 10_080_000.0; // 10.08 Mbps total mux rate
+pub(crate) const DVD_MAX_VIDEO_RATE_BPS: f64 = 9_800_000.0; // 9.8 Mbps max video ES
+
+/// Still menus are ~1-2 MB (MPEG-2 still + highlights); motion menus use
+/// their duration at a moderate bitrate.
+const STILL_MENU_BYTES: f64 = 1_500_000.0;
+const MOTION_MENU_BITRATE_BPS: f64 = 5_000_000.0;
+
+/// This disc's overall capacity budget, plus the per-title average video
+/// bitrate the build pipeline should actually encode at to respect it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapacityEstimate {
+    pub capacity_bytes: f64,
+    pub total_duration_secs: f64,
+    pub estimated_menu_bytes: f64,
+    pub safety_margin_bytes: f64,
+    pub estimated_overhead_bytes: f64,
+    pub usable_bytes: f64,
+    /// Disc-wide average video bitrate available within budget, capped to
+    /// DVD spec limits. This is what `duration-weighted` allocation gives
+    /// every title; other strategies redistribute the same total budget.
+    pub available_bits_per_second: f64,
+    /// True when the disc's capacity (not the DVD spec) is the binding constraint.
+    pub is_capacity_constrained: bool,
+    /// Estimated encoded size at the budgeted rate — not source file size,
+    /// since source files are re-encoded to DVD-compliant MPEG-2 before authoring.
+    pub estimated_output_bytes: f64,
+    pub usage_pct: f64,
+    pub is_over_capacity: bool,
+    /// Per-title average video bitrate, after distributing the disc-wide
+    /// budget according to `BuildSettings.allocation_strategy`.
+    pub title_bitrates: Vec<TitleBitrateAllocation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TitleBitrateAllocation {
+    pub title_id: String,
+    pub bits_per_second: f64,
+}
+
+/// Estimate encoded disc size and bitrate budget from total title duration,
+/// the disc's capacity target, and authored menus — shared by the build
+/// pipeline and the frontend so they never disagree about whether a project
+/// fits on its target disc, and so the build actually respects the estimate.
+pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate {
+    let disc = &project.disc;
+    let capacity_bytes = disc.capacity_target.capacity_bytes() as f64;
+
+    let titles_with_duration: Vec<(&Title, f64)> = disc
+        .titlesets
+        .iter()
+        .flat_map(|ts| ts.titles.iter())
+        .map(|title| {
+            let duration = title
+                .source_asset_id
+                .as_deref()
+                .and_then(|id| project.assets.iter().find(|a| a.id == id))
+                .and_then(|asset| asset.duration_secs)
+                .unwrap_or(0.0);
+            (title, duration)
+        })
+        .collect();
+
+    let total_duration_secs: f64 = titles_with_duration.iter().map(|(_, d)| d).sum();
+
+    let all_menus: Vec<&Menu> = disc
+        .global_menus
+        .iter()
+        .chain(disc.titlesets.iter().flat_map(|ts| ts.menus.iter()))
+        .collect();
+    let estimated_menu_bytes: f64 = all_menus
+        .iter()
+        .map(|menu| {
+            if menu.background_mode == BackgroundMode::Motion {
+                if let Some(secs) = menu.motion_duration_secs {
+                    return (MOTION_MENU_BITRATE_BPS * secs) / 8.0;
+                }
+            }
+            STILL_MENU_BYTES
+        })
+        .sum();
+
+    let safety_margin_bytes = project.build_settings.safety_margin_bytes as f64;
+    let estimated_overhead_bytes = 50_000_000.0 + estimated_menu_bytes;
+    let usable_bytes = capacity_bytes - safety_margin_bytes - estimated_overhead_bytes;
+
+    // NOTE: this budgeted rate is advisory only until it's fed into the build —
+    // see liminal-hq/spindle#43.
+    let raw_bits_per_second = if total_duration_secs > 0.0 {
+        (usable_bytes * 8.0) / total_duration_secs
+    } else {
+        0.0
+    };
+    let available_bits_per_second = raw_bits_per_second.min(DVD_MAX_VIDEO_RATE_BPS);
+    let is_capacity_constrained = raw_bits_per_second < DVD_MAX_VIDEO_RATE_BPS;
+
+    let estimated_output_bytes = if total_duration_secs > 0.0 {
+        (raw_bits_per_second.min(DVD_MAX_MUX_RATE_BPS) * total_duration_secs) / 8.0
+    } else {
+        0.0
+    };
+    let usage_pct = if estimated_output_bytes > 0.0 {
+        (estimated_output_bytes / capacity_bytes) * 100.0
+    } else {
+        0.0
+    };
+    let is_over_capacity = estimated_output_bytes > usable_bytes;
+
+    let title_bitrates = allocate_title_bitrates(
+        &titles_with_duration,
+        total_duration_secs,
+        available_bits_per_second,
+        project.build_settings.allocation_strategy,
+    );
+
+    CapacityEstimate {
+        capacity_bytes,
+        total_duration_secs,
+        estimated_menu_bytes,
+        safety_margin_bytes,
+        estimated_overhead_bytes,
+        usable_bytes,
+        available_bits_per_second,
+        is_capacity_constrained,
+        estimated_output_bytes,
+        usage_pct,
+        is_over_capacity,
+        title_bitrates,
+    }
+}
+
+/// Distribute the disc-wide average bitrate budget across titles.
+///
+/// `priority-weighted` has no per-title weight data yet (tracked in
+/// liminal-hq/spindle#44), so it falls back to `duration-weighted` until that
+/// lands.
+fn allocate_title_bitrates(
+    titles_with_duration: &[(&Title, f64)],
+    total_duration_secs: f64,
+    available_bits_per_second: f64,
+    strategy: AllocationStrategy,
+) -> Vec<TitleBitrateAllocation> {
+    if titles_with_duration.is_empty() || available_bits_per_second <= 0.0 {
+        return titles_with_duration
+            .iter()
+            .map(|(title, _)| TitleBitrateAllocation {
+                title_id: title.id.clone(),
+                bits_per_second: available_bits_per_second.max(0.0),
+            })
+            .collect();
+    }
+
+    match strategy {
+        AllocationStrategy::DurationWeighted | AllocationStrategy::PriorityWeighted => {
+            // Every title gets the same average rate; bytes naturally scale
+            // with each title's own duration.
+            titles_with_duration
+                .iter()
+                .map(|(title, _)| TitleBitrateAllocation {
+                    title_id: title.id.clone(),
+                    bits_per_second: available_bits_per_second,
+                })
+                .collect()
+        }
+        AllocationStrategy::EqualShare => {
+            // Every title gets the same total byte budget regardless of
+            // duration, so short titles get a higher per-second rate.
+            let total_budget_bits = available_bits_per_second * total_duration_secs;
+            let share_bits = total_budget_bits / titles_with_duration.len() as f64;
+            titles_with_duration
+                .iter()
+                .map(|(title, duration)| {
+                    let bits_per_second = if *duration > 0.0 {
+                        (share_bits / duration).min(DVD_MAX_VIDEO_RATE_BPS)
+                    } else {
+                        available_bits_per_second
+                    };
+                    TitleBitrateAllocation {
+                        title_id: title.id.clone(),
+                        bits_per_second,
+                    }
+                })
+                .collect()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build::test_support::test_project;
+
+    #[test]
+    fn duration_weighted_gives_every_title_the_same_rate() {
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+        project.build_settings.allocation_strategy = AllocationStrategy::DurationWeighted;
+
+        let estimate = estimate_disc_capacity(&project);
+
+        assert_eq!(estimate.title_bitrates.len(), 1);
+        assert_eq!(
+            estimate.title_bitrates[0].bits_per_second,
+            estimate.available_bits_per_second
+        );
+    }
+
+    #[test]
+    fn equal_share_gives_short_titles_a_higher_rate_than_long_titles() {
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+        project.build_settings.allocation_strategy = AllocationStrategy::EqualShare;
+
+        let mut second_title = project.disc.titlesets[0].titles[0].clone();
+        second_title.id = "title-2".to_string();
+        project.disc.titlesets[0].titles.push(second_title);
+
+        let mut short_asset = project.assets[0].clone();
+        short_asset.id = "asset-2".to_string();
+        short_asset.duration_secs = Some(60.0);
+        project.assets.push(short_asset);
+        project.disc.titlesets[0].titles[1].source_asset_id = Some("asset-2".to_string());
+
+        let estimate = estimate_disc_capacity(&project);
+
+        let long_rate = estimate.title_bitrates[0].bits_per_second;
+        let short_rate = estimate.title_bitrates[1].bits_per_second;
+        assert!(
+            short_rate > long_rate,
+            "expected the 60s title to get a higher rate than the 3600s title under equal-share, \
+             got short={short_rate} long={long_rate}"
+        );
+    }
+
+    #[test]
+    fn no_titles_does_not_panic() {
+        let mut project = test_project();
+        project.disc.titlesets[0].titles.clear();
+
+        let estimate = estimate_disc_capacity(&project);
+
+        assert_eq!(estimate.total_duration_secs, 0.0);
+        assert!(estimate.title_bitrates.is_empty());
+    }
+}

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -60,22 +60,26 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
     let disc = &project.disc;
     let capacity_bytes = disc.capacity_target.capacity_bytes() as f64;
 
-    let titles_with_duration: Vec<(&Title, f64)> = disc
+    // Per-title duration and estimated audio bitrate — the latter is muxed
+    // alongside video at the rate `build_ffmpeg_transcode_command` actually
+    // requests, so both the disc-wide budget and each title's own video cap
+    // need to account for it (see `allocate_title_bitrates`).
+    let titles_with_duration: Vec<(&Title, f64, f64)> = disc
         .titlesets
         .iter()
         .flat_map(|ts| ts.titles.iter())
         .map(|title| {
-            let duration = title
+            let asset = title
                 .source_asset_id
                 .as_deref()
-                .and_then(|id| project.assets.iter().find(|a| a.id == id))
-                .and_then(|asset| asset.duration_secs)
-                .unwrap_or(0.0);
-            (title, duration)
+                .and_then(|id| project.assets.iter().find(|a| a.id == id));
+            let duration = asset.and_then(|a| a.duration_secs).unwrap_or(0.0);
+            let audio_bps = estimate_title_audio_bitrate_bps(title, asset);
+            (title, duration, audio_bps)
         })
         .collect();
 
-    let total_duration_secs: f64 = titles_with_duration.iter().map(|(_, d)| d).sum();
+    let total_duration_secs: f64 = titles_with_duration.iter().map(|(_, d, _)| d).sum();
 
     // Audio is muxed alongside video at the same rates `build_ffmpeg_transcode_command`
     // requests, so it must be reserved out of the budget before any of it is
@@ -83,14 +87,8 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
     // build encodes the full video budget *plus* audio and overflows the target.
     let total_audio_bytes: f64 = titles_with_duration
         .iter()
-        .filter(|(_, duration)| *duration > 0.0)
-        .map(|(title, duration)| {
-            let asset = title
-                .source_asset_id
-                .as_deref()
-                .and_then(|id| project.assets.iter().find(|a| a.id == id));
-            (estimate_title_audio_bitrate_bps(title, asset) * duration) / 8.0
-        })
+        .filter(|(_, duration, _)| *duration > 0.0)
+        .map(|(_, duration, audio_bps)| (audio_bps * duration) / 8.0)
         .sum();
 
     let all_menus: Vec<&Menu> = disc
@@ -140,7 +138,7 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
     let video_output_bytes: f64 = titles_with_duration
         .iter()
         .zip(title_bitrates.iter())
-        .map(|((_, duration), alloc)| (alloc.bits_per_second * duration) / 8.0)
+        .map(|((_, duration, _), alloc)| (alloc.bits_per_second * duration) / 8.0)
         .sum();
     let estimated_output_bytes = video_output_bytes + total_audio_bytes;
     let usage_pct = if estimated_output_bytes > 0.0 {
@@ -220,7 +218,7 @@ fn estimate_title_audio_bitrate_bps(title: &Title, asset: Option<&Asset>) -> f64
 /// liminal-hq/spindle#44), so it falls back to `duration-weighted` until that
 /// lands.
 fn allocate_title_bitrates(
-    titles_with_duration: &[(&Title, f64)],
+    titles_with_duration: &[(&Title, f64, f64)],
     total_duration_secs: f64,
     available_bits_per_second: f64,
     strategy: AllocationStrategy,
@@ -228,9 +226,11 @@ fn allocate_title_bitrates(
     if titles_with_duration.is_empty() || available_bits_per_second <= 0.0 {
         return titles_with_duration
             .iter()
-            .map(|(title, _)| TitleBitrateAllocation {
+            .map(|(title, _, audio_bps)| TitleBitrateAllocation {
                 title_id: title.id.clone(),
-                bits_per_second: available_bits_per_second.max(0.0),
+                bits_per_second: available_bits_per_second
+                    .max(0.0)
+                    .min((super::ffmpeg::MUX_RATE_BPS - audio_bps).max(0.0)),
             })
             .collect();
     }
@@ -244,7 +244,7 @@ fn allocate_title_bitrates(
 
     titles_with_duration
         .iter()
-        .map(|(title, duration)| {
+        .map(|(title, duration, audio_bps)| {
             // Unknown-duration titles aren't counted in `total_duration_secs`
             // or the disc-level byte estimate at all, so handing them a
             // capacity-derived rate would let the build encode real,
@@ -254,7 +254,7 @@ fn allocate_title_bitrates(
             let bits_per_second = if *duration <= 0.0 {
                 0.0
             } else {
-                match strategy {
+                let video_bps = match strategy {
                     // Every title gets the same average rate; bytes naturally
                     // scale with each title's own duration.
                     AllocationStrategy::DurationWeighted | AllocationStrategy::PriorityWeighted => {
@@ -267,7 +267,12 @@ fn allocate_title_bitrates(
                         let share_bits = total_budget_bits / titles_with_duration.len() as f64;
                         (share_bits / duration).min(capped_rate)
                     }
-                }
+                };
+                // Video plus this title's own audio must still fit under the
+                // disc's `-muxrate` ceiling, even if the disc-wide video pool
+                // alone would not exceed it (a heavy per-title audio track,
+                // e.g. multichannel LPCM, can still blow the combined mux rate).
+                video_bps.min((super::ffmpeg::MUX_RATE_BPS - audio_bps).max(0.0))
             };
             TitleBitrateAllocation {
                 title_id: title.id.clone(),
@@ -404,6 +409,32 @@ mod tests {
             clamped_video_bytes,
             audio_bytes,
             raw_video_bytes
+        );
+    }
+
+    #[test]
+    fn title_video_rate_is_capped_to_leave_room_for_its_own_audio_under_the_mux_rate() {
+        // Regression test: a short, unconstrained project can have plenty of
+        // disc-wide budget (so the video pool hits the 9 Mbps encoder
+        // ceiling), but a heavy per-title audio track (e.g. 5.1 LPCM at
+        // ~4.6 Mbps) plus that video would still exceed the 10.08 Mbps
+        // `-muxrate` ceiling `build_ffmpeg_transcode_command` always sets.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+        project.assets[0].audio_streams[0].channels = 6;
+        project.disc.titlesets[0].titles[0].audio_mappings[0].output_target =
+            AudioOutputTarget::Lpcm;
+
+        let estimate = estimate_disc_capacity(&project);
+        let audio_bps = 16.0 * 48_000.0 * 6.0;
+
+        assert!(
+            estimate.title_bitrates[0].bits_per_second + audio_bps
+                <= super::super::ffmpeg::MUX_RATE_BPS + 1.0,
+            "title video ({}) plus its own audio ({}) should fit under the mux rate ({})",
+            estimate.title_bitrates[0].bits_per_second,
+            audio_bps,
+            super::super::ffmpeg::MUX_RATE_BPS
         );
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -176,40 +176,55 @@ fn estimate_title_audio_bitrate_bps(title: &Title, asset: Option<&Asset>) -> f64
     title
         .audio_mappings
         .iter()
-        .map(|mapping| match mapping.copy_mode {
-            CopyMode::ReEncode => match mapping.output_target {
-                AudioOutputTarget::Ac3 => 448_000.0,
-                AudioOutputTarget::Mp2 => 384_000.0,
-                AudioOutputTarget::Dts => 768_000.0,
-                // LPCM is uncompressed and has no fixed rate of its own —
-                // `build_ffmpeg_transcode_command` never forces `-ac`, so the
-                // encode keeps the source channel count. Derive the real rate
-                // from it instead of assuming stereo (16-bit/48kHz).
-                AudioOutputTarget::Lpcm => {
-                    let channels = asset
-                        .and_then(|a| {
-                            a.audio_streams
-                                .iter()
-                                .find(|s| s.index == mapping.source_stream_index)
-                        })
-                        .map(|stream| stream.channels)
-                        .unwrap_or(2);
-                    16.0 * 48_000.0 * channels as f64
+        .map(|mapping| {
+            let source_channels = || {
+                asset
+                    .and_then(|a| {
+                        a.audio_streams
+                            .iter()
+                            .find(|s| s.index == mapping.source_stream_index)
+                    })
+                    .map(|stream| stream.channels)
+                    .unwrap_or(2)
+            };
+
+            match mapping.copy_mode {
+                CopyMode::ReEncode => {
+                    output_target_rate_bps(mapping.output_target, source_channels())
                 }
-            },
-            // Copied as-is: use the source stream's known bitrate, or fall
-            // back to the heaviest re-encode target (AC3) if unknown.
-            CopyMode::Copy => asset
-                .and_then(|a| {
-                    a.audio_streams
-                        .iter()
-                        .find(|s| s.index == mapping.source_stream_index)
-                })
-                .and_then(|stream| stream.bitrate_bps)
-                .map(|bps| bps as f64)
-                .unwrap_or(448_000.0),
+                // Copied as-is: use the source stream's known bitrate. When
+                // it's unknown, a copy stream isn't necessarily AC3-sized —
+                // it could be any DVD-legal format the source already used
+                // (LPCM, DTS, etc.) — so estimate from `output_target` (what
+                // the user mapped this track as) rather than assuming AC3.
+                CopyMode::Copy => asset
+                    .and_then(|a| {
+                        a.audio_streams
+                            .iter()
+                            .find(|s| s.index == mapping.source_stream_index)
+                    })
+                    .and_then(|stream| stream.bitrate_bps)
+                    .map(|bps| bps as f64)
+                    .unwrap_or_else(|| {
+                        output_target_rate_bps(mapping.output_target, source_channels())
+                    }),
+            }
         })
         .sum()
+}
+
+/// The audio bitrate `build_ffmpeg_transcode_command` requests for a given
+/// re-encode target, or the best estimate for a copy-mode stream whose
+/// source bitrate is unknown.
+fn output_target_rate_bps(target: AudioOutputTarget, channels: u32) -> f64 {
+    match target {
+        AudioOutputTarget::Ac3 => 448_000.0,
+        AudioOutputTarget::Mp2 => 384_000.0,
+        AudioOutputTarget::Dts => 768_000.0,
+        // LPCM is uncompressed and has no fixed rate of its own — derive it
+        // from the channel count (16-bit/48kHz) instead of assuming stereo.
+        AudioOutputTarget::Lpcm => 16.0 * 48_000.0 * channels as f64,
+    }
 }
 
 /// Distribute the disc-wide average bitrate budget across titles.
@@ -226,11 +241,21 @@ fn allocate_title_bitrates(
     if titles_with_duration.is_empty() || available_bits_per_second <= 0.0 {
         return titles_with_duration
             .iter()
-            .map(|(title, _, audio_bps)| TitleBitrateAllocation {
+            .map(|(title, duration, _)| TitleBitrateAllocation {
                 title_id: title.id.clone(),
-                bits_per_second: available_bits_per_second
-                    .max(0.0)
-                    .min((super::ffmpeg::MUX_RATE_BPS - audio_bps).max(0.0)),
+                // A known-duration title still gets encoded even with zero
+                // disc-wide video budget left — `build_ffmpeg_transcode_command`
+                // falls back to its own default rate for any non-positive
+                // input. Report that default here too, so estimated_output_bytes
+                // reflects what the build will really produce instead of
+                // letting a real "no room left" condition masquerade as zero
+                // bytes of video. Unknown-duration titles stay at 0 — that's
+                // the explicit "no data to estimate from" sentinel.
+                bits_per_second: if *duration > 0.0 {
+                    super::ffmpeg::DEFAULT_VIDEO_BITRATE_BPS
+                } else {
+                    0.0
+                },
             })
             .collect();
     }
@@ -272,7 +297,17 @@ fn allocate_title_bitrates(
                 // disc's `-muxrate` ceiling, even if the disc-wide video pool
                 // alone would not exceed it (a heavy per-title audio track,
                 // e.g. multichannel LPCM, can still blow the combined mux rate).
-                video_bps.min((super::ffmpeg::MUX_RATE_BPS - audio_bps).max(0.0))
+                let mux_capped = video_bps.min((super::ffmpeg::MUX_RATE_BPS - audio_bps).max(0.0));
+                // If that leaves no room at all, the build still encodes this
+                // title — `build_ffmpeg_transcode_command` falls back to its
+                // own default rate for non-positive input — so report that
+                // default rather than 0, or the estimate would understate
+                // what the build actually produces.
+                if mux_capped > 0.0 {
+                    mux_capped
+                } else {
+                    super::ffmpeg::DEFAULT_VIDEO_BITRATE_BPS
+                }
             };
             TitleBitrateAllocation {
                 title_id: title.id.clone(),
@@ -326,6 +361,27 @@ mod tests {
                 super::super::ffmpeg::MAX_VIDEO_RATE_BPS
             );
         }
+    }
+
+    #[test]
+    fn exhausted_disc_budget_reports_the_encoder_default_not_zero() {
+        // Regression test: when there's no disc-wide video budget left (e.g.
+        // safety margin/overhead eats the whole disc), a known-duration
+        // title still gets encoded — `build_ffmpeg_transcode_command` falls
+        // back to its own default rate for non-positive input. The estimate
+        // must report that default, not a literal 0, or estimated_output_bytes
+        // would understate what the build actually produces.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+        project.build_settings.safety_margin_bytes = project.disc.capacity_target.capacity_bytes();
+
+        let estimate = estimate_disc_capacity(&project);
+
+        assert_eq!(estimate.available_bits_per_second, 0.0);
+        assert_eq!(
+            estimate.title_bitrates[0].bits_per_second,
+            super::super::ffmpeg::DEFAULT_VIDEO_BITRATE_BPS
+        );
     }
 
     #[test]
@@ -409,6 +465,35 @@ mod tests {
             clamped_video_bytes,
             audio_bytes,
             raw_video_bytes
+        );
+    }
+
+    #[test]
+    fn copy_mode_audio_with_unknown_bitrate_uses_its_output_target_not_always_ac3() {
+        // Regression test: `-c:a copy` doesn't cap the stream to AC3 size, so
+        // a copy-mode mapping with no known source bitrate shouldn't always
+        // be estimated at AC3's 448 kbps — a track mapped (and thus expected)
+        // as DTS or LPCM can be far heavier and so should reserve more.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+        project.assets[0].audio_streams[0].bitrate_bps = None;
+        project.disc.titlesets[0].titles[0].audio_mappings[0].copy_mode = CopyMode::Copy;
+        project.disc.titlesets[0].titles[0].audio_mappings[0].output_target =
+            AudioOutputTarget::Dts;
+
+        let ac3_estimate = {
+            let mut p = project.clone();
+            p.disc.titlesets[0].titles[0].audio_mappings[0].output_target = AudioOutputTarget::Ac3;
+            estimate_disc_capacity(&p)
+        };
+        let dts_estimate = estimate_disc_capacity(&project);
+
+        assert!(
+            dts_estimate.available_bits_per_second < ac3_estimate.available_bits_per_second,
+            "expected an unknown-bitrate copy mapped as DTS to reserve more than one mapped as AC3, \
+             got dts={} ac3={}",
+            dts_estimate.available_bits_per_second,
+            ac3_estimate.available_bits_per_second
         );
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -10,8 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::models::*;
 
-/// DVD-Video spec limits (ISO/IEC 13818-1).
-const DVD_MAX_MUX_RATE_BPS: f64 = 10_080_000.0; // 10.08 Mbps total mux rate
+/// DVD-Video spec limit (ISO/IEC 13818-1).
 pub(crate) const DVD_MAX_VIDEO_RATE_BPS: f64 = 9_800_000.0; // 9.8 Mbps max video ES
 
 /// Still menus are ~1-2 MB (MPEG-2 still + highlights); motion menus use
@@ -127,25 +126,29 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
     let available_bits_per_second = raw_bits_per_second.min(DVD_MAX_VIDEO_RATE_BPS);
     let is_capacity_constrained = raw_bits_per_second < DVD_MAX_VIDEO_RATE_BPS;
 
-    let estimated_output_bytes = if total_duration_secs > 0.0 {
-        let video_bps = raw_bits_per_second.min(DVD_MAX_MUX_RATE_BPS);
-        ((video_bps * total_duration_secs) / 8.0) + total_audio_bytes
-    } else {
-        0.0
-    };
-    let usage_pct = if estimated_output_bytes > 0.0 {
-        (estimated_output_bytes / capacity_bytes) * 100.0
-    } else {
-        0.0
-    };
-    let is_over_capacity = estimated_output_bytes > usable_bytes;
-
     let title_bitrates = allocate_title_bitrates(
         &titles_with_duration,
         total_duration_secs,
         available_bits_per_second,
         project.build_settings.allocation_strategy,
     );
+
+    // Sum the *allocated* (encoder-clamped) per-title rates rather than the
+    // raw disc-wide budget — when the raw budget exceeds the encoder's
+    // ceiling, `title_bitrates` is clamped below it, so deriving output size
+    // from the raw rate would report bytes the build cannot actually produce.
+    let video_output_bytes: f64 = titles_with_duration
+        .iter()
+        .zip(title_bitrates.iter())
+        .map(|((_, duration), alloc)| (alloc.bits_per_second * duration) / 8.0)
+        .sum();
+    let estimated_output_bytes = video_output_bytes + total_audio_bytes;
+    let usage_pct = if estimated_output_bytes > 0.0 {
+        (estimated_output_bytes / capacity_bytes) * 100.0
+    } else {
+        0.0
+    };
+    let is_over_capacity = estimated_output_bytes > usable_bytes;
 
     CapacityEstimate {
         capacity_bytes,
@@ -374,6 +377,37 @@ mod tests {
     }
 
     #[test]
+    fn estimated_output_bytes_uses_the_clamped_rate_not_the_raw_disc_wide_budget() {
+        // Regression test: when the raw disc-wide budget exceeds the
+        // encoder's ceiling, `title_bitrates` is clamped below it (see
+        // `title_bitrates_are_clamped_to_the_encoder_ceiling_...` above), so
+        // estimated_output_bytes/usage_pct must reflect what the build will
+        // really emit, not the looser raw rate.
+        let mut project = test_project();
+        project.assets[0].duration_secs = Some(3600.0);
+
+        let estimate = estimate_disc_capacity(&project);
+        assert!(estimate.available_bits_per_second > super::super::ffmpeg::MAX_VIDEO_RATE_BPS);
+
+        let raw_video_bytes =
+            (estimate.available_bits_per_second * estimate.total_duration_secs) / 8.0;
+        let clamped_video_bytes =
+            (estimate.title_bitrates[0].bits_per_second * estimate.total_duration_secs) / 8.0;
+        // The default test title has one AC3 (448 kbps) re-encode mapping.
+        let audio_bytes = (448_000.0 * estimate.total_duration_secs) / 8.0;
+
+        assert!(clamped_video_bytes < raw_video_bytes);
+        assert!(
+            (estimate.estimated_output_bytes - (clamped_video_bytes + audio_bytes)).abs() < 1.0,
+            "expected estimated_output_bytes ({}) to equal clamped video bytes ({}) plus audio bytes ({}), not the raw budget ({})",
+            estimate.estimated_output_bytes,
+            clamped_video_bytes,
+            audio_bytes,
+            raw_video_bytes
+        );
+    }
+
+    #[test]
     fn lpcm_audio_reservation_scales_with_source_channel_count() {
         // Regression test: a 5.1 source re-encoded to LPCM keeps all 6
         // channels (build_ffmpeg_transcode_command never forces `-ac`), so
@@ -409,7 +443,7 @@ mod tests {
 
         let estimate = estimate_disc_capacity(&project);
         let video_only_bytes =
-            (estimate.available_bits_per_second * estimate.total_duration_secs) / 8.0;
+            (estimate.title_bitrates[0].bits_per_second * estimate.total_duration_secs) / 8.0;
 
         assert!(
             estimate.estimated_output_bytes > video_only_bytes,

--- a/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
@@ -7,6 +7,17 @@ use std::path::Path;
 
 use crate::models::*;
 
+/// Default average video bitrate used when no disc-capacity budget could be
+/// computed for this title (e.g. zero-duration asset, or capacity estimation
+/// isn't available in this call path).
+pub(crate) const DEFAULT_VIDEO_BITRATE_BPS: f64 = 6_000_000.0;
+
+/// Encoder safety ceiling for `-maxrate`. Kept independent of the disc
+/// capacity budget's `DVD_MAX_VIDEO_RATE_BPS` (9.8 Mbps) — this is the
+/// short-term peak the encoder is allowed to burst to, not the requested
+/// average, and is clamped below the average if the average is unusually high.
+const MAX_VIDEO_RATE_BPS: f64 = 9_000_000.0;
+
 pub(crate) fn build_ffmpeg_transcode_command(
     source_path: &str,
     output_path: &Path,
@@ -14,7 +25,14 @@ pub(crate) fn build_ffmpeg_transcode_command(
     asset: &Asset,
     disc: &Disc,
     video_info: Option<&VideoStreamInfo>,
+    video_bitrate_bps: f64,
 ) -> Vec<String> {
+    let video_bitrate_bps = if video_bitrate_bps > 0.0 {
+        video_bitrate_bps.min(MAX_VIDEO_RATE_BPS)
+    } else {
+        DEFAULT_VIDEO_BITRATE_BPS
+    };
+    let maxrate_bps = MAX_VIDEO_RATE_BPS.max(video_bitrate_bps);
     let mut cmd = vec!["ffmpeg".to_string(), "-y".to_string()];
 
     cmd.extend(["-i".to_string(), source_path.to_string()]);
@@ -69,9 +87,9 @@ pub(crate) fn build_ffmpeg_transcode_command(
         "-r".to_string(),
         fps_rational_str(output_fps).to_string(),
         "-b:v".to_string(),
-        "6000k".to_string(),
+        format!("{}k", (video_bitrate_bps / 1000.0).round() as i64),
         "-maxrate".to_string(),
-        "9000k".to_string(),
+        format!("{}k", (maxrate_bps / 1000.0).round() as i64),
         "-bufsize".to_string(),
         "1835k".to_string(),
         "-g".to_string(),
@@ -392,6 +410,65 @@ mod tests {
         assert!(cmd.contains(&"mpeg2video".to_string()));
         let vf_arg = cmd.iter().find(|a| a.starts_with("scale="));
         assert!(vf_arg.is_some(), "expected scale=720:480 in -vf filter");
+    }
+
+    #[test]
+    fn ffmpeg_bitrate_reflects_disc_capacity_budget_not_a_hardcoded_default() {
+        // Regression test for liminal-hq/spindle#43: the transcode used to
+        // always request a flat 6000k regardless of disc capacity. The
+        // default test project (DVD5, one 3600s title, no menus) computes a
+        // budget above the 9.8 Mbps DVD spec ceiling, which the encoder
+        // safety ceiling then caps to 9000k.
+        let project = test_project();
+        let plan = generate_build_plan(&project, "/tmp/dvd_output", false).unwrap();
+
+        let transcode = plan
+            .jobs
+            .iter()
+            .find(|j| matches!(j, crate::build::BuildJob::TranscodeTitle { .. }))
+            .unwrap();
+        let cmd = transcode.command().unwrap();
+
+        let bv_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-b:v")
+            .nth(1)
+            .expect("-b:v value");
+        assert_eq!(
+            bv_arg, "9000k",
+            "expected the capacity-budgeted rate (clamped to the encoder ceiling), not the old hardcoded 6000k"
+        );
+
+        let maxrate_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-maxrate")
+            .nth(1)
+            .expect("-maxrate value");
+        assert_eq!(maxrate_arg, "9000k");
+    }
+
+    #[test]
+    fn ffmpeg_falls_back_to_default_bitrate_when_no_budget_is_available() {
+        let project = test_project();
+        let title = &project.disc.titlesets[0].titles[0];
+        let asset = &project.assets[0];
+
+        let cmd = super::build_ffmpeg_transcode_command(
+            &asset.source_path,
+            std::path::Path::new("/tmp/out.mpg"),
+            title,
+            asset,
+            &project.disc,
+            None,
+            0.0,
+        );
+
+        let bv_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-b:v")
+            .nth(1)
+            .expect("-b:v value");
+        assert_eq!(bv_arg, "6000k");
     }
 
     #[test]

--- a/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
@@ -18,6 +18,10 @@ pub(crate) const DEFAULT_VIDEO_BITRATE_BPS: f64 = 6_000_000.0;
 /// average, and is clamped below the average if the average is unusually high.
 pub(crate) const MAX_VIDEO_RATE_BPS: f64 = 9_000_000.0;
 
+/// DVD-Video's total mux rate ceiling — the `-muxrate` this command always
+/// requests. Video and audio together must fit under it.
+pub(crate) const MUX_RATE_BPS: f64 = 10_080_000.0;
+
 pub(crate) fn build_ffmpeg_transcode_command(
     source_path: &str,
     output_path: &Path,
@@ -198,7 +202,7 @@ pub(crate) fn build_ffmpeg_transcode_command(
         "-f".to_string(),
         "dvd".to_string(),
         "-muxrate".to_string(),
-        "10080000".to_string(),
+        (MUX_RATE_BPS as i64).to_string(),
         output_path.display().to_string(),
     ]);
 

--- a/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
@@ -16,7 +16,7 @@ pub(crate) const DEFAULT_VIDEO_BITRATE_BPS: f64 = 6_000_000.0;
 /// capacity budget's `DVD_MAX_VIDEO_RATE_BPS` (9.8 Mbps) — this is the
 /// short-term peak the encoder is allowed to burst to, not the requested
 /// average, and is clamped below the average if the average is unusually high.
-const MAX_VIDEO_RATE_BPS: f64 = 9_000_000.0;
+pub(crate) const MAX_VIDEO_RATE_BPS: f64 = 9_000_000.0;
 
 pub(crate) fn build_ffmpeg_transcode_command(
     source_path: &str,

--- a/plugins/tauri-plugin-spindle-project/src/build/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 mod authoring;
+mod capacity;
 mod dvd_navigation;
 mod executor;
 mod ffmpeg;
@@ -13,6 +14,7 @@ mod navigation;
 mod planner;
 mod skia;
 
+pub use capacity::{estimate_disc_capacity, CapacityEstimate, TitleBitrateAllocation};
 pub use menu::{authorable_menus, AuthorableMenuRef, MenuDomain};
 pub use skia::{enumerate_fonts, render_menu_scene_to_png, FontEntry, FontSource};
 #[cfg(test)]

--- a/plugins/tauri-plugin-spindle-project/src/build/planner.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner.rs
@@ -192,6 +192,15 @@ pub fn generate_build_plan_with_options(
     let assets: HashMap<&str, &Asset> = project.assets.iter().map(|a| (a.id.as_str(), a)).collect();
     ensure_supported_menu_backend(project)?;
 
+    // Per-title average video bitrate, computed from the disc-wide capacity
+    // budget so the transcode actually respects what the Planner/Overview
+    // estimate promised (see liminal-hq/spindle#43).
+    let title_bitrates: HashMap<String, f64> = super::estimate_disc_capacity(project)
+        .title_bitrates
+        .into_iter()
+        .map(|alloc| (alloc.title_id, alloc.bits_per_second))
+        .collect();
+
     let all_titles: Vec<(&Titleset, &Title)> = project
         .disc
         .titlesets
@@ -285,6 +294,10 @@ pub fn generate_build_plan_with_options(
                 .as_ref()
                 .and_then(|vm| asset.video_streams.get(vm.source_stream_index as usize));
 
+            let video_bitrate_bps = title_bitrates
+                .get(title.id.as_str())
+                .copied()
+                .unwrap_or(0.0);
             let mut command = build_ffmpeg_transcode_command(
                 &asset.source_path,
                 &output_path,
@@ -292,6 +305,7 @@ pub fn generate_build_plan_with_options(
                 asset,
                 &project.disc,
                 video_info,
+                video_bitrate_bps,
             );
             command[0] = tools.ffmpeg.clone();
 

--- a/plugins/tauri-plugin-spindle-project/src/commands.rs
+++ b/plugins/tauri-plugin-spindle-project/src/commands.rs
@@ -99,6 +99,17 @@ pub(crate) async fn validate_project<R: Runtime>(
     app.spindle_project().validate_project(&project)
 }
 
+/// Estimate disc-capacity usage and the per-title bitrate budget the build
+/// pipeline will actually encode at — the single source of truth shared by
+/// the Overview/Planner UI and `generate_build_plan`/`execute_build`.
+#[command]
+pub(crate) async fn estimate_disc_capacity<R: Runtime>(
+    _app: AppHandle<R>,
+    project: SpindleProjectFile,
+) -> Result<build::CapacityEstimate> {
+    Ok(build::estimate_disc_capacity(&project))
+}
+
 /// Inspect a media file and return its metadata as an Asset.
 #[command]
 pub(crate) async fn inspect_asset<R: Runtime>(_app: AppHandle<R>, path: String) -> Result<Asset> {

--- a/plugins/tauri-plugin-spindle-project/src/lib.rs
+++ b/plugins/tauri-plugin-spindle-project/src/lib.rs
@@ -48,6 +48,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::parse_project,
             commands::serialise_project,
             commands::validate_project,
+            commands::estimate_disc_capacity,
             commands::inspect_asset,
             commands::extract_video_thumbnail,
             commands::extract_image_thumbnail,


### PR DESCRIPTION
## Summary

### Build pipeline
- **Make the disc-capacity budget the encoder's actual rate**: the title transcode previously always hardcoded `-b:v 6000k`/`-maxrate 9000k`, ignoring disc capacity entirely. `build_ffmpeg_transcode_command` now takes a computed per-title average bitrate and uses it.
- **Single source of truth for the budget**: ports the capacity calculation into Rust as `build::estimate_disc_capacity`, used by both `generate_build_plan` (to drive the actual encode) and a new `estimate_disc_capacity` Tauri command (for the frontend). The build and the UI estimate can no longer disagree.
- **Per-title bitrate allocation**: the disc-wide budget is distributed across titles honouring `BuildSettings.allocationStrategy` — `duration-weighted` gives every title the same rate (bytes scale with duration), `equal-share` gives every title the same byte budget (short titles get a higher rate). `priority-weighted` falls back to `duration-weighted` until #44 adds per-title weight data.

### Frontend
- `apps/spindle/src/utils/capacity.ts` is now a thin wrapper around the new command (a `useDiscCapacityEstimate` hook + `formatBytes`) instead of a parallel TS implementation of the same math.
- Overview and Planner both consume the hook; Planner's title breakdown now shows the *actual* per-title video bitrate the build will use, not just its duration share.

### Plugin/packaging
- New `estimate_disc_capacity` command added through the plugin's existing guest-js layer (`guest-js/index.ts`), matching the convention adopted in #33 — not a raw `invoke` call from app code.
- Permissions regenerated (`allow-estimate-disc-capacity` added to `default.toml`).

### Follow-up
- Filed #44 for the bigger feature this unblocks but doesn't implement: per-title bitrate weighting, floor/ceiling clamps, an over-floor warning, and manual bitrate pinning.

## Test plan

- [x] `cargo test -p tauri-plugin-spindle-project --lib` — 171 passed, including new `build::capacity` tests (duration-weighted parity, equal-share favouring short titles, no-titles edge case) and new `build::ffmpeg` tests (budgeted rate replaces the old hardcoded 6000k; falls back to 6000k when no budget is available).
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `npx tsc --noEmit` / `npx vitest run` (71 passed) / `npx prettier --check` — clean.
- [x] Manually traced the default test project's numbers end-to-end (DVD5, one 3600s title, no menus) to confirm the computed budget (~10.2 Mbps raw, capped to 9.8 Mbps DVD spec, then to the encoder's 9 Mbps ceiling) matches what the new ffmpeg test asserts.

Closes #43
