### PR TITLE
test(frontend): add app chrome characterization tests

### DIFF
--- a/apps/spindle/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/apps/spindle/src/components/ContextMenu/ContextMenu.test.tsx
@@ -1,0 +1,113 @@
+// Tests for the ContextMenu portal component.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ContextMenu } from './ContextMenu';
+import type { MenuModel } from './types';
+
+const model: MenuModel = {
+	sections: [{ items: [{ id: 'item-1', label: 'Item 1' }] }],
+};
+
+describe('ContextMenu', () => {
+	it('renders menu sections into a document.body portal', () => {
+		render(
+			<ContextMenu
+				model={model}
+				position={{ x: 0, y: 0 }}
+				onClose={vi.fn()}
+				onItemClick={vi.fn()}
+			/>,
+		);
+
+		const menu = document.querySelector('.context-menu');
+		expect(menu).not.toBeNull();
+		expect(menu?.parentElement).toBe(document.body);
+		expect(screen.getByText('Item 1')).toBeInTheDocument();
+	});
+
+	it('calls onItemClick and onClose when an item is clicked', () => {
+		const onItemClick = vi.fn();
+		const onClose = vi.fn();
+
+		render(
+			<ContextMenu
+				model={model}
+				position={{ x: 0, y: 0 }}
+				onClose={onClose}
+				onItemClick={onItemClick}
+			/>,
+		);
+		fireEvent.click(screen.getByText('Item 1'));
+
+		expect(onItemClick).toHaveBeenCalledWith('item-1', undefined);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls onClose when clicking outside the menu', () => {
+		const onClose = vi.fn();
+
+		render(
+			<ContextMenu
+				model={model}
+				position={{ x: 0, y: 0 }}
+				onClose={onClose}
+				onItemClick={vi.fn()}
+			/>,
+		);
+		fireEvent.mouseDown(document.body);
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call onClose when clicking inside the menu', () => {
+		const onClose = vi.fn();
+
+		render(
+			<ContextMenu
+				model={model}
+				position={{ x: 0, y: 0 }}
+				onClose={onClose}
+				onItemClick={vi.fn()}
+			/>,
+		);
+		fireEvent.mouseDown(screen.getByText('Item 1'));
+
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose on Escape key', () => {
+		const onClose = vi.fn();
+
+		render(
+			<ContextMenu
+				model={model}
+				position={{ x: 0, y: 0 }}
+				onClose={onClose}
+				onItemClick={vi.fn()}
+			/>,
+		);
+		fireEvent.keyDown(document, { key: 'Escape' });
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls onClose on window blur', () => {
+		const onClose = vi.fn();
+
+		render(
+			<ContextMenu
+				model={model}
+				position={{ x: 0, y: 0 }}
+				onClose={onClose}
+				onItemClick={vi.fn()}
+			/>,
+		);
+		fireEvent(window, new Event('blur'));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/spindle/src/components/ContextMenu/MenuItem.test.tsx
+++ b/apps/spindle/src/components/ContextMenu/MenuItem.test.tsx
@@ -1,0 +1,140 @@
+// Tests for the MenuItem context-menu component.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MenuItem } from './MenuItem';
+import type { MenuItem as MenuItemType } from './types';
+
+describe('MenuItem', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('renders the label and calls onItemClick with id and action when clicked', () => {
+		const action = vi.fn();
+		const onItemClick = vi.fn();
+		const item: MenuItemType = { id: 'item-1', label: 'Do Thing', action };
+
+		render(<MenuItem item={item} onItemClick={onItemClick} />);
+		fireEvent.click(screen.getByText('Do Thing'));
+
+		expect(onItemClick).toHaveBeenCalledWith('item-1', action);
+	});
+
+	it('does not call onItemClick when the item is disabled', () => {
+		const onItemClick = vi.fn();
+		const item: MenuItemType = { id: 'item-1', label: 'Do Thing', disabled: true };
+
+		render(<MenuItem item={item} onItemClick={onItemClick} />);
+		fireEvent.click(screen.getByText('Do Thing'));
+
+		expect(onItemClick).not.toHaveBeenCalled();
+	});
+
+	it('renders the shortcut when provided', () => {
+		const item: MenuItemType = { id: 'item-1', label: 'Save', shortcut: 'Ctrl+S' };
+
+		render(<MenuItem item={item} onItemClick={vi.fn()} />);
+
+		expect(screen.getByText('Ctrl+S')).toBeInTheDocument();
+	});
+
+	it('renders a checkbox indicator when checked is a boolean', () => {
+		const item: MenuItemType = { id: 'item-1', label: 'Toggle', checked: true };
+
+		const { container } = render(<MenuItem item={item} onItemClick={vi.fn()} />);
+
+		expect(container.querySelector('.menu-item-checkbox.checked')).not.toBeNull();
+	});
+
+	it('opens the submenu on click instead of firing onItemClick when children exist', () => {
+		const onItemClick = vi.fn();
+		const item: MenuItemType = {
+			id: 'parent',
+			label: 'More',
+			children: [{ id: 'child-1', label: 'Child' }],
+		};
+
+		render(<MenuItem item={item} onItemClick={onItemClick} />);
+		fireEvent.click(screen.getByText('More'));
+
+		expect(onItemClick).not.toHaveBeenCalled();
+		expect(screen.getByText('Child')).toBeInTheDocument();
+	});
+
+	it('applies the danger class for danger items', () => {
+		const item: MenuItemType = { id: 'item-1', label: 'Delete', danger: true };
+
+		render(<MenuItem item={item} onItemClick={vi.fn()} />);
+
+		expect(screen.getByText('Delete').closest('button')).toHaveClass('danger');
+	});
+
+	it('opens the submenu after a hover delay', () => {
+		const item: MenuItemType = {
+			id: 'parent',
+			label: 'More',
+			children: [{ id: 'child-1', label: 'Child' }],
+		};
+
+		render(<MenuItem item={item} onItemClick={vi.fn()} />);
+		fireEvent.mouseEnter(screen.getByText('More'));
+
+		expect(screen.queryByText('Child')).not.toBeInTheDocument();
+		act(() => vi.advanceTimersByTime(250));
+		expect(screen.getByText('Child')).toBeInTheDocument();
+	});
+
+	it('does not open the submenu if the mouse leaves before the hover delay elapses', () => {
+		const item: MenuItemType = {
+			id: 'parent',
+			label: 'More',
+			children: [{ id: 'child-1', label: 'Child' }],
+		};
+
+		render(<MenuItem item={item} onItemClick={vi.fn()} />);
+		fireEvent.mouseEnter(screen.getByText('More'));
+		act(() => vi.advanceTimersByTime(100));
+		fireEvent.mouseLeave(screen.getByText('More'));
+		act(() => vi.advanceTimersByTime(300));
+
+		expect(screen.queryByText('Child')).not.toBeInTheDocument();
+	});
+
+	it('closes an open submenu after a leave delay', () => {
+		const item: MenuItemType = {
+			id: 'parent',
+			label: 'More',
+			children: [{ id: 'child-1', label: 'Child' }],
+		};
+
+		render(<MenuItem item={item} onItemClick={vi.fn()} />);
+		fireEvent.mouseEnter(screen.getByText('More'));
+		act(() => vi.advanceTimersByTime(250));
+		expect(screen.getByText('Child')).toBeInTheDocument();
+
+		fireEvent.mouseLeave(screen.getByText('More'));
+		act(() => vi.advanceTimersByTime(299));
+		expect(screen.getByText('Child')).toBeInTheDocument();
+
+		act(() => vi.advanceTimersByTime(1));
+		expect(screen.queryByText('Child')).not.toBeInTheDocument();
+	});
+
+	it('items without children ignore hover events', () => {
+		const item: MenuItemType = { id: 'item-1', label: 'Do Thing' };
+
+		render(<MenuItem item={item} onItemClick={vi.fn()} />);
+		fireEvent.mouseEnter(screen.getByText('Do Thing'));
+		act(() => vi.advanceTimersByTime(1000));
+
+		expect(screen.queryByText('Child')).not.toBeInTheDocument();
+	});
+});

--- a/apps/spindle/src/components/ContextMenu/MenuSection.test.tsx
+++ b/apps/spindle/src/components/ContextMenu/MenuSection.test.tsx
@@ -1,0 +1,54 @@
+// Tests for the MenuSection context-menu renderer.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MenuSection } from './MenuSection';
+import type { MenuSection as MenuSectionType } from './types';
+
+describe('MenuSection', () => {
+	it('renders the section title when provided', () => {
+		const section: MenuSectionType = {
+			title: 'Window',
+			items: [{ id: 'item-1', label: 'Item 1' }],
+		};
+
+		render(<MenuSection section={section} onItemClick={vi.fn()} />);
+
+		expect(screen.getByText('Window')).toBeInTheDocument();
+	});
+
+	it('renders no title element when title is omitted', () => {
+		const section: MenuSectionType = { items: [{ id: 'item-1', label: 'Item 1' }] };
+
+		const { container } = render(<MenuSection section={section} onItemClick={vi.fn()} />);
+
+		expect(container.querySelector('.menu-section-title')).toBeNull();
+	});
+
+	it('renders all menu items', () => {
+		const section: MenuSectionType = {
+			items: [
+				{ id: 'item-1', label: 'Item 1' },
+				{ id: 'item-2', label: 'Item 2' },
+			],
+		};
+
+		render(<MenuSection section={section} onItemClick={vi.fn()} />);
+
+		expect(screen.getByText('Item 1')).toBeInTheDocument();
+		expect(screen.getByText('Item 2')).toBeInTheDocument();
+	});
+
+	it('renders a separator for separator entries', () => {
+		const section: MenuSectionType = {
+			items: [{ id: 'item-1', label: 'Item 1' }, { type: 'separator' }],
+		};
+
+		const { container } = render(<MenuSection section={section} onItemClick={vi.fn()} />);
+
+		expect(container.querySelector('.menu-separator')).not.toBeNull();
+	});
+});

--- a/apps/spindle/src/components/ContextMenu/Submenu.test.tsx
+++ b/apps/spindle/src/components/ContextMenu/Submenu.test.tsx
@@ -1,0 +1,77 @@
+// Tests for the Submenu portal renderer.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Submenu } from './Submenu';
+import type { MenuItem as MenuItemType } from './types';
+
+const items: MenuItemType[] = [{ id: 'child-1', label: 'Child 1' }];
+
+const parentRect = { top: 10, left: 10, right: 20, bottom: 20, width: 10, height: 10 } as DOMRect;
+
+describe('Submenu', () => {
+	it('renders items into a document.body portal', () => {
+		render(
+			<Submenu items={items} parentRect={parentRect} onItemClick={vi.fn()} onClose={vi.fn()} />,
+		);
+
+		const submenu = document.querySelector('.submenu');
+		expect(submenu).not.toBeNull();
+		expect(submenu?.parentElement).toBe(document.body);
+		expect(screen.getByText('Child 1')).toBeInTheDocument();
+	});
+
+	it('calls onItemClick when a child item is clicked', () => {
+		const onItemClick = vi.fn();
+
+		render(
+			<Submenu items={items} parentRect={parentRect} onItemClick={onItemClick} onClose={vi.fn()} />,
+		);
+		fireEvent.click(screen.getByText('Child 1'));
+
+		expect(onItemClick).toHaveBeenCalledWith('child-1', undefined);
+	});
+
+	it('forwards onMouseEnter and onMouseLeave to the submenu container', () => {
+		const onMouseEnter = vi.fn();
+		const onMouseLeave = vi.fn();
+
+		render(
+			<Submenu
+				items={items}
+				parentRect={parentRect}
+				onItemClick={vi.fn()}
+				onClose={vi.fn()}
+				onMouseEnter={onMouseEnter}
+				onMouseLeave={onMouseLeave}
+			/>,
+		);
+		const submenu = document.querySelector('.submenu') as HTMLElement;
+		fireEvent.mouseEnter(submenu);
+		fireEvent.mouseLeave(submenu);
+
+		expect(onMouseEnter).toHaveBeenCalledTimes(1);
+		expect(onMouseLeave).toHaveBeenCalledTimes(1);
+	});
+
+	it('stops propagation of mousedown so the parent menu does not treat it as outside-click', () => {
+		const submenuMouseDown = vi.fn();
+		const documentMouseDown = vi.fn();
+		document.addEventListener('mousedown', documentMouseDown);
+
+		render(
+			<Submenu items={items} parentRect={parentRect} onItemClick={vi.fn()} onClose={vi.fn()} />,
+		);
+		const submenu = document.querySelector('.submenu') as HTMLElement;
+		submenu.addEventListener('mousedown', submenuMouseDown);
+		fireEvent.mouseDown(submenu);
+
+		expect(submenuMouseDown).toHaveBeenCalledTimes(1);
+		expect(documentMouseDown).not.toHaveBeenCalled();
+
+		document.removeEventListener('mousedown', documentMouseDown);
+	});
+});

--- a/apps/spindle/src/components/NoProjectState.test.tsx
+++ b/apps/spindle/src/components/NoProjectState.test.tsx
@@ -1,0 +1,55 @@
+// Tests for the NoProjectState shared empty-state component.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { NoProjectState } from './NoProjectState';
+
+const initialState = useProjectStore.getState();
+
+describe('NoProjectState', () => {
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+	});
+
+	it('renders the title, description, and icon', () => {
+		render(
+			<NoProjectState
+				title="No Assets"
+				description="Open a project to manage assets."
+				icon={<svg data-testid="icon" />}
+			/>,
+		);
+
+		expect(screen.getByText('No Assets')).toBeInTheDocument();
+		expect(screen.getByText('Open a project to manage assets.')).toBeInTheDocument();
+		expect(screen.getByTestId('icon')).toBeInTheDocument();
+	});
+
+	it('calls createProject with default values when "New Project" is clicked', () => {
+		const createProject = vi.fn().mockResolvedValue(undefined);
+		useProjectStore.setState({ createProject });
+
+		render(<NoProjectState title="t" description="d" icon={null} />);
+		fireEvent.click(screen.getByText('New Project'));
+
+		expect(createProject).toHaveBeenCalledWith({
+			name: 'Untitled Project',
+			standard: 'NTSC',
+			capacityTarget: 'DVD5',
+		});
+	});
+
+	it('calls openProject when "Open Project" is clicked', () => {
+		const openProject = vi.fn().mockResolvedValue(undefined);
+		useProjectStore.setState({ openProject });
+
+		render(<NoProjectState title="t" description="d" icon={null} />);
+		fireEvent.click(screen.getByText('Open Project'));
+
+		expect(openProject).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/spindle/src/components/Sidebar.test.tsx
+++ b/apps/spindle/src/components/Sidebar.test.tsx
@@ -1,0 +1,101 @@
+// Tests for the Sidebar navigation component.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { createDefaultProject } from '../types/project';
+import { Sidebar } from './Sidebar';
+
+const initialState = useProjectStore.getState();
+
+describe('Sidebar', () => {
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+	});
+
+	it('renders all nav sections and items', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Sidebar currentRoute="/" onNavigate={vi.fn()} />);
+
+		expect(screen.getByText('Overview')).toBeInTheDocument();
+		expect(screen.getByText('Assets')).toBeInTheDocument();
+		expect(screen.getByText('Chapters')).toBeInTheDocument();
+		expect(screen.getByText('Menus')).toBeInTheDocument();
+		expect(screen.getByText('Planner')).toBeInTheDocument();
+		expect(screen.getByText('Build')).toBeInTheDocument();
+		expect(screen.getByText('Logs')).toBeInTheDocument();
+		expect(screen.getByText('Settings')).toBeInTheDocument();
+	});
+
+	it('marks the current route item as active', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Sidebar currentRoute="/assets" onNavigate={vi.fn()} />);
+
+		expect(screen.getByText('Assets').closest('button')).toHaveClass('sidebar__item--active');
+		expect(screen.getByText('Overview').closest('button')).not.toHaveClass('sidebar__item--active');
+	});
+
+	it('greys out items that require a project when none is open', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Sidebar currentRoute="/" onNavigate={vi.fn()} />);
+
+		expect(screen.getByText('Chapters').closest('button')).toHaveClass('sidebar__item--inactive');
+		expect(screen.getByText('Overview').closest('button')).not.toHaveClass(
+			'sidebar__item--inactive',
+		);
+	});
+
+	it('does not grey out project-requiring items when a project is open', () => {
+		useProjectStore.setState({ project: createDefaultProject() });
+
+		render(<Sidebar currentRoute="/" onNavigate={vi.fn()} />);
+
+		expect(screen.getByText('Chapters').closest('button')).not.toHaveClass(
+			'sidebar__item--inactive',
+		);
+	});
+
+	it('calls onNavigate with the route id when a nav item is clicked', () => {
+		useProjectStore.setState({ project: null });
+		const onNavigate = vi.fn();
+
+		render(<Sidebar currentRoute="/" onNavigate={onNavigate} />);
+		fireEvent.click(screen.getByText('Settings'));
+
+		expect(onNavigate).toHaveBeenCalledWith('/settings');
+	});
+
+	it('shows a title count badge when titles exist', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [{ id: 't1' } as any];
+		useProjectStore.setState({ project });
+
+		render(<Sidebar currentRoute="/" onNavigate={vi.fn()} />);
+
+		expect(screen.getByText('Titles').parentElement?.textContent).toContain('1');
+	});
+
+	it('shows no Build Disc button when no project is open', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Sidebar currentRoute="/" onNavigate={vi.fn()} />);
+
+		expect(screen.queryByText('Build Disc')).not.toBeInTheDocument();
+	});
+
+	it('shows the Build Disc button and navigates to /build when a project is open', () => {
+		useProjectStore.setState({ project: createDefaultProject() });
+		const onNavigate = vi.fn();
+
+		render(<Sidebar currentRoute="/" onNavigate={onNavigate} />);
+		fireEvent.click(screen.getByText('Build Disc'));
+
+		expect(onNavigate).toHaveBeenCalledWith('/build');
+	});
+});

--- a/apps/spindle/src/components/Statusbar.test.tsx
+++ b/apps/spindle/src/components/Statusbar.test.tsx
@@ -1,0 +1,137 @@
+// Tests for the Statusbar component.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { createDefaultProject } from '../types/project';
+import { Statusbar } from './Statusbar';
+
+vi.mock('@tauri-apps/api/app', () => ({
+	getVersion: vi.fn().mockResolvedValue('1.2.3'),
+}));
+
+const initialState = useProjectStore.getState();
+
+describe('Statusbar', () => {
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+	});
+
+	it('shows the no-project state when no project is open', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Statusbar />);
+
+		expect(screen.getByText('No project open')).toBeInTheDocument();
+	});
+
+	it('shows disc standard, capacity, title/menu counts for an open project', () => {
+		const project = createDefaultProject('My Disc');
+		project.disc.standard = 'NTSC';
+		project.disc.capacityTarget = 'DVD9';
+		project.disc.titlesets[0].titles = [
+			{
+				id: 'title-1',
+				name: 'Feature',
+				sourceAssetId: null,
+				videoMapping: null,
+				videoOutputProfile: null,
+				audioMappings: [],
+				subtitleMappings: [],
+				chapters: [],
+				endAction: null,
+				orderIndex: 0,
+				bitrateWeight: 1,
+				bitrateFloorBps: null,
+				bitrateCeilingBps: null,
+				pinnedBitrateBps: null,
+			} as any,
+		];
+
+		useProjectStore.setState({ project, isDirty: false, validationIssues: [] });
+
+		render(<Statusbar />);
+
+		expect(screen.getByText(/DVD-Video/)).toBeInTheDocument();
+		expect(screen.getByText(/NTSC/)).toBeInTheDocument();
+		expect(screen.getByText('DVD-9 (8.5 GB)')).toBeInTheDocument();
+		expect(screen.getByText(/1 title/)).toBeInTheDocument();
+		expect(screen.getByText(/0 menus/)).toBeInTheDocument();
+	});
+
+	it('pluralises title/menu counts correctly for multiple items', () => {
+		const project = createDefaultProject('Multi Disc');
+		project.disc.globalMenus = [{ id: 'menu-1' } as any, { id: 'menu-2' } as any];
+
+		useProjectStore.setState({ project, isDirty: false, validationIssues: [] });
+
+		render(<Statusbar />);
+
+		expect(screen.getByText(/0 titles/)).toBeInTheDocument();
+		expect(screen.getByText(/2 menus/)).toBeInTheDocument();
+	});
+
+	it('shows an unsaved-changes indicator when the project is dirty', () => {
+		useProjectStore.setState({
+			project: createDefaultProject(),
+			isDirty: true,
+			validationIssues: [],
+		});
+
+		render(<Statusbar />);
+
+		expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+	});
+
+	it('does not show the unsaved-changes indicator when the project is clean', () => {
+		useProjectStore.setState({
+			project: createDefaultProject(),
+			isDirty: false,
+			validationIssues: [],
+		});
+
+		render(<Statusbar />);
+
+		expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
+	});
+
+	it('shows an error dot when validation issues include an error', () => {
+		const project = createDefaultProject();
+		useProjectStore.setState({
+			project,
+			isDirty: false,
+			validationIssues: [{ severity: 'error', message: 'bad', path: '' } as any],
+		});
+
+		const { container } = render(<Statusbar />);
+
+		expect(container.querySelector('.statusbar__dot--error')).not.toBeNull();
+	});
+
+	it('shows a warning dot when validation issues include only warnings', () => {
+		const project = createDefaultProject();
+		useProjectStore.setState({
+			project,
+			isDirty: false,
+			validationIssues: [{ severity: 'warning', message: 'meh', path: '' } as any],
+		});
+
+		const { container } = render(<Statusbar />);
+
+		expect(container.querySelector('.statusbar__dot--warning')).not.toBeNull();
+		expect(container.querySelector('.statusbar__dot--error')).toBeNull();
+	});
+
+	it('loads and displays the app version from the Tauri runtime', async () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Statusbar />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Spindle v1.2.3')).toBeInTheDocument();
+		});
+	});
+});

--- a/apps/spindle/src/components/Topbar.test.tsx
+++ b/apps/spindle/src/components/Topbar.test.tsx
@@ -1,0 +1,148 @@
+// Tests for the Topbar component.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { createDefaultProject } from '../types/project';
+import { Topbar } from './Topbar';
+
+const {
+	mockMinimize,
+	mockToggleMaximize,
+	mockClose,
+	mockIsMaximized,
+	mockStartDragging,
+	mockListen,
+} = vi.hoisted(() => ({
+	mockMinimize: vi.fn(),
+	mockToggleMaximize: vi.fn(),
+	mockClose: vi.fn(),
+	mockIsMaximized: vi.fn().mockResolvedValue(false),
+	mockStartDragging: vi.fn(),
+	mockListen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+	getCurrentWindow: () => ({
+		minimize: mockMinimize,
+		toggleMaximize: mockToggleMaximize,
+		close: mockClose,
+		isMaximized: mockIsMaximized,
+		startDragging: mockStartDragging,
+		listen: mockListen,
+	}),
+}));
+
+const { mockPlatform } = vi.hoisted(() => ({ mockPlatform: vi.fn().mockReturnValue('linux') }));
+
+vi.mock('@tauri-apps/plugin-os', () => ({
+	platform: mockPlatform,
+}));
+
+const initialState = useProjectStore.getState();
+
+describe('Topbar', () => {
+	beforeEach(() => {
+		mockIsMaximized.mockResolvedValue(false);
+		mockPlatform.mockReturnValue('linux');
+	});
+
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+		vi.clearAllMocks();
+	});
+
+	it('does not render the project selector or save button when no project is open', async () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Topbar />);
+
+		await waitFor(() => {
+			expect(mockIsMaximized).toHaveBeenCalled();
+		});
+		expect(document.querySelector('.project-selector')).toBeNull();
+		expect(screen.queryByTitle('Save (Ctrl+S)')).not.toBeInTheDocument();
+	});
+
+	it('shows the project name and a dirty marker when a project is open and dirty', async () => {
+		useProjectStore.setState({ project: createDefaultProject('My Disc'), isDirty: true });
+
+		render(<Topbar />);
+
+		await waitFor(() => {
+			expect(screen.getByText('My Disc *')).toBeInTheDocument();
+		});
+	});
+
+	it('does not show a dirty marker when the project is clean', async () => {
+		useProjectStore.setState({ project: createDefaultProject('My Disc'), isDirty: false });
+
+		render(<Topbar />);
+
+		await waitFor(() => {
+			expect(screen.getByText('My Disc')).toBeInTheDocument();
+		});
+	});
+
+	it('calls saveProject when the save button is clicked', async () => {
+		const saveProject = vi.fn().mockResolvedValue(undefined);
+		useProjectStore.setState({ project: createDefaultProject('My Disc'), saveProject });
+
+		render(<Topbar />);
+		await waitFor(() => screen.getByTitle('Save (Ctrl+S)'));
+		fireEvent.click(screen.getByTitle('Save (Ctrl+S)'));
+
+		expect(saveProject).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders Linux window controls with minimize/maximize/close handlers', async () => {
+		mockPlatform.mockReturnValue('linux');
+		useProjectStore.setState({ project: null });
+
+		render(<Topbar />);
+		await waitFor(() => expect(document.querySelector('.window-controls.linux')).not.toBeNull());
+
+		fireEvent.click(document.querySelector('.linux-minimize')!);
+		expect(mockMinimize).toHaveBeenCalledTimes(1);
+
+		fireEvent.click(document.querySelector('.linux-close')!);
+		expect(mockClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders Mac window controls when platform is macos', async () => {
+		mockPlatform.mockReturnValue('macos');
+		useProjectStore.setState({ project: null });
+
+		render(<Topbar />);
+
+		await waitFor(() => expect(document.querySelector('.window-controls.mac')).not.toBeNull());
+	});
+
+	it('renders Windows window controls when platform is windows', async () => {
+		mockPlatform.mockReturnValue('windows');
+		useProjectStore.setState({ project: null });
+
+		render(<Topbar />);
+
+		await waitFor(() => expect(document.querySelector('.window-controls.win')).not.toBeNull());
+	});
+
+	it('opens a context menu on right-click and toggles maximise via the menu item', async () => {
+		useProjectStore.setState({ project: null });
+
+		render(<Topbar />);
+		await waitFor(() => expect(mockIsMaximized).toHaveBeenCalled());
+
+		fireEvent.contextMenu(document.querySelector('.topbar')!);
+
+		await waitFor(() => {
+			expect(screen.getByText('Maximise')).toBeInTheDocument();
+		});
+
+		fireEvent.click(screen.getByText('Maximise'));
+		expect(mockToggleMaximize).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- Part of #79: `Topbar`, `Statusbar`, `Sidebar`, `NoProjectState`, and the `ContextMenu/` component cluster — the app's persistent chrome, rendered on every page — had zero tests
- Added 51 tests across 8 new test files:
  - `Topbar.test.tsx` (8): no-project vs. open-project rendering, dirty-marker suffix, save button wiring, per-platform window controls (mac/linux/win), right-click window context menu's maximise toggle
  - `Statusbar.test.tsx` (8): no-project fallback, disc standard/capacity/title/menu-count rendering and pluralisation, unsaved-changes indicator, error/warning validation dot, async app-version load
  - `Sidebar.test.tsx` (8): nav rendering, active-route highlighting, requires-project greyed-out state, badge counts, conditional Build Disc button
  - `NoProjectState.test.tsx` (3): prop rendering, New/Open Project button wiring
  - `ContextMenu/ContextMenu.test.tsx` (6): portal mounting, item-click + close wiring, click-outside/Escape/blur dismissal
  - `ContextMenu/MenuItem.test.tsx` (10): click/disabled/shortcut/checkbox/danger rendering, 250ms/300ms hover-delay submenu open/close (fake timers)
  - `ContextMenu/MenuSection.test.tsx` (4) and `ContextMenu/Submenu.test.tsx` (4): title/separator rendering, submenu portal mounting, click wiring, mousedown propagation stopping
- Does not close #79 — `AssetsPage`, `ChaptersPage`, `LogsPage`, `OverviewPage`, `SettingsPage` are still untested (`app-settings-store.ts` was closed out in #87); those will land in follow-up PRs

## Test plan
- [x] `pnpm vitest run` — 168 passed (117 pre-existing + 51 new)
- [x] `pnpm exec tsc --noEmit` (clean)
- [x] `pnpm exec prettier --check` (clean)
- [x] Independent code review (no @codex review — Codex usage limits exhausted)
