### PR TITLE
fix(validation): catch dangling refs in disc.firstPlayAction and menu.timeoutAction

### DIFF
--- a/plugins/tauri-plugin-spindle-project/src/validation/disc.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/disc.rs
@@ -1,14 +1,21 @@
-// Disc-level structural checks: titlesets present, titles present, first-play action set.
+// Disc-level structural checks: titlesets present, titles present, first-play action set
+// and pointing at a target that still exists.
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
+use std::collections::HashSet;
+
 use crate::models::*;
+
+use super::menu_action::{validate_action, ActionSubject};
 
 /// Runs disc-level checks and returns the total title count across all titlesets,
 /// which the build-settings checks also need.
 pub(super) fn validate_disc(
     project: &SpindleProjectFile,
+    all_title_ids: &HashSet<&str>,
+    all_menu_ids: &HashSet<&str>,
     issues: &mut Vec<ValidationIssue>,
 ) -> usize {
     if project.disc.titlesets.is_empty() {
@@ -45,17 +52,127 @@ pub(super) fn validate_disc(
         });
     }
 
-    if project.disc.first_play_action.is_none() && total_titles > 0 {
-        issues.push(ValidationIssue {
-            severity: IssueSeverity::Info,
-            code: "disc.no-first-play".to_string(),
-            message: "No first-play action is set. Consider setting a menu or title as the entry point.".to_string(),
-            context: None,
-            entity_type: Some("disc".to_string()),
-            entity_name: None,
-            suggested_fix: Some("Set a first-play action on the overview page so the disc has a defined startup behaviour.".to_string()),
-        });
+    match &project.disc.first_play_action {
+        None if total_titles > 0 => {
+            issues.push(ValidationIssue {
+                severity: IssueSeverity::Info,
+                code: "disc.no-first-play".to_string(),
+                message: "No first-play action is set. Consider setting a menu or title as the entry point.".to_string(),
+                context: None,
+                entity_type: Some("disc".to_string()),
+                entity_name: None,
+                suggested_fix: Some("Set a first-play action on the overview page so the disc has a defined startup behaviour.".to_string()),
+            });
+        }
+        Some(action) => {
+            validate_action(
+                action,
+                all_title_ids,
+                all_menu_ids,
+                &project.disc,
+                &ActionSubject {
+                    subject: "Disc first-play action".to_string(),
+                    entity_type: "disc",
+                    entity_name: None,
+                    context_id: None,
+                },
+                None,
+                issues,
+            );
+        }
+        None => {}
     }
 
     total_titles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project_with_one_title() -> SpindleProjectFile {
+        let mut project = SpindleProjectFile::default();
+        project.disc.titlesets.push(Titleset {
+            id: "titleset-1".to_string(),
+            name: "Main".to_string(),
+            titles: vec![Title {
+                id: "title-1".to_string(),
+                name: "Feature".to_string(),
+                source_asset_id: None,
+                video_mapping: None,
+                video_output_profile: None,
+                audio_mappings: vec![],
+                subtitle_mappings: vec![],
+                chapters: vec![],
+                end_action: None,
+                order_index: 0,
+                bitrate_weight: 1.0,
+                bitrate_floor_bps: None,
+                bitrate_ceiling_bps: None,
+                pinned_bitrate_bps: None,
+            }],
+            menus: vec![],
+        });
+        project
+    }
+
+    #[test]
+    fn validate_disc_flags_first_play_action_targeting_a_deleted_title() {
+        let mut project = project_with_one_title();
+        project.disc.first_play_action = Some(PlaybackAction::PlayTitle {
+            title_id: "stale-title-id".to_string(),
+        });
+        let all_title_ids: HashSet<&str> = ["title-1"].into_iter().collect();
+        let all_menu_ids: HashSet<&str> = HashSet::new();
+        let mut issues = Vec::new();
+
+        validate_disc(&project, &all_title_ids, &all_menu_ids, &mut issues);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "menu.dangling-title-ref"
+                    && i.entity_type.as_deref() == Some("disc")),
+            "expected a dangling-title-ref issue scoped to the disc, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_disc_flags_first_play_action_targeting_a_deleted_menu() {
+        let mut project = project_with_one_title();
+        project.disc.first_play_action = Some(PlaybackAction::ShowMenu {
+            menu_id: "stale-menu-id".to_string(),
+        });
+        let all_title_ids: HashSet<&str> = ["title-1"].into_iter().collect();
+        let all_menu_ids: HashSet<&str> = HashSet::new();
+        let mut issues = Vec::new();
+
+        validate_disc(&project, &all_title_ids, &all_menu_ids, &mut issues);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "menu.dangling-menu-ref"
+                    && i.entity_type.as_deref() == Some("disc")),
+            "expected a dangling-menu-ref issue scoped to the disc, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_disc_accepts_first_play_action_targeting_an_existing_title() {
+        let mut project = project_with_one_title();
+        project.disc.first_play_action = Some(PlaybackAction::PlayTitle {
+            title_id: "title-1".to_string(),
+        });
+        let all_title_ids: HashSet<&str> = ["title-1"].into_iter().collect();
+        let all_menu_ids: HashSet<&str> = HashSet::new();
+        let mut issues = Vec::new();
+
+        validate_disc(&project, &all_title_ids, &all_menu_ids, &mut issues);
+
+        assert!(
+            !issues.iter().any(|i| i.code.starts_with("menu.dangling")),
+            "valid first-play target should not raise a dangling-reference issue, got {issues:?}"
+        );
+    }
 }

--- a/plugins/tauri-plugin-spindle-project/src/validation/menu.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/menu.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::models::*;
 
-use super::menu_action::validate_action;
+use super::menu_action::{validate_action, ActionSubject};
 use super::menu_aspect::titleset_stream_counts;
 use super::scene::{
     count_scene_buttons, validate_button_video_usage, validate_motion_keyframes,
@@ -19,6 +19,8 @@ pub(super) fn validate_menus(
     project: &SpindleProjectFile,
     asset_ids: &HashSet<&str>,
     asset_map: &HashMap<&str, &Asset>,
+    all_title_ids: &HashSet<&str>,
+    all_menu_ids: &HashSet<&str>,
     issues: &mut Vec<ValidationIssue>,
 ) {
     // Pair each menu with its owning titleset so stream index validation has context.
@@ -37,15 +39,6 @@ pub(super) fn validate_menus(
         )
         .collect();
 
-    let all_menu_ids: HashSet<&str> = all_menus.iter().map(|(m, _)| m.id.as_str()).collect();
-
-    let all_title_ids: HashSet<&str> = project
-        .disc
-        .titlesets
-        .iter()
-        .flat_map(|ts| ts.titles.iter().map(|t| t.id.as_str()))
-        .collect();
-
     for (menu, titleset_opt) in &all_menus {
         let stream_counts = titleset_opt.map(titleset_stream_counts);
         let background_mode = menu.resolved_background_mode();
@@ -53,6 +46,34 @@ pub(super) fn validate_menus(
         let motion_loop_start_secs = menu.resolved_motion_loop_start_secs();
         let background_asset_id = menu.resolved_background_asset_id();
         let motion_audio_asset_id = menu.resolved_motion_audio_asset_id();
+
+        // Validate the timeout action's target. Runs ahead of the
+        // empty-buttons check below since a menu can have a valid timeout
+        // action (or authored scene buttons) even with an empty legacy
+        // `buttons[]` array. Mirrors the authored-document-vs-legacy split
+        // used for button actions: the authored document's interaction
+        // graph is authoritative when present, otherwise the legacy field.
+        let timeout_action = menu
+            .authored_document
+            .as_ref()
+            .map(|doc| &doc.interaction.timeout_action)
+            .unwrap_or(&menu.timeout_action);
+        if let Some(action) = timeout_action {
+            validate_action(
+                action,
+                all_title_ids,
+                all_menu_ids,
+                &project.disc,
+                &ActionSubject {
+                    subject: format!("Timeout action in menu \"{}\"", menu.name),
+                    entity_type: "menu",
+                    entity_name: Some(&menu.name),
+                    context_id: Some(&menu.id),
+                },
+                stream_counts,
+                issues,
+            );
+        }
 
         // Hard limit: 36 buttons per menu (DVD spec limit for most players/configurations)
         if menu.buttons.len() > 36 {
@@ -154,12 +175,18 @@ pub(super) fn validate_menus(
                 if let Some(action) = &button.action {
                     validate_action(
                         action,
-                        &all_title_ids,
-                        &all_menu_ids,
+                        all_title_ids,
+                        all_menu_ids,
                         &project.disc,
-                        &menu.name,
-                        &menu.id,
-                        &button.label,
+                        &ActionSubject {
+                            subject: format!(
+                                "Action \"{}\" in menu \"{}\"",
+                                button.label, menu.name
+                            ),
+                            entity_type: "menu",
+                            entity_name: Some(&menu.name),
+                            context_id: Some(&menu.id),
+                        },
                         stream_counts,
                         issues,
                     );
@@ -262,12 +289,18 @@ pub(super) fn validate_menus(
                 if let Some(action) = &focus_node.action {
                     validate_action(
                         action,
-                        &all_title_ids,
-                        &all_menu_ids,
+                        all_title_ids,
+                        all_menu_ids,
                         &project.disc,
-                        &menu.name,
-                        &menu.id,
-                        &format!("Interaction: {}", focus_node.node_id),
+                        &ActionSubject {
+                            subject: format!(
+                                "Action \"Interaction: {}\" in menu \"{}\"",
+                                focus_node.node_id, menu.name
+                            ),
+                            entity_type: "menu",
+                            entity_name: Some(&menu.name),
+                            context_id: Some(&menu.id),
+                        },
                         stream_counts,
                         issues,
                     );
@@ -424,5 +457,160 @@ pub(super) fn validate_menus(
         if let Some(doc) = &menu.authored_document {
             validate_motion_keyframes(doc, menu, motion_duration_secs, issues);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project_with_menu(menu: Menu) -> SpindleProjectFile {
+        let mut project = SpindleProjectFile::default();
+        project.disc.global_menus.push(menu);
+        project
+    }
+
+    fn authored_document_with_timeout(action: Option<PlaybackAction>) -> MenuDocument {
+        MenuDocument {
+            id: "menu-1".to_string(),
+            name: "Main Menu".to_string(),
+            domain: MenuDomain::Vmgm,
+            scene: MenuScene {
+                design_size: MenuSize {
+                    width: 720.0,
+                    height: 480.0,
+                    aspect: AspectMode::SixteenByNine,
+                },
+                background: SceneBackground {
+                    asset_id: None,
+                    colour: Some("#000000".to_string()),
+                },
+                nodes: vec![],
+                guides: vec![],
+            },
+            interaction: MenuInteractionGraph {
+                default_focus_id: None,
+                nodes: vec![],
+                timeout_action: action,
+            },
+            timing: MenuTiming::default(),
+            highlight_colours: MenuHighlightColours::default(),
+            background_mode: BackgroundMode::Still,
+            theme_ref: None,
+            generation_meta: None,
+            compile_policy: MenuCompilePolicy::default(),
+        }
+    }
+
+    #[test]
+    fn legacy_timeout_action_targeting_a_deleted_title_is_flagged() {
+        let mut menu = Menu {
+            id: "menu-1".to_string(),
+            name: "Main Menu".to_string(),
+            timeout_action: Some(PlaybackAction::PlayTitle {
+                title_id: "stale-title-id".to_string(),
+            }),
+            ..Menu::default()
+        };
+        // No buttons at all — regression guard: the timeout action must still
+        // be validated even though the empty-buttons check below would
+        // otherwise `continue` past it.
+        menu.buttons.clear();
+        let project = project_with_menu(menu);
+
+        let asset_ids = HashSet::new();
+        let asset_map = HashMap::new();
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "menu.dangling-title-ref"
+                    && i.context.as_deref() == Some("menu-1")),
+            "expected a dangling-title-ref issue for the menu's timeout action, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn authored_document_timeout_action_targeting_a_deleted_menu_is_flagged() {
+        let menu = Menu {
+            id: "menu-1".to_string(),
+            name: "Main Menu".to_string(),
+            authored_document: Some(authored_document_with_timeout(Some(
+                PlaybackAction::ShowMenu {
+                    menu_id: "stale-menu-id".to_string(),
+                },
+            ))),
+            ..Menu::default()
+        };
+        let project = project_with_menu(menu);
+
+        let asset_ids = HashSet::new();
+        let asset_map = HashMap::new();
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "menu.dangling-menu-ref"
+                    && i.context.as_deref() == Some("menu-1")),
+            "expected a dangling-menu-ref issue for the authored timeout action, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn timeout_action_targeting_an_existing_title_is_not_flagged() {
+        let mut menu = Menu {
+            id: "menu-1".to_string(),
+            name: "Main Menu".to_string(),
+            timeout_action: Some(PlaybackAction::PlayTitle {
+                title_id: "title-1".to_string(),
+            }),
+            ..Menu::default()
+        };
+        menu.buttons.clear();
+        let project = project_with_menu(menu);
+
+        let asset_ids = HashSet::new();
+        let asset_map = HashMap::new();
+        let all_title_ids: HashSet<&str> = ["title-1"].into_iter().collect();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            !issues.iter().any(|i| i.code.starts_with("menu.dangling")),
+            "valid timeout action target should not raise a dangling-reference issue, got {issues:?}"
+        );
     }
 }

--- a/plugins/tauri-plugin-spindle-project/src/validation/menu_action.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/menu_action.rs
@@ -9,55 +9,63 @@ use crate::models::*;
 
 use super::chapter::{chapter_target_exists, dangling_play_chapter_issue};
 
+/// Describes where an action lives, for issue messages and routing.
+///
+/// `subject` is a human-readable phrase naming the action and its owner
+/// (e.g. `"Action \"Play Title 1\" in menu \"Main Menu\""` or `"Disc
+/// first-play action"`), used as the lead-in for every generated message.
+/// `entity_type`/`entity_name`/`context_id` populate `ValidationIssue` so the
+/// frontend can route a click to the right page (see `entityType` handling
+/// in `BuildPage.tsx`/`OverviewPage.tsx`).
+pub(super) struct ActionSubject<'a> {
+    pub(super) subject: String,
+    pub(super) entity_type: &'a str,
+    pub(super) entity_name: Option<&'a str>,
+    pub(super) context_id: Option<&'a str>,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn validate_action(
     action: &PlaybackAction,
     all_title_ids: &HashSet<&str>,
     all_menu_ids: &HashSet<&str>,
     disc: &Disc,
-    menu_name: &str,
-    menu_id: &str,
-    button_label: &str,
+    subject: &ActionSubject<'_>,
     stream_counts: Option<(usize, usize)>,
     issues: &mut Vec<ValidationIssue>,
 ) {
+    let issue = |code: &str, message: String, suggested_fix: String| ValidationIssue {
+        severity: IssueSeverity::Error,
+        code: code.to_string(),
+        message,
+        context: subject.context_id.map(|id| id.to_string()),
+        entity_type: Some(subject.entity_type.to_string()),
+        entity_name: subject.entity_name.map(|name| name.to_string()),
+        suggested_fix: Some(suggested_fix),
+    };
+
     match action {
         PlaybackAction::PlayTitle { title_id } => {
             if !all_title_ids.contains(title_id.as_str()) {
-                issues.push(ValidationIssue {
-                    severity: IssueSeverity::Error,
-                    code: "menu.dangling-title-ref".to_string(),
-                    message: format!(
-                        "Action \"{}\" in menu \"{}\" references a title that does not exist.",
-                        button_label, menu_name
+                issues.push(issue(
+                    "menu.dangling-title-ref",
+                    format!(
+                        "{} references a title that does not exist.",
+                        subject.subject
                     ),
-                    context: Some(menu_id.to_string()),
-                    entity_type: Some("menu".to_string()),
-                    entity_name: Some(menu_name.to_string()),
-                    suggested_fix: Some(
-                        "Update the action to point to an existing title or remove it.".to_string(),
-                    ),
-                });
+                    "Update the action to point to an existing title or remove it.".to_string(),
+                ));
             }
         }
         PlaybackAction::ShowMenu {
             menu_id: target_id, ..
         } => {
             if !all_menu_ids.contains(target_id.as_str()) {
-                issues.push(ValidationIssue {
-                    severity: IssueSeverity::Error,
-                    code: "menu.dangling-menu-ref".to_string(),
-                    message: format!(
-                        "Action \"{}\" in menu \"{}\" references a menu that does not exist.",
-                        button_label, menu_name
-                    ),
-                    context: Some(menu_id.to_string()),
-                    entity_type: Some("menu".to_string()),
-                    entity_name: Some(menu_name.to_string()),
-                    suggested_fix: Some(
-                        "Update the action to point to an existing menu or remove it.".to_string(),
-                    ),
-                });
+                issues.push(issue(
+                    "menu.dangling-menu-ref",
+                    format!("{} references a menu that does not exist.", subject.subject),
+                    "Update the action to point to an existing menu or remove it.".to_string(),
+                ));
             }
         }
         PlaybackAction::PlayChapter {
@@ -68,12 +76,12 @@ pub(super) fn validate_action(
                 issues.push(dangling_play_chapter_issue(
                     "menu.dangling-chapter-ref",
                     format!(
-                        "Action \"{}\" in menu \"{}\" references a chapter target that does not exist.",
-                        button_label, menu_name
+                        "{} references a chapter target that does not exist.",
+                        subject.subject
                     ),
-                    Some(menu_id.to_string()),
-                    "menu",
-                    Some(menu_name.to_string()),
+                    subject.context_id.map(|id| id.to_string()),
+                    subject.entity_type,
+                    subject.entity_name.map(|name| name.to_string()),
                     "Update the action to point to an existing chapter or remove it.",
                 ));
             }
@@ -81,34 +89,26 @@ pub(super) fn validate_action(
         PlaybackAction::SetAudioStream { stream_index } => {
             if let Some((audio_count, _)) = stream_counts {
                 if audio_count == 0 {
-                    issues.push(ValidationIssue {
-                        severity: IssueSeverity::Error,
-                        code: "menu.action.audio-stream-no-tracks".to_string(),
-                        message: format!(
-                            "Action \"{}\" in menu \"{}\" sets audio stream {}, but this titleset has no audio tracks.",
-                            button_label, menu_name, stream_index
+                    issues.push(issue(
+                        "menu.action.audio-stream-no-tracks",
+                        format!(
+                            "{} sets audio stream {}, but this titleset has no audio tracks.",
+                            subject.subject, stream_index
                         ),
-                        context: Some(menu_id.to_string()),
-                        entity_type: Some("menu".to_string()),
-                        entity_name: Some(menu_name.to_string()),
-                        suggested_fix: Some("Add audio track mappings to the titles in this titleset, or remove this action.".to_string()),
-                    });
+                        "Add audio track mappings to the titles in this titleset, or remove this action.".to_string(),
+                    ));
                 } else if *stream_index as usize >= audio_count {
-                    issues.push(ValidationIssue {
-                        severity: IssueSeverity::Error,
-                        code: "menu.action.audio-stream-out-of-range".to_string(),
-                        message: format!(
-                            "Action \"{}\" in menu \"{}\" sets audio stream {}, but this titleset only has {} audio track(s) (valid indices: 0–{}).",
-                            button_label, menu_name, stream_index, audio_count, audio_count - 1
+                    issues.push(issue(
+                        "menu.action.audio-stream-out-of-range",
+                        format!(
+                            "{} sets audio stream {}, but this titleset only has {} audio track(s) (valid indices: 0–{}).",
+                            subject.subject, stream_index, audio_count, audio_count - 1
                         ),
-                        context: Some(menu_id.to_string()),
-                        entity_type: Some("menu".to_string()),
-                        entity_name: Some(menu_name.to_string()),
-                        suggested_fix: Some(format!(
+                        format!(
                             "Use a stream index between 0 and {} inclusive, or add more audio track mappings.",
                             audio_count - 1
-                        )),
-                    });
+                        ),
+                    ));
                 }
             }
         }
@@ -116,34 +116,26 @@ pub(super) fn validate_action(
             // stream_index of None means "disable subtitles" — always valid.
             if let (Some(idx), Some((_, subtitle_count))) = (stream_index, stream_counts) {
                 if subtitle_count == 0 {
-                    issues.push(ValidationIssue {
-                        severity: IssueSeverity::Error,
-                        code: "menu.action.subtitle-stream-no-tracks".to_string(),
-                        message: format!(
-                            "Action \"{}\" in menu \"{}\" sets subtitle stream {}, but this titleset has no subtitle tracks.",
-                            button_label, menu_name, idx
+                    issues.push(issue(
+                        "menu.action.subtitle-stream-no-tracks",
+                        format!(
+                            "{} sets subtitle stream {}, but this titleset has no subtitle tracks.",
+                            subject.subject, idx
                         ),
-                        context: Some(menu_id.to_string()),
-                        entity_type: Some("menu".to_string()),
-                        entity_name: Some(menu_name.to_string()),
-                        suggested_fix: Some("Add subtitle track mappings to the titles in this titleset, or use disable-subtitles instead.".to_string()),
-                    });
+                        "Add subtitle track mappings to the titles in this titleset, or use disable-subtitles instead.".to_string(),
+                    ));
                 } else if *idx as usize >= subtitle_count {
-                    issues.push(ValidationIssue {
-                        severity: IssueSeverity::Error,
-                        code: "menu.action.subtitle-stream-out-of-range".to_string(),
-                        message: format!(
-                            "Action \"{}\" in menu \"{}\" sets subtitle stream {}, but this titleset only has {} subtitle track(s) (valid indices: 0–{}).",
-                            button_label, menu_name, idx, subtitle_count, subtitle_count - 1
+                    issues.push(issue(
+                        "menu.action.subtitle-stream-out-of-range",
+                        format!(
+                            "{} sets subtitle stream {}, but this titleset only has {} subtitle track(s) (valid indices: 0–{}).",
+                            subject.subject, idx, subtitle_count, subtitle_count - 1
                         ),
-                        context: Some(menu_id.to_string()),
-                        entity_type: Some("menu".to_string()),
-                        entity_name: Some(menu_name.to_string()),
-                        suggested_fix: Some(format!(
+                        format!(
                             "Use a stream index between 0 and {} inclusive, or add more subtitle track mappings.",
                             subtitle_count - 1
-                        )),
-                    });
+                        ),
+                    ));
                 }
             }
         }
@@ -154,9 +146,7 @@ pub(super) fn validate_action(
                     all_title_ids,
                     all_menu_ids,
                     disc,
-                    menu_name,
-                    menu_id,
-                    button_label,
+                    subject,
                     stream_counts,
                     issues,
                 );

--- a/plugins/tauri-plugin-spindle-project/src/validation/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/mod.rs
@@ -22,14 +22,35 @@ mod titleset;
 pub(crate) fn run(project: &SpindleProjectFile) -> Vec<ValidationIssue> {
     let mut issues = Vec::new();
 
-    let total_titles = disc::validate_disc(project, &mut issues);
+    let all_title_ids: HashSet<&str> = project
+        .disc
+        .titlesets
+        .iter()
+        .flat_map(|ts| ts.titles.iter().map(|t| t.id.as_str()))
+        .collect();
+    let all_menu_ids: HashSet<&str> = project
+        .disc
+        .global_menus
+        .iter()
+        .chain(project.disc.titlesets.iter().flat_map(|ts| ts.menus.iter()))
+        .map(|m| m.id.as_str())
+        .collect();
+
+    let total_titles = disc::validate_disc(project, &all_title_ids, &all_menu_ids, &mut issues);
 
     let asset_ids: HashSet<&str> = project.assets.iter().map(|a| a.id.as_str()).collect();
     let asset_map: HashMap<&str, &Asset> =
         project.assets.iter().map(|a| (a.id.as_str(), a)).collect();
 
     title::validate_titles(project, &asset_ids, &asset_map, &mut issues);
-    menu::validate_menus(project, &asset_ids, &asset_map, &mut issues);
+    menu::validate_menus(
+        project,
+        &asset_ids,
+        &asset_map,
+        &all_title_ids,
+        &all_menu_ids,
+        &mut issues,
+    );
     menu_aspect::validate_menu_aspect_sections(project, &mut issues);
     titleset::validate_titleset_formats(project, &mut issues);
     build_settings::validate_build_settings(project, total_titles, &mut issues);
@@ -51,7 +72,7 @@ mod tests {
     };
 
     use super::chapter::{chapter_target_exists, dangling_play_chapter_issue};
-    use super::menu_action::validate_action;
+    use super::menu_action::{validate_action, ActionSubject};
     use super::menu_aspect::{titleset_stream_counts, validate_menu_aspect_section};
     use super::scene::{validate_button_video_usage, validate_motion_keyframes};
 
@@ -217,9 +238,12 @@ mod tests {
             &all_title_ids,
             &all_menu_ids,
             &disc,
-            "Setup Menu",
-            "menu-1",
-            "Audio English",
+            &ActionSubject {
+                subject: "Action \"Audio English\" in menu \"Setup Menu\"".to_string(),
+                entity_type: "menu",
+                entity_name: Some("Setup Menu"),
+                context_id: Some("menu-1"),
+            },
             stream_counts,
             &mut issues,
         );


### PR DESCRIPTION
## Summary
- Fixes #72: pre-build validation never checked that `disc.firstPlayAction` or `menu.timeoutAction` pointed at a target that still exists — only that *something* was set. A title/menu deleted and re-added under a new ID left a stale reference that the QA Scorecard reported as healthy ("First-play action set" + "No dangling references", both green), only for the real build to fail later with `Unknown title target: <stale-uuid>`.
- Generalised `validate_action` to take an `ActionSubject` (message lead-in + `entity_type`/`entity_name`/`context_id`) instead of hard-coding "in menu \"{name}\"" everywhere, so the same dangling-reference logic now also covers:
  - `disc.firstPlayAction`, scoped as `entity_type: "disc"` so a QA Scorecard click routes to Overview (not Menus).
  - `menu.timeoutAction` (legacy field) and the authored document's `interaction.timeoutAction`.
- The new timeout-action check runs ahead of the existing "menu has no buttons" early-`continue` — a menu with an empty legacy `buttons[]` array (the normal case for menus authored entirely in the new scene editor) but a dangling timeout action would otherwise skip validation entirely.
- `validate_disc`/`validate_menus` now share one project-wide title/menu ID set computed once in `validation::run`, instead of `validate_menus` building its own copy.
- No other validation behavior changes — existing button/interaction-node action messages are unchanged.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 195 passed, 0 failed, 3 ignored (189 pre-existing + 6 new regression tests covering: dangling first-play title/menu refs, valid first-play ref, legacy timeout action with empty buttons, authored-document timeout action, valid timeout ref)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all --check` (clean)
- [x] Independent code review (no @codex review — Codex usage limits exhausted)
