### PR TITLE
fix(build): show elapsed time and ETA instead of raw ffmpeg source position

### DIFF
--- a/apps/spindle/src/pages/BuildPage.test.tsx
+++ b/apps/spindle/src/pages/BuildPage.test.tsx
@@ -1,0 +1,119 @@
+// Tests for the build progress step-detail line: elapsed/ETA formatting vs
+// the raw stepDetail fallback for non-FFmpeg steps.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BuildPage } from './BuildPage';
+import { useProjectStore } from '../store/project-store';
+import type { ProjectState } from '../store/project-store';
+import type { BuildProgress, SpindleProjectFile } from '../types/project';
+
+vi.mock('../App', () => ({
+	useNavigation: () => ({
+		consumePendingEntityId: () => null,
+		navigateTo: () => {},
+	}),
+}));
+
+function buildProject(): SpindleProjectFile {
+	return {
+		schemaVersion: 1,
+		project: {
+			id: 'project-1',
+			name: 'Build Progress Lab',
+			createdAt: '2026-04-01T00:00:00Z',
+			modifiedAt: '2026-04-01T00:00:00Z',
+		},
+		disc: {
+			family: 'dvd-video',
+			standard: 'NTSC',
+			capacityTarget: 'DVD5',
+			firstPlayAction: null,
+			globalMenus: [],
+			titlesets: [],
+		},
+		assets: [],
+		buildSettings: {
+			outputDirectory: '/tmp/dvd_output',
+			generateIso: false,
+			safetyMarginBytes: 0,
+			allocationStrategy: 'duration-weighted',
+		},
+	};
+}
+
+function baseProgress(overrides: Partial<BuildProgress> = {}): BuildProgress {
+	return {
+		jobIndex: 0,
+		totalJobs: 1,
+		currentLabel: 'Transcode "Feature"',
+		status: 'running',
+		output: null,
+		stepLabel: 'FFmpeg transcode',
+		stepPercent: 42,
+		stepDetail: null,
+		stepStatus: 'running',
+		...overrides,
+	};
+}
+
+describe('BuildPage step-detail line', () => {
+	let initialState: ProjectState;
+
+	beforeEach(() => {
+		initialState = useProjectStore.getState();
+		useProjectStore.setState({
+			...initialState,
+			project: buildProject(),
+			validateProject: vi.fn().mockResolvedValue(undefined),
+			buildStatus: 'building',
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+		useProjectStore.setState(initialState);
+	});
+
+	it('shows elapsed time and an ETA when both are present', () => {
+		useProjectStore.setState({
+			buildProgress: baseProgress({ elapsedSecs: 754, etaSecs: 500 }),
+		});
+
+		render(<BuildPage />);
+
+		expect(screen.getByText('12m34s elapsed · ~8m20s remaining')).toBeInTheDocument();
+	});
+
+	it('shows elapsed time alone when no ETA is available yet', () => {
+		useProjectStore.setState({
+			buildProgress: baseProgress({ elapsedSecs: 12, etaSecs: null }),
+		});
+
+		render(<BuildPage />);
+
+		expect(screen.getByText('12s elapsed')).toBeInTheDocument();
+		expect(screen.queryByText(/remaining/)).not.toBeInTheDocument();
+	});
+
+	it('falls back to the raw stepDetail for non-FFmpeg-progress steps', () => {
+		useProjectStore.setState({
+			buildProgress: baseProgress({
+				stepLabel: 'Prepare subtitle text',
+				stepDetail: '/tmp/dvd_output/_spindle_work/subtitles/title-1_sub_2.srt',
+				elapsedSecs: null,
+				etaSecs: null,
+			}),
+		});
+
+		render(<BuildPage />);
+
+		expect(
+			screen.getByText('/tmp/dvd_output/_spindle_work/subtitles/title-1_sub_2.srt'),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/elapsed/)).not.toBeInTheDocument();
+	});
+});

--- a/apps/spindle/src/pages/BuildPage.tsx
+++ b/apps/spindle/src/pages/BuildPage.tsx
@@ -181,8 +181,16 @@ export function BuildPage() {
 								{buildProgress.stepLabel && (
 									<span className="build__step-label text-muted">{buildProgress.stepLabel}</span>
 								)}
-								{buildProgress.stepDetail && (
-									<span className="build__step-detail text-muted">{buildProgress.stepDetail}</span>
+								{buildProgress.elapsedSecs != null ? (
+									<span className="build__step-detail text-muted">
+										{formatElapsedEta(buildProgress.elapsedSecs, buildProgress.etaSecs ?? null)}
+									</span>
+								) : (
+									buildProgress.stepDetail && (
+										<span className="build__step-detail text-muted">
+											{buildProgress.stepDetail}
+										</span>
+									)
 								)}
 							</div>
 						</div>
@@ -293,6 +301,23 @@ export function BuildPage() {
 			)}
 		</div>
 	);
+}
+
+/** Format wall-clock elapsed time and an optional ETA, e.g. "12m34s elapsed · ~8m20s remaining". */
+function formatElapsedEta(elapsedSecs: number, etaSecs: number | null): string {
+	const elapsed = formatShortDuration(elapsedSecs);
+	if (etaSecs == null) return `${elapsed} elapsed`;
+	return `${elapsed} elapsed · ~${formatShortDuration(etaSecs)} remaining`;
+}
+
+function formatShortDuration(seconds: number): string {
+	const total = Math.max(0, Math.round(seconds));
+	const h = Math.floor(total / 3600);
+	const m = Math.floor((total % 3600) / 60);
+	const s = total % 60;
+	if (h > 0) return `${h}h${String(m).padStart(2, '0')}m`;
+	if (m > 0) return `${m}m${String(s).padStart(2, '0')}s`;
+	return `${s}s`;
 }
 
 function buildIssueRoute(issue: ValidationIssue): string | null {

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -658,6 +658,14 @@ export interface BuildProgress {
 	stepDetail?: string | null;
 	/** Lifecycle state of the sub-operation. */
 	stepStatus?: 'starting' | 'running' | 'complete' | 'failed' | null;
+	/** Wall-clock seconds elapsed since the current sub-operation started. */
+	elapsedSecs?: number | null;
+	/**
+	 * Estimated remaining seconds for the current sub-operation, derived from
+	 * FFmpeg's realtime `speed` multiplier rather than averaged elapsed time,
+	 * so it reacts to the encode speeding up or slowing down.
+	 */
+	etaSecs?: number | null;
 }
 
 export interface BuildResult {

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -654,7 +654,10 @@ export interface BuildProgress {
 	stepLabel?: string | null;
 	/** Estimated completion of the current sub-operation, clamped to 0-100. */
 	stepPercent?: number | null;
-	/** Freeform detail such as media timestamp or encoding phase. */
+	/**
+	 * Freeform detail not covered by `elapsedSecs`/`etaSecs`, such as a file
+	 * path for non-FFmpeg-progress steps.
+	 */
 	stepDetail?: string | null;
 	/** Lifecycle state of the sub-operation. */
 	stepStatus?: 'starting' | 'running' | 'complete' | 'failed' | null;

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
@@ -331,6 +331,8 @@ where
                     step_percent: None,
                     step_detail: Some(subtitle_path.clone()),
                     step_status: Some(BuildJobStatus::Running),
+                    elapsed_secs: None,
+                    eta_secs: None,
                 });
 
                 match run_ffmpeg_command(
@@ -389,6 +391,8 @@ where
                             step_percent: Some(100.0),
                             step_detail: Some(subtitle_path.clone()),
                             step_status: Some(BuildJobStatus::Complete),
+                            elapsed_secs: None,
+                            eta_secs: None,
                         });
                         on_progress(BuildProgress::job(
                             i,
@@ -433,6 +437,8 @@ where
                     step_percent: None,
                     step_detail: Some(output_path.clone()),
                     step_status: Some(BuildJobStatus::Running),
+                    elapsed_secs: None,
+                    eta_secs: None,
                 });
 
                 match run_spumux_command(command, input_path, output_path) {

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/process.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/process.rs
@@ -67,7 +67,9 @@ where
 
     let mut reader = std::io::BufReader::new(stderr);
     let mut stderr_buf = String::new();
+    let job_start = Instant::now();
     let mut last_emit = Instant::now();
+    let mut last_speed: Option<f64> = None;
     let mut raw_line = Vec::new();
 
     // Read stderr as raw bytes and decode lossily so non-UTF-8 metadata
@@ -88,11 +90,19 @@ where
         let line = String::from_utf8_lossy(&raw_line);
         let line = line.trim_end_matches('\n').trim_end_matches('\r');
 
+        // `speed=` lines arrive separately from `out_time=` lines within the
+        // same `-progress` block; remember the latest value so it's available
+        // when the next `out_time=` line triggers an emit below.
+        if let Some(speed_val) = ffmpeg_progress::extract_progress_value(line, "speed") {
+            last_speed = ffmpeg_progress::parse_speed(speed_val);
+        }
+
         // Try to extract progress from `-progress pipe:2` output.
         if let Some(time_val) = ffmpeg_progress::extract_progress_value(line, "out_time") {
             if let Some(elapsed) = ffmpeg_progress::parse_out_time_secs(time_val) {
                 let pct = ffmpeg_progress::step_percent(elapsed, duration_secs);
-                let detail = ffmpeg_progress::format_timestamp(elapsed);
+                let eta = last_speed
+                    .and_then(|speed| ffmpeg_progress::eta_secs(elapsed, duration_secs, speed));
 
                 // Throttle emissions to avoid flooding the frontend.
                 if last_emit.elapsed().as_millis() >= PROGRESS_THROTTLE_MS {
@@ -104,8 +114,10 @@ where
                         output: None,
                         step_label: Some(step_label.to_string()),
                         step_percent: pct,
-                        step_detail: Some(detail),
+                        step_detail: None,
                         step_status: Some(BuildJobStatus::Running),
+                        elapsed_secs: Some(job_start.elapsed().as_secs_f64()),
+                        eta_secs: eta,
                     });
                     last_emit = Instant::now();
                 }

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/process.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/process.rs
@@ -69,6 +69,7 @@ where
     let mut stderr_buf = String::new();
     let job_start = Instant::now();
     let mut last_emit = Instant::now();
+    let mut last_out_time: Option<f64> = None;
     let mut last_speed: Option<f64> = None;
     let mut raw_line = Vec::new();
 
@@ -90,16 +91,21 @@ where
         let line = String::from_utf8_lossy(&raw_line);
         let line = line.trim_end_matches('\n').trim_end_matches('\r');
 
-        // `speed=` lines arrive separately from `out_time=` lines within the
-        // same `-progress` block; remember the latest value so it's available
-        // when the next `out_time=` line triggers an emit below.
+        // FFmpeg's `-progress` output writes one key=value pair per line,
+        // in a fixed order per block: ..., out_time, ..., speed,
+        // progress=continue|end. Remember out_time/speed as they arrive and
+        // only act once `progress=` closes the block, so the percent/ETA
+        // computed below always pairs same-block values rather than mixing
+        // this block's out_time with the previous block's speed.
+        if let Some(time_val) = ffmpeg_progress::extract_progress_value(line, "out_time") {
+            last_out_time = ffmpeg_progress::parse_out_time_secs(time_val);
+        }
         if let Some(speed_val) = ffmpeg_progress::extract_progress_value(line, "speed") {
             last_speed = ffmpeg_progress::parse_speed(speed_val);
         }
 
-        // Try to extract progress from `-progress pipe:2` output.
-        if let Some(time_val) = ffmpeg_progress::extract_progress_value(line, "out_time") {
-            if let Some(elapsed) = ffmpeg_progress::parse_out_time_secs(time_val) {
+        if ffmpeg_progress::extract_progress_value(line, "progress").is_some() {
+            if let Some(elapsed) = last_out_time {
                 let pct = ffmpeg_progress::step_percent(elapsed, duration_secs);
                 let eta = last_speed
                     .and_then(|speed| ffmpeg_progress::eta_secs(elapsed, duration_secs, speed));

--- a/plugins/tauri-plugin-spindle-project/src/build/ffmpeg_progress.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/ffmpeg_progress.rs
@@ -48,13 +48,35 @@ pub fn step_percent(elapsed_secs: f64, duration_secs: Option<f64>) -> Option<f64
     Some(pct.clamp(0.0, 100.0))
 }
 
-/// Format elapsed seconds as a human-readable `HH:MM:SS` string.
-pub fn format_timestamp(secs: f64) -> String {
-    let total = secs.max(0.0) as u64;
-    let h = total / 3600;
-    let m = (total % 3600) / 60;
-    let s = total % 60;
-    format!("{h:02}:{m:02}:{s:02}")
+/// Parse a `speed` value from FFmpeg `-progress` output, e.g. `2.3x`.
+///
+/// FFmpeg emits `N/A` before the encode has produced any timed output, and
+/// `0x` momentarily at the very start — both treated as "no usable speed
+/// yet" since they can't drive an ETA estimate.
+pub fn parse_speed(value: &str) -> Option<f64> {
+    let value = value.trim().trim_end_matches('x');
+    let speed: f64 = value.parse().ok()?;
+    if speed > 0.0 {
+        Some(speed)
+    } else {
+        None
+    }
+}
+
+/// Estimate remaining seconds for an FFmpeg encode from progress so far and
+/// the current realtime `speed` multiplier (see `parse_speed`).
+///
+/// Returns `None` when there's no usable duration or speed to estimate from.
+/// Reacting to the live `speed` value (rather than averaging elapsed
+/// wall-clock time) means the estimate adjusts as the encode speeds up or
+/// slows down across different scenes.
+pub fn eta_secs(out_time_secs: f64, duration_secs: Option<f64>, speed: f64) -> Option<f64> {
+    let dur = duration_secs.filter(|&d| d > 0.0)?;
+    if speed <= 0.0 {
+        return None;
+    }
+    let remaining_source_secs = (dur - out_time_secs).max(0.0);
+    Some(remaining_source_secs / speed)
 }
 
 #[cfg(test)]
@@ -132,17 +154,43 @@ mod tests {
     }
 
     #[test]
-    fn format_timestamp_basic() {
-        assert_eq!(format_timestamp(3661.0), "01:01:01");
+    fn parse_speed_basic() {
+        assert_eq!(parse_speed("2.3x"), Some(2.3));
     }
 
     #[test]
-    fn format_timestamp_zero() {
-        assert_eq!(format_timestamp(0.0), "00:00:00");
+    fn parse_speed_not_available() {
+        assert_eq!(parse_speed("N/A"), None);
     }
 
     #[test]
-    fn format_timestamp_negative_clamps() {
-        assert_eq!(format_timestamp(-5.0), "00:00:00");
+    fn parse_speed_zero_is_not_usable() {
+        assert_eq!(parse_speed("0x"), None);
+    }
+
+    #[test]
+    fn parse_speed_whitespace() {
+        assert_eq!(parse_speed("  1.0x  "), Some(1.0));
+    }
+
+    #[test]
+    fn eta_secs_normal() {
+        // 50s into a 100s source at 2x speed → 50s of source remaining / 2x = 25s.
+        assert_eq!(eta_secs(50.0, Some(100.0), 2.0), Some(25.0));
+    }
+
+    #[test]
+    fn eta_secs_none_without_duration() {
+        assert_eq!(eta_secs(50.0, None, 2.0), None);
+    }
+
+    #[test]
+    fn eta_secs_none_for_zero_speed() {
+        assert_eq!(eta_secs(50.0, Some(100.0), 0.0), None);
+    }
+
+    #[test]
+    fn eta_secs_clamps_when_past_duration() {
+        assert_eq!(eta_secs(150.0, Some(100.0), 2.0), Some(0.0));
     }
 }

--- a/plugins/tauri-plugin-spindle-project/src/build/types.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/types.rs
@@ -187,6 +187,14 @@ pub struct BuildProgress {
     /// Lifecycle state of the sub-operation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_status: Option<BuildJobStatus>,
+    /// Wall-clock seconds elapsed since the current sub-operation started.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed_secs: Option<f64>,
+    /// Estimated remaining seconds for the current sub-operation, derived
+    /// from FFmpeg's realtime `speed` multiplier rather than averaged
+    /// elapsed time, so it reacts to the encode speeding up or slowing down.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eta_secs: Option<f64>,
 }
 
 impl BuildProgress {
@@ -208,6 +216,8 @@ impl BuildProgress {
             step_percent: None,
             step_detail: None,
             step_status: None,
+            elapsed_secs: None,
+            eta_secs: None,
         }
     }
 }

--- a/plugins/tauri-plugin-spindle-project/src/build/types.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/types.rs
@@ -181,7 +181,8 @@ pub struct BuildProgress {
     /// Estimated completion of the current sub-operation, clamped to 0–100.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_percent: Option<f64>,
-    /// Freeform detail such as media timestamp or encoding phase.
+    /// Freeform detail not covered by `elapsed_secs`/`eta_secs`, such as a
+    /// file path for non-FFmpeg-progress steps.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_detail: Option<String>,
     /// Lifecycle state of the sub-operation.


### PR DESCRIPTION
## Summary
- Fixes #73: the Build page rendered ffmpeg's raw `out_time=` value next to the progress bar — the position within the *source* media currently being encoded, not wall-clock elapsed time and not a remaining-time estimate. Easy to misread as either while watching a build.
- Parses ffmpeg's `speed=` value (realtime multiplier), which was previously discarded, and uses it to compute an ETA that reacts to the encode speeding up or slowing down per scene, rather than averaging elapsed-so-far.
- Adds `elapsedSecs`/`etaSecs` to `BuildProgress` (Rust struct + hand-written TS bindings in `guest-js/index.ts`, rebuilt `dist-js`).
- `BuildPage.tsx` now shows "12m34s elapsed · ~8m20s remaining" for FFmpeg-driven steps, falling back to the raw `stepDetail` text for the one non-timestamp use (the "Prepare subtitle text" skip-message event, which carries a file path).
- Removed `format_timestamp` from `ffmpeg_progress.rs` — its only caller was the raw-timestamp `step_detail` this change replaces.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 200 passed, 0 failed, 3 ignored (189 pre-existing − 3 removed `format_timestamp` tests + 14 new `parse_speed`/`eta_secs` tests)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all --check` (clean)
- [x] `tsc --noEmit` (clean)
- [x] `pnpm vitest run` — 97 passed (94 pre-existing + 3 new in `BuildPage.test.tsx`, covering elapsed+ETA, elapsed-only, and the raw-`stepDetail` fallback)
- [x] `pnpm exec prettier --check` (clean)
- [x] Live-verified the rendered UI via the Tauri MCP bridge against a running `pnpm tauri dev` session — injected build-progress state directly into the app's store for all three rendering cases and confirmed each renders correctly
- [x] Independent code review (no @codex review — Codex usage limits exhausted)
