### PR TITLE
test(frontend): add LogsPage, SettingsPage, OverviewPage tests

### DIFF
--- a/apps/spindle/src/pages/LogsPage.test.tsx
+++ b/apps/spindle/src/pages/LogsPage.test.tsx
@@ -1,0 +1,109 @@
+// Tests for the Logs & Diagnostics page.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { createDefaultProject } from '../types/project';
+import { LogsPage } from './LogsPage';
+
+const initialState = useProjectStore.getState();
+
+describe('LogsPage', () => {
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+	});
+
+	it('shows the no-project state when no project is open', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<LogsPage />);
+
+		expect(screen.getByText('No Project Open')).toBeInTheDocument();
+	});
+
+	it('renders the project report with title/chapter/menu/button counts', () => {
+		const project = createDefaultProject('My Disc');
+		project.disc.globalMenus = [
+			{
+				id: 'menu-1',
+				buttons: [{ id: 'btn-1' }, { id: 'btn-2' }],
+			} as any,
+		];
+
+		useProjectStore.setState({ project, validationIssues: [] });
+
+		render(<LogsPage />);
+
+		expect(screen.getByText('My Disc')).toBeInTheDocument();
+		expect(screen.getByText(/DVD-Video/)).toBeInTheDocument();
+		expect(screen.getByText('Buttons').nextElementSibling).toHaveTextContent('2');
+	});
+
+	it('shows "No validation issues" when there are none', () => {
+		useProjectStore.setState({ project: createDefaultProject(), validationIssues: [] });
+
+		render(<LogsPage />);
+
+		expect(
+			screen.getByText('No validation issues. Run validation to check for problems.'),
+		).toBeInTheDocument();
+		expect(screen.getByText('0 issues')).toBeInTheDocument();
+	});
+
+	it('renders validation issues with severity, code, and message', () => {
+		useProjectStore.setState({
+			project: createDefaultProject(),
+			validationIssues: [
+				{ severity: 'error', code: 'E001', message: 'Bad reference' } as any,
+				{ severity: 'warning', code: 'W001', message: 'Maybe fine' } as any,
+			],
+		});
+
+		render(<LogsPage />);
+
+		expect(screen.getByText('2 issues')).toBeInTheDocument();
+		expect(screen.getByText('E001')).toBeInTheDocument();
+		expect(screen.getByText('Bad reference')).toBeInTheDocument();
+		expect(screen.getByText('W001')).toBeInTheDocument();
+		expect(screen.getByText('Maybe fine')).toBeInTheDocument();
+	});
+
+	it('calls validateProject when "Run Validation" is clicked', () => {
+		const validateProject = vi.fn();
+		useProjectStore.setState({ project: createDefaultProject(), validateProject });
+
+		render(<LogsPage />);
+		fireEvent.click(screen.getByText('Run Validation'));
+
+		expect(validateProject).toHaveBeenCalledTimes(1);
+	});
+
+	it('shows asset diagnostics only when assets exist', () => {
+		const project = createDefaultProject();
+		useProjectStore.setState({ project, validationIssues: [] });
+
+		const { rerender } = render(<LogsPage />);
+		expect(screen.queryByText('Asset Diagnostics')).not.toBeInTheDocument();
+
+		project.assets = [
+			{
+				id: 'asset-1',
+				fileName: 'movie.mkv',
+				containerFormat: 'matroska',
+				videoStreams: [],
+				audioStreams: [],
+				subtitleStreams: [],
+				compatibility: 'remux-compatible',
+			} as any,
+		];
+		useProjectStore.setState({ project: { ...project } });
+		rerender(<LogsPage />);
+
+		expect(screen.getByText('Asset Diagnostics')).toBeInTheDocument();
+		expect(screen.getByText('movie.mkv')).toBeInTheDocument();
+		expect(screen.getByText('remux-compatible')).toBeInTheDocument();
+	});
+});

--- a/apps/spindle/src/pages/OverviewPage.test.tsx
+++ b/apps/spindle/src/pages/OverviewPage.test.tsx
@@ -1,0 +1,175 @@
+// Tests for the Overview dashboard page.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { createDefaultProject } from '../types/project';
+import { OverviewPage } from './OverviewPage';
+import type { CapacityEstimate } from 'tauri-plugin-spindle-project-api';
+
+const { estimateDiscCapacity } = vi.hoisted(() => ({
+	estimateDiscCapacity: vi.fn(),
+}));
+
+vi.mock('tauri-plugin-spindle-project-api', () => ({
+	estimateDiscCapacity,
+}));
+
+function buildEstimate(overrides: Partial<CapacityEstimate> = {}): CapacityEstimate {
+	return {
+		capacityBytes: 4_700_000_000,
+		totalDurationSecs: 0,
+		estimatedMenuBytes: 0,
+		safetyMarginBytes: 50_000_000,
+		estimatedOverheadBytes: 0,
+		usableBytes: 4_650_000_000,
+		availableBitsPerSecond: 9_800_000,
+		isCapacityConstrained: false,
+		estimatedOutputBytes: 0,
+		usagePct: 0,
+		isOverCapacity: false,
+		titleBitrates: [],
+		floorInfeasible: false,
+		...overrides,
+	};
+}
+
+const initialState = useProjectStore.getState();
+
+describe('OverviewPage', () => {
+	beforeEach(() => {
+		estimateDiscCapacity.mockReset();
+		estimateDiscCapacity.mockResolvedValue(buildEstimate());
+	});
+
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+	});
+
+	it('shows the no-project welcome state when no project is open', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<OverviewPage />);
+
+		expect(screen.getByText('Welcome to Spindle')).toBeInTheDocument();
+	});
+
+	it('renders title/asset/menu/chapter stat counts', async () => {
+		const project = createDefaultProject('My Disc');
+		project.disc.globalMenus = [{ id: 'menu-1' } as any];
+		project.assets = [{ id: 'asset-1' } as any];
+
+		useProjectStore.setState({ project, validationIssues: [] });
+
+		render(<OverviewPage />);
+
+		await waitFor(() => expect(estimateDiscCapacity).toHaveBeenCalled());
+
+		expect(screen.getByDisplayValue('My Disc')).toBeInTheDocument();
+		expect(screen.getByText('Titles')).toBeInTheDocument();
+		expect(screen.getByText('Assets')).toBeInTheDocument();
+		expect(screen.getByText('Menus')).toBeInTheDocument();
+		expect(screen.getByText('Chapters')).toBeInTheDocument();
+	});
+
+	it('renames the project when the title input changes', async () => {
+		const project = createDefaultProject('Old Name');
+		useProjectStore.setState({ project, validationIssues: [] });
+
+		render(<OverviewPage />);
+		fireEvent.change(screen.getByDisplayValue('Old Name'), { target: { value: 'New Name' } });
+
+		expect(useProjectStore.getState().project?.project.name).toBe('New Name');
+	});
+
+	it('shows "No titles added yet" when capacity is loaded but there are no titles', async () => {
+		useProjectStore.setState({ project: createDefaultProject(), validationIssues: [] });
+
+		render(<OverviewPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/No titles added yet/)).toBeInTheDocument();
+		});
+	});
+
+	it('shows "Calculating…" before the capacity estimate resolves', () => {
+		estimateDiscCapacity.mockReturnValue(new Promise(() => {})); // never resolves
+		useProjectStore.setState({ project: createDefaultProject(), validationIssues: [] });
+
+		render(<OverviewPage />);
+
+		expect(screen.getByText('Calculating…')).toBeInTheDocument();
+	});
+
+	it('shows estimated/remaining bytes once titles exist and capacity has loaded', async () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [{ id: 'title-1', chapters: [] } as any];
+		estimateDiscCapacity.mockResolvedValue(
+			buildEstimate({ estimatedOutputBytes: 1_000_000_000, usableBytes: 4_650_000_000 }),
+		);
+
+		useProjectStore.setState({ project, validationIssues: [] });
+
+		render(<OverviewPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/estimated/)).toBeInTheDocument();
+		});
+		expect(screen.getByText(/remaining/)).toBeInTheDocument();
+	});
+
+	it('shows "No issues found" when there are no validation issues and titles exist', async () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [{ id: 'title-1', chapters: [] } as any];
+		useProjectStore.setState({ project, validationIssues: [] });
+
+		render(<OverviewPage />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('No issues found. Project looks ready to build.'),
+			).toBeInTheDocument();
+		});
+	});
+
+	it('renders validation issue rows when issues exist', async () => {
+		useProjectStore.setState({
+			project: createDefaultProject(),
+			validationIssues: [
+				{ severity: 'error', message: 'Dangling reference', suggestedFix: 'Remove it' } as any,
+			],
+		});
+
+		render(<OverviewPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Dangling reference')).toBeInTheDocument();
+		});
+		expect(screen.getByText('Remove it')).toBeInTheDocument();
+	});
+
+	it('updates the video standard when the select changes', () => {
+		useProjectStore.setState({ project: createDefaultProject(), validationIssues: [] });
+
+		render(<OverviewPage />);
+		fireEvent.change(screen.getByDisplayValue('NTSC (29.97 fps, 720×480)'), {
+			target: { value: 'PAL' },
+		});
+
+		expect(useProjectStore.getState().project?.disc.standard).toBe('PAL');
+	});
+
+	it('updates generateIso when the ISO checkbox is toggled', () => {
+		useProjectStore.setState({ project: createDefaultProject(), validationIssues: [] });
+
+		render(<OverviewPage />);
+		fireEvent.click(
+			screen.getByText('Generate ISO image').closest('label')!.querySelector('input')!,
+		);
+
+		expect(useProjectStore.getState().project?.buildSettings.generateIso).toBe(true);
+	});
+});

--- a/apps/spindle/src/pages/SettingsPage.test.tsx
+++ b/apps/spindle/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,223 @@
+// Tests for the Settings page.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { useAppSettingsStore } from '../store/app-settings-store';
+import { createDefaultProject } from '../types/project';
+import { SettingsPage } from './SettingsPage';
+
+const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
+const { mockConfirm, mockSave } = vi.hoisted(() => ({
+	mockConfirm: vi.fn(),
+	mockSave: vi.fn(),
+}));
+const { mockExportDiagnostics } = vi.hoisted(() => ({ mockExportDiagnostics: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({
+	invoke: mockInvoke,
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+	confirm: mockConfirm,
+	save: mockSave,
+}));
+
+vi.mock('tauri-plugin-spindle-project-api', () => ({
+	exportDiagnostics: mockExportDiagnostics,
+}));
+
+const initialProjectState = useProjectStore.getState();
+const initialSettingsState = useAppSettingsStore.getState();
+
+describe('SettingsPage', () => {
+	beforeEach(() => {
+		mockInvoke.mockReset();
+		mockInvoke.mockResolvedValue({ path: '/cache/thumbnails', sizeBytes: 0, fileCount: 0 });
+		mockConfirm.mockReset();
+		mockSave.mockReset();
+		mockExportDiagnostics.mockReset();
+	});
+
+	afterEach(() => {
+		useProjectStore.setState(initialProjectState, true);
+		useAppSettingsStore.setState(initialSettingsState, true);
+	});
+
+	it('checks the toolchain on mount', () => {
+		const checkToolchain = vi.fn();
+		useProjectStore.setState({ checkToolchain });
+
+		render(<SettingsPage />);
+
+		expect(checkToolchain).toHaveBeenCalled();
+	});
+
+	it('shows "Checking toolchain…" when no toolchain entries are loaded yet', () => {
+		useProjectStore.setState({ toolchain: [], checkToolchain: vi.fn() });
+
+		render(<SettingsPage />);
+
+		expect(screen.getByText('Checking toolchain…')).toBeInTheDocument();
+	});
+
+	it('renders toolchain entries with availability and version', () => {
+		useProjectStore.setState({
+			checkToolchain: vi.fn(),
+			toolchain: [
+				{ name: 'ffmpeg', purpose: 'encode', available: true, version: '6.0' },
+				{ name: 'dvdauthor', purpose: 'author', available: false, version: null },
+			],
+		});
+
+		render(<SettingsPage />);
+
+		expect(screen.getByText('ffmpeg')).toBeInTheDocument();
+		expect(screen.getByText('6.0')).toBeInTheDocument();
+		expect(screen.getByText('dvdauthor')).toBeInTheDocument();
+	});
+
+	it('loads and displays thumbnail cache status on mount', async () => {
+		mockInvoke.mockResolvedValue({ path: '/cache/thumbs', sizeBytes: 2_000_000, fileCount: 5 });
+		useProjectStore.setState({ checkToolchain: vi.fn() });
+
+		render(<SettingsPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Items').nextElementSibling).toHaveTextContent('5');
+		});
+		expect(screen.getByText('Size').nextElementSibling).toHaveTextContent('2.0 MB');
+		expect(screen.getByText('/cache/thumbs')).toBeInTheDocument();
+	});
+
+	it('shows a cache error message when the cache status lookup fails', async () => {
+		mockInvoke.mockRejectedValue(new Error('cache unavailable'));
+		useProjectStore.setState({ checkToolchain: vi.fn() });
+
+		render(<SettingsPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText('cache unavailable')).toBeInTheDocument();
+		});
+	});
+
+	it('clears the thumbnail cache after confirmation', async () => {
+		mockInvoke.mockResolvedValueOnce({ path: '/cache', sizeBytes: 1000, fileCount: 3 });
+		mockConfirm.mockResolvedValue(true);
+		useProjectStore.setState({ checkToolchain: vi.fn() });
+
+		render(<SettingsPage />);
+		await waitFor(() =>
+			expect(screen.getByText('Items').nextElementSibling).toHaveTextContent('3'),
+		);
+
+		mockInvoke.mockResolvedValueOnce(undefined); // clear_thumbnail_cache
+		mockInvoke.mockResolvedValueOnce({ path: '/cache', sizeBytes: 0, fileCount: 0 }); // refresh
+
+		fireEvent.click(screen.getByText('Clear Thumbnail Cache'));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith('clear_thumbnail_cache');
+		});
+	});
+
+	it('does not clear the thumbnail cache when the confirmation is declined', async () => {
+		mockInvoke.mockResolvedValueOnce({ path: '/cache', sizeBytes: 1000, fileCount: 3 });
+		mockConfirm.mockResolvedValue(false);
+		useProjectStore.setState({ checkToolchain: vi.fn() });
+
+		render(<SettingsPage />);
+		await waitFor(() =>
+			expect(screen.getByText('Items').nextElementSibling).toHaveTextContent('3'),
+		);
+
+		fireEvent.click(screen.getByText('Clear Thumbnail Cache'));
+
+		await waitFor(() => {
+			expect(mockConfirm).toHaveBeenCalled();
+		});
+		expect(mockInvoke).not.toHaveBeenCalledWith('clear_thumbnail_cache');
+	});
+
+	it('toggles devSkipSidecar and re-checks the toolchain', async () => {
+		const setDevSkipSidecar = vi.fn().mockResolvedValue(undefined);
+		const checkToolchain = vi.fn();
+		useAppSettingsStore.setState({ setDevSkipSidecar });
+		useProjectStore.setState({ checkToolchain });
+
+		render(<SettingsPage />);
+		checkToolchain.mockClear();
+
+		fireEvent.click(
+			screen.getByText('Skip bundled sidecars').closest('label')!.querySelector('input')!,
+		);
+
+		expect(setDevSkipSidecar).toHaveBeenCalledWith(true);
+		expect(checkToolchain).toHaveBeenCalled();
+	});
+
+	it('toggles devSkipUnsupportedStreams without re-checking the toolchain', () => {
+		const setDevSkipUnsupportedStreams = vi.fn().mockResolvedValue(undefined);
+		const checkToolchain = vi.fn();
+		useAppSettingsStore.setState({ setDevSkipUnsupportedStreams });
+		useProjectStore.setState({ checkToolchain });
+
+		render(<SettingsPage />);
+		checkToolchain.mockClear();
+
+		fireEvent.click(
+			screen.getByText('Skip unsupported streams').closest('label')!.querySelector('input')!,
+		);
+
+		expect(setDevSkipUnsupportedStreams).toHaveBeenCalledWith(true);
+		expect(checkToolchain).not.toHaveBeenCalled();
+	});
+
+	it('toggles devQuantizeOverlayPalette without re-checking the toolchain', () => {
+		const setDevQuantizeOverlayPalette = vi.fn().mockResolvedValue(undefined);
+		const checkToolchain = vi.fn();
+		useAppSettingsStore.setState({ setDevQuantizeOverlayPalette });
+		useProjectStore.setState({ checkToolchain });
+
+		render(<SettingsPage />);
+		checkToolchain.mockClear();
+
+		fireEvent.click(
+			screen.getByText('Quantize overlay palette (dev)').closest('label')!.querySelector('input')!,
+		);
+
+		expect(setDevQuantizeOverlayPalette).toHaveBeenCalledWith(true);
+		expect(checkToolchain).not.toHaveBeenCalled();
+	});
+
+	it('exports diagnostics via dialog save and write_text_file', async () => {
+		useProjectStore.setState({ project: createDefaultProject(), checkToolchain: vi.fn() });
+		mockExportDiagnostics.mockResolvedValue('{"diagnostics":true}');
+		mockSave.mockResolvedValue('/tmp/diagnostics.json');
+
+		render(<SettingsPage />);
+		fireEvent.click(screen.getByText('Export Diagnostics…'));
+
+		await waitFor(() => {
+			expect(mockInvoke).toHaveBeenCalledWith('write_text_file', {
+				path: '/tmp/diagnostics.json',
+				contents: '{"diagnostics":true}',
+			});
+		});
+	});
+
+	it('does not write a file when the export save dialog is cancelled', async () => {
+		useProjectStore.setState({ project: createDefaultProject(), checkToolchain: vi.fn() });
+		mockExportDiagnostics.mockResolvedValue('{}');
+		mockSave.mockResolvedValue(null);
+
+		render(<SettingsPage />);
+		fireEvent.click(screen.getByText('Export Diagnostics…'));
+
+		await waitFor(() => expect(mockSave).toHaveBeenCalled());
+		expect(mockInvoke).not.toHaveBeenCalledWith('write_text_file', expect.anything());
+	});
+});


### PR DESCRIPTION
## Summary
- Part of #79: `LogsPage`, `SettingsPage`, and `OverviewPage` had zero tests
- Added 28 tests across 3 new test files:
  - `LogsPage.test.tsx` (6): no-project state, project-report counts, validation-issue rendering (and the "no issues" fallback), "Run Validation" wiring, conditional asset-diagnostics card
  - `SettingsPage.test.tsx` (13): toolchain check on mount and rendering, thumbnail-cache load/error/clear flows (including declined-confirmation), all three dev-toggle switches, and the export-diagnostics save/write flow including a cancelled save dialog
  - `OverviewPage.test.tsx` (10): no-project welcome state, stat counts, project renaming, capacity bar's calculating/no-titles/estimated-remaining states, validation health summary, video-standard/ISO settings selects
- Does not close #79 — `AssetsPage` and `ChaptersPage` are still untested; those will land in a follow-up PR

## Test plan
- [x] `pnpm vitest run` — 196 passed (168 pre-existing + 28 new)
- [x] `pnpm exec tsc --noEmit` (clean)
- [x] `pnpm exec prettier --check` (clean)
- [x] Independent code review (no @codex review — Codex usage limits exhausted)
