### PR TITLE
test(frontend): add AssetsPage and ChaptersPage tests

### DIFF
--- a/apps/spindle/src/pages/AssetsPage.test.tsx
+++ b/apps/spindle/src/pages/AssetsPage.test.tsx
@@ -1,0 +1,282 @@
+// Tests for the Assets page.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { createDefaultProject } from '../types/project';
+import { AssetsPage } from './AssetsPage';
+import type { Asset } from 'tauri-plugin-spindle-project-api';
+
+const { mockReadFile } = vi.hoisted(() => ({ mockReadFile: vi.fn() }));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+	BaseDirectory: { AppCache: 0 },
+	readFile: mockReadFile,
+}));
+
+function buildAsset(overrides: Partial<Asset> = {}): Asset {
+	return {
+		id: 'asset-1',
+		fileName: 'feature.mkv',
+		sourcePath: '/media/feature.mkv',
+		fileSizeBytes: 2_000_000_000,
+		durationSecs: 3725,
+		containerFormat: 'matroska',
+		videoStreams: [],
+		audioStreams: [],
+		subtitleStreams: [],
+		compatibility: null,
+		fingerprint: null,
+		compatibilityDetail: null,
+		warnings: [],
+		thumbnailPath: null,
+		thumbnailError: null,
+		sourceChapters: [],
+		formatTitle: null,
+		...overrides,
+	};
+}
+
+const initialState = useProjectStore.getState();
+
+describe('AssetsPage', () => {
+	beforeEach(() => {
+		mockReadFile.mockReset();
+		mockReadFile.mockRejectedValue(new Error('no thumbnail'));
+	});
+
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+	});
+
+	it('shows the no-project state when no project is open', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<AssetsPage />);
+
+		expect(screen.getByText('No Project Open')).toBeInTheDocument();
+	});
+
+	it('shows the empty-assets view and calls importAssets when there are no assets', () => {
+		const importAssets = vi.fn();
+		const project = createDefaultProject();
+		useProjectStore.setState({ project, importAssets });
+
+		render(<AssetsPage />);
+		expect(screen.getByText('No assets imported')).toBeInTheDocument();
+
+		fireEvent.click(screen.getAllByText('Import Media')[0]);
+		expect(importAssets).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders an asset row with duration, container, and size', () => {
+		const project = createDefaultProject();
+		project.assets = [buildAsset()];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+
+		expect(screen.getByText('feature.mkv')).toBeInTheDocument();
+		expect(screen.getByText('1:02:05')).toBeInTheDocument();
+		expect(screen.getByText('matroska')).toBeInTheDocument();
+		expect(screen.getByText('2.0 GB')).toBeInTheDocument();
+	});
+
+	it('shows stream-count badges for video/audio/subtitle streams', () => {
+		const project = createDefaultProject();
+		project.assets = [
+			buildAsset({
+				videoStreams: [{ index: 0 } as any],
+				audioStreams: [{ index: 0 } as any, { index: 1 } as any],
+				subtitleStreams: [{ index: 0 } as any],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+
+		expect(screen.getByText('1 video')).toBeInTheDocument();
+		expect(screen.getByText('2 audio')).toBeInTheDocument();
+		expect(screen.getByText('1 sub')).toBeInTheDocument();
+	});
+
+	it('shows the "image" badge for still-image assets', () => {
+		const project = createDefaultProject();
+		project.assets = [buildAsset({ fileName: 'cover.png' })];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+
+		expect(screen.getByText('image')).toBeInTheDocument();
+	});
+
+	it('selects an asset on click and shows its detail panel', () => {
+		const project = createDefaultProject();
+		project.assets = [buildAsset()];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+		fireEvent.click(screen.getByText('feature.mkv'));
+
+		expect(screen.getByText('/media/feature.mkv')).toBeInTheDocument();
+		expect(screen.getByText('Relink…')).toBeInTheDocument();
+	});
+
+	it('calls removeAsset and clears selection when Remove is clicked', () => {
+		const removeAsset = vi.fn();
+		const project = createDefaultProject();
+		project.assets = [buildAsset()];
+		useProjectStore.setState({ project, removeAsset });
+
+		render(<AssetsPage />);
+		fireEvent.click(screen.getByText('feature.mkv'));
+		fireEvent.click(screen.getByText('Remove'));
+
+		expect(removeAsset).toHaveBeenCalledWith('asset-1');
+		expect(screen.queryByText('/media/feature.mkv')).not.toBeInTheDocument();
+	});
+
+	it('calls relinkAsset when Relink is clicked', () => {
+		const relinkAsset = vi.fn().mockResolvedValue(undefined);
+		const project = createDefaultProject();
+		project.assets = [buildAsset()];
+		useProjectStore.setState({ project, relinkAsset });
+
+		render(<AssetsPage />);
+		fireEvent.click(screen.getByText('feature.mkv'));
+		fireEvent.click(screen.getByText('Relink…'));
+
+		expect(relinkAsset).toHaveBeenCalledWith('asset-1');
+	});
+
+	it('renders video/audio/subtitle stream details when present', () => {
+		const project = createDefaultProject();
+		project.assets = [
+			buildAsset({
+				videoStreams: [
+					{ index: 0, codec: 'h264', width: 1920, height: 1080, frameRate: 23.976 } as any,
+				],
+				audioStreams: [
+					{ index: 0, codec: 'aac', channels: 2, sampleRate: 48000, language: 'eng' } as any,
+				],
+				subtitleStreams: [
+					{ index: 0, codec: 'subrip', subtitleType: 'text', language: 'eng' } as any,
+				],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+		fireEvent.click(screen.getByText('feature.mkv'));
+
+		expect(screen.getByText('Video Streams')).toBeInTheDocument();
+		expect(screen.getByText(/h264/)).toBeInTheDocument();
+		expect(screen.getByText('Audio Streams')).toBeInTheDocument();
+		expect(screen.getByText(/aac/)).toBeInTheDocument();
+		expect(screen.getByText('Subtitle Streams')).toBeInTheDocument();
+		expect(screen.getByText(/subrip/)).toBeInTheDocument();
+	});
+
+	it('shows asset warnings in both the row and the detail panel', () => {
+		const project = createDefaultProject();
+		project.assets = [buildAsset({ warnings: [{ code: 'W1', message: 'Unusual frame rate' }] })];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+
+		expect(screen.getByText('Unusual frame rate')).toBeInTheDocument();
+		fireEvent.click(screen.getByText('feature.mkv'));
+		expect(screen.getAllByText('Unusual frame rate').length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('shows a compatibility badge based on the assessment', () => {
+		const project = createDefaultProject();
+		project.assets = [buildAsset({ compatibility: 're-encode-required' })];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+
+		expect(screen.getByText('Re-encode')).toBeInTheDocument();
+	});
+
+	it('expands compatibility detail rows when "Show details" is clicked', () => {
+		const project = createDefaultProject();
+		project.assets = [
+			buildAsset({
+				compatibility: 're-encode-required',
+				compatibilityDetail: {
+					overall: 're-encode-required',
+					video: {
+						codec: { value: 'hevc', dvdRequires: 'mpeg2', action: 'transcode', compatible: false },
+						resolution: {
+							value: '1920x1080',
+							dvdRequires: '720x480',
+							action: 'scale',
+							compatible: false,
+						},
+						frameRate: { value: '24', dvdRequires: '29.97', action: 'none', compatible: true },
+					},
+					audioStreams: [],
+					container: {
+						format: { value: 'matroska', dvdRequires: 'vob', action: 'remux', compatible: false },
+					},
+				},
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+		fireEvent.click(screen.getByText('feature.mkv'));
+		fireEvent.click(screen.getByText('Show details'));
+
+		expect(screen.getByText('Video codec')).toBeInTheDocument();
+		expect(screen.getByText('hevc')).toBeInTheDocument();
+		expect(screen.getByText('Hide details')).toBeInTheDocument();
+	});
+
+	it('loads a still-image preview via readFile and renders an img element', async () => {
+		mockReadFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+		const project = createDefaultProject();
+		project.assets = [buildAsset({ fileName: 'cover.png', sourcePath: '/media/cover.png' })];
+		useProjectStore.setState({ project });
+
+		const { container } = render(<AssetsPage />);
+
+		await waitFor(() => {
+			expect(mockReadFile).toHaveBeenCalledWith('/media/cover.png');
+		});
+		await waitFor(() => {
+			expect(container.querySelector('img.assets__row-thumb')).not.toBeNull();
+		});
+	});
+
+	it('retries once before showing a failure placeholder for a non-still-image thumbnail', async () => {
+		mockReadFile.mockRejectedValue(new Error('not found'));
+		const project = createDefaultProject();
+		project.assets = [buildAsset({ thumbnailPath: '/cache/thumbnails/abc.jpg' })];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+
+		await waitFor(() => {
+			expect(mockReadFile).toHaveBeenCalledTimes(2);
+		});
+		expect(mockReadFile).toHaveBeenCalledWith('thumbnails/abc.jpg', { baseDir: 0 });
+		await waitFor(() => {
+			expect(screen.getByText('!')).toBeInTheDocument();
+		});
+	});
+
+	it('shows a placeholder when no thumbnail is available', () => {
+		const project = createDefaultProject();
+		project.assets = [buildAsset()];
+		useProjectStore.setState({ project });
+
+		render(<AssetsPage />);
+
+		expect(screen.getByText('No preview')).toBeInTheDocument();
+	});
+});

--- a/apps/spindle/src/pages/ChaptersPage.test.tsx
+++ b/apps/spindle/src/pages/ChaptersPage.test.tsx
@@ -1,0 +1,297 @@
+// Tests for the Chapters page.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useProjectStore } from '../store/project-store';
+import { createDefaultProject } from '../types/project';
+import type { Title } from 'tauri-plugin-spindle-project-api';
+import { ChaptersPage } from './ChaptersPage';
+
+function buildTitle(overrides: Partial<Title> = {}): Title {
+	return {
+		id: 'title-1',
+		name: 'Feature',
+		sourceAssetId: null,
+		videoMapping: null,
+		videoOutputProfile: null,
+		audioMappings: [],
+		subtitleMappings: [],
+		chapters: [],
+		endAction: null,
+		orderIndex: 0,
+		bitrateWeight: 1,
+		bitrateFloorBps: null,
+		bitrateCeilingBps: null,
+		pinnedBitrateBps: null,
+		...overrides,
+	};
+}
+
+const initialState = useProjectStore.getState();
+
+describe('ChaptersPage', () => {
+	beforeEach(() => {
+		window.confirm = vi.fn().mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		useProjectStore.setState(initialState, true);
+		vi.restoreAllMocks();
+	});
+
+	it('shows the no-project state when no project is open', () => {
+		useProjectStore.setState({ project: null });
+
+		render(<ChaptersPage />);
+
+		expect(screen.getByText('No Project Open')).toBeInTheDocument();
+	});
+
+	it('shows "No titles available" when the project has no titles', () => {
+		useProjectStore.setState({ project: createDefaultProject() });
+
+		render(<ChaptersPage />);
+
+		expect(screen.getByText('No titles available')).toBeInTheDocument();
+	});
+
+	it('lists titles with chapter-count badges', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [
+			buildTitle({ id: 't1', name: 'Feature', chapters: [{ id: 'c1' } as any] }),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+
+		expect(screen.getByText('Feature')).toBeInTheDocument();
+		expect(screen.getByText('1 ch')).toBeInTheDocument();
+	});
+
+	it('prompts to select a title before showing the editor', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [buildTitle()];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+
+		expect(screen.getByText('Select a title to manage its chapters.')).toBeInTheDocument();
+	});
+
+	it('shows "Add First Chapter" when a title with no chapters is selected', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [buildTitle()];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+
+		expect(screen.getByText('No chapters for "Feature" yet.')).toBeInTheDocument();
+		expect(screen.getByText('Add First Chapter')).toBeInTheDocument();
+	});
+
+	it('adds a chapter when "Add Chapter" is clicked', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [buildTitle()];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.click(screen.getByText('Add First Chapter'));
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters).toHaveLength(1);
+		expect(updatedTitle.chapters[0].name).toBe('Chapter 1');
+		expect(updatedTitle.chapters[0].timestampSecs).toBe(0);
+	});
+
+	it('appends a new chapter 60 seconds after the last one via the header Add Chapter button', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				chapters: [{ id: 'c1', name: 'Chapter 1', timestampSecs: 120, orderIndex: 0 }],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.click(screen.getByText('Add Chapter'));
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters).toHaveLength(2);
+		expect(updatedTitle.chapters[1].timestampSecs).toBe(180);
+	});
+
+	it('renders existing chapters with name and formatted timestamp inputs', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				chapters: [{ id: 'c1', name: 'Intro', timestampSecs: 65, orderIndex: 0 }],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+
+		expect(screen.getByDisplayValue('Intro')).toBeInTheDocument();
+		expect(screen.getByDisplayValue('0:01:05')).toBeInTheDocument();
+	});
+
+	it('renames a chapter when its name input changes', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				chapters: [{ id: 'c1', name: 'Intro', timestampSecs: 0, orderIndex: 0 }],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.change(screen.getByDisplayValue('Intro'), { target: { value: 'Opening' } });
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters[0].name).toBe('Opening');
+	});
+
+	it('re-sorts chapters by timestamp when a chapter time is edited', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				chapters: [
+					{ id: 'c1', name: 'First', timestampSecs: 0, orderIndex: 0 },
+					{ id: 'c2', name: 'Second', timestampSecs: 60, orderIndex: 1 },
+				],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.change(screen.getByDisplayValue('0:00:00'), { target: { value: '0:02:00' } });
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters.map((c: any) => c.name)).toEqual(['Second', 'First']);
+		expect(updatedTitle.chapters[1].orderIndex).toBe(1);
+	});
+
+	it('ignores an unparseable timestamp edit', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				chapters: [{ id: 'c1', name: 'Intro', timestampSecs: 30, orderIndex: 0 }],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.change(screen.getByDisplayValue('0:00:30'), { target: { value: 'garbage' } });
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters[0].timestampSecs).toBe(30);
+	});
+
+	it('removes a chapter and re-indexes the rest', () => {
+		const project = createDefaultProject();
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				chapters: [
+					{ id: 'c1', name: 'First', timestampSecs: 0, orderIndex: 0 },
+					{ id: 'c2', name: 'Second', timestampSecs: 60, orderIndex: 1 },
+				],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.click(screen.getAllByTitle('Remove chapter')[0]);
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters).toHaveLength(1);
+		expect(updatedTitle.chapters[0].name).toBe('Second');
+		expect(updatedTitle.chapters[0].orderIndex).toBe(0);
+	});
+
+	it('does not show "Seed from Source" when the asset has no source chapters', () => {
+		const project = createDefaultProject();
+		project.assets = [{ id: 'asset-1', sourceChapters: [] } as any];
+		project.disc.titlesets[0].titles = [buildTitle({ sourceAssetId: 'asset-1' })];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+
+		expect(screen.queryByText('Seed from Source')).not.toBeInTheDocument();
+	});
+
+	it('seeds chapters from the source asset when "Seed from Source" is clicked', () => {
+		const project = createDefaultProject();
+		project.assets = [
+			{
+				id: 'asset-1',
+				sourceChapters: [
+					{ startSecs: 0, endSecs: 60, title: 'Opening' },
+					{ startSecs: 60, endSecs: 120, title: null },
+				],
+			} as any,
+		];
+		project.disc.titlesets[0].titles = [buildTitle({ sourceAssetId: 'asset-1' })];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.click(screen.getByText('Seed from Source'));
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters).toHaveLength(2);
+		expect(updatedTitle.chapters[0].name).toBe('Opening');
+		expect(updatedTitle.chapters[1].name).toBe('Chapter 2');
+	});
+
+	it('asks for confirmation before replacing existing chapters via seed-from-source', () => {
+		window.confirm = vi.fn().mockReturnValue(false);
+		const project = createDefaultProject();
+		project.assets = [
+			{ id: 'asset-1', sourceChapters: [{ startSecs: 0, endSecs: 60, title: 'Opening' }] } as any,
+		];
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				sourceAssetId: 'asset-1',
+				chapters: [{ id: 'c1', name: 'Existing', timestampSecs: 0, orderIndex: 0 }],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+		fireEvent.click(screen.getByText('Seed from Source'));
+
+		const updatedTitle = useProjectStore.getState().project!.disc.titlesets[0].titles[0];
+		expect(updatedTitle.chapters).toHaveLength(1);
+		expect(updatedTitle.chapters[0].name).toBe('Existing');
+	});
+
+	it('renders a chapter timeline mark when the source asset has a known duration', () => {
+		const project = createDefaultProject();
+		project.assets = [{ id: 'asset-1', durationSecs: 600 } as any];
+		project.disc.titlesets[0].titles = [
+			buildTitle({
+				sourceAssetId: 'asset-1',
+				chapters: [{ id: 'c1', name: 'Mid', timestampSecs: 300, orderIndex: 0 }],
+			}),
+		];
+		useProjectStore.setState({ project });
+
+		const { container } = render(<ChaptersPage />);
+		fireEvent.click(screen.getByText('Feature'));
+
+		expect(container.querySelector('.chapters__timeline-mark')).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- Part of #79: `AssetsPage` and `ChaptersPage` had zero tests, the last untested surface from the issue's original list
- Added 31 tests across 2 new test files:
  - `AssetsPage.test.tsx` (15): no-project state, empty-assets import prompt, asset-row rendering (duration/container/size, stream-count badges, still-image badge), selection + detail panel, remove/relink wiring, per-stream-type detail sections, warnings, the compatibility badge and its expandable detail table, and the thumbnail loader's three paths (still-image success, retry-then-fail for non-still thumbnails, no-thumbnail placeholder)
  - `ChaptersPage.test.tsx` (16): no-project/no-titles states, title list with chapter-count badges, adding the first/subsequent chapter, renaming and re-sorting on timestamp edit, ignoring unparseable timestamps, removing + re-indexing, the conditional "Seed from Source" button and its confirm-before-replacing guard, and timeline rendering
- Closes the #79 follow-up batch — combined with #87 (app-settings-store), #88 (app chrome), and #89 (simple pages), every page/component issue #79 called out as untested now has coverage

## Test plan
- [x] `pnpm vitest run` — 227 passed (196 pre-existing + 31 new)
- [x] `pnpm exec tsc --noEmit` (clean)
- [x] `pnpm exec prettier --check` (clean)
- [x] Independent code review (no @codex review — Codex usage limits exhausted)

Closes #79