### PR TITLE
fix(menus): stop double-reporting a single dangling menu reference

### DIFF
--- a/plugins/tauri-plugin-spindle-project/src/desktop.rs
+++ b/plugins/tauri-plugin-spindle-project/src/desktop.rs
@@ -537,19 +537,26 @@ impl<R: Runtime> SpindleProject<R> {
                     });
                 }
 
-                // Validate action targets exist
-                if let Some(action) = &button.action {
-                    validate_action(
-                        action,
-                        &all_title_ids,
-                        &all_menu_ids,
-                        &project.disc,
-                        &menu.name,
-                        &menu.id,
-                        &button.label,
-                        stream_counts,
-                        &mut issues,
-                    );
+                // Validate action targets exist. Skipped when this menu has
+                // an authored document: `buttons[]` is then just a best-effort
+                // mirror of `authored_document.interaction.nodes[]` (kept in
+                // sync by the frontend, not guaranteed authoritative), and
+                // that authored-document action is validated below — checking
+                // both would report the same dangling/invalid target twice.
+                if menu.authored_document.is_none() {
+                    if let Some(action) = &button.action {
+                        validate_action(
+                            action,
+                            &all_title_ids,
+                            &all_menu_ids,
+                            &project.disc,
+                            &menu.name,
+                            &menu.id,
+                            &button.label,
+                            stream_counts,
+                            &mut issues,
+                        );
+                    }
                 }
 
                 // Navigation link validation


### PR DESCRIPTION
## Summary

A menu with both an authored document (new scene editor) and a legacy `buttons[]` mirror had its button actions validated twice: once against `buttons[]`, once against `authoredDocument.interaction.nodes[]`. For a button targeting a deleted menu, this produced two identical `menu.dangling-menu-ref` errors instead of one.

`buttons[]` is a best-effort sync of the authored document (kept up to date by the frontend's `syncMenu`, not an independent source of truth) — this matches the existing `Menu::resolved_*()` pattern (`resolved_background_mode`, etc.) and the `AuthorableMenuRef::buttons()` resolution the build pipeline already uses for the same dual-representation problem. `validate_project` was the one place still reading both representations unconditionally.

Fix: action-target validation (the check that produces `menu.dangling-menu-ref`) now only reads `buttons[]` when the menu has no authored document, and reads the authored document's interaction graph when it does — single source per menu, matching the rest of the codebase's resolution pattern.

Closes #37

## Scope note

The issue's repro also mentions the build pipeline surfacing a raw `Build failed: Unknown menu target: <id>` instead of a friendly validation message. Traced that separately: the build pipeline already goes through `AuthorableMenuRef::buttons()` (the same single-source resolution this PR brings to `validate_project`), so it doesn't double-report and isn't affected by this bug. That panic-style message is really about validation not running/blocking before build, which is a separate, already-existing gap unrelated to the duplication bug — not touched here to keep this fix scoped and quick, as requested.

The other per-button checks in `validate_project` (button count limits, no-buttons warning, no-default-button, nav-link checks) still read raw `buttons[]` unconditionally — that's issue #29's territory (false-negative "no buttons" for scene-editor-only menus), not this issue's. Left untouched.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test --lib` (189 passed, no regressions)
- [x] No frontend changes — Rust-only fix.
- [x] Manually verified via the Tauri MCP server against the real `validate_project` command (not mocks):
  - A menu with both `buttons[]` and an authored document, where the mirrored button/interaction-node targets a deleted menu, now reports exactly **one** `menu.dangling-menu-ref` error (was two before this fix, confirmed against the unfixed behavior during development).
  - A legacy menu (no authored document) with the same dangling reference still reports its one error via the `buttons[]` path — confirms the fallback path wasn't broken.
