### PR TITLE
feat(build): add opt-in two-pass title encoding; fix single-pass CBR and silent-audio ordering bug

### DIFF
--- a/apps/spindle/src/pages/OverviewPage.test.tsx
+++ b/apps/spindle/src/pages/OverviewPage.test.tsx
@@ -172,4 +172,18 @@ describe('OverviewPage', () => {
 
 		expect(useProjectStore.getState().project?.buildSettings.generateIso).toBe(true);
 	});
+
+	it('updates twoPassVideoEncoding when the two-pass checkbox is toggled', () => {
+		useProjectStore.setState({ project: createDefaultProject(), validationIssues: [] });
+
+		render(<OverviewPage />);
+		fireEvent.click(
+			screen
+				.getByText('Two-pass encoding (slower, more accurate sizing & quality)')
+				.closest('label')!
+				.querySelector('input')!,
+		);
+
+		expect(useProjectStore.getState().project?.buildSettings.twoPassVideoEncoding).toBe(true);
+	});
 });

--- a/apps/spindle/src/pages/OverviewPage.tsx
+++ b/apps/spindle/src/pages/OverviewPage.tsx
@@ -220,6 +220,25 @@ export function OverviewPage() {
 						</label>
 					</div>
 					<div className="overview__setting">
+						<label className="overview__setting-label">Video Encoding</label>
+						<label className="overview__setting-checkbox">
+							<input
+								type="checkbox"
+								checked={project.buildSettings.twoPassVideoEncoding ?? false}
+								onChange={(e) =>
+									updateProject((p) => ({
+										...p,
+										buildSettings: {
+											...p.buildSettings,
+											twoPassVideoEncoding: e.target.checked,
+										},
+									}))
+								}
+							/>
+							Two-pass encoding (slower, more accurate sizing &amp; quality)
+						</label>
+					</div>
+					<div className="overview__setting">
 						<label className="overview__setting-label">First Play</label>
 						<select
 							className="overview__setting-select"

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -529,6 +529,10 @@ export interface BuildSettings {
 	safetyMarginBytes: number;
 	allocationStrategy: AllocationStrategy;
 	subtitleRenderMode?: 'one-pass' | 'two-pass';
+	/** Two-pass title-video encoding for more accurate output sizing and
+	 * better quality-per-byte, at roughly double the per-title encode time.
+	 * Defaults to false. */
+	twoPassVideoEncoding?: boolean;
 }
 
 // ── Validation ──────────────────────────────────────────────────────────────

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
@@ -269,10 +269,50 @@ where
                 }
             }
             BuildJob::TranscodeTitle {
+                pass1_command,
                 command,
                 duration_secs,
                 ..
             } => {
+                if let Some(pass1_command) = pass1_command {
+                    log_lines.push(format!("  $ {}", pass1_command.join(" ")));
+
+                    on_progress(BuildProgress::job(
+                        i,
+                        total,
+                        label.clone(),
+                        BuildJobStatus::Running,
+                        None,
+                    ));
+
+                    match run_ffmpeg_command(
+                        pass1_command,
+                        *duration_secs,
+                        i,
+                        total,
+                        &label,
+                        "Two-pass analysis (pass 1/2)",
+                        &mut on_progress,
+                    ) {
+                        Ok(output) => {
+                            if !output.is_empty() {
+                                log_lines.push(output);
+                            }
+                        }
+                        Err(msg) => {
+                            log_lines.push(msg.clone());
+                            on_progress(BuildProgress::job(
+                                i,
+                                total,
+                                label,
+                                BuildJobStatus::Failed,
+                                Some(msg.clone()),
+                            ));
+                            return failure(plan, log_lines, i, msg);
+                        }
+                    }
+                }
+
                 log_lines.push(format!("  $ {}", command.join(" ")));
 
                 on_progress(BuildProgress::job(
@@ -289,7 +329,11 @@ where
                     i,
                     total,
                     &label,
-                    "FFmpeg transcode",
+                    if pass1_command.is_some() {
+                        "Two-pass encode (pass 2/2)"
+                    } else {
+                        "FFmpeg transcode"
+                    },
                     &mut on_progress,
                 ) {
                     Ok(output) => {

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/tests.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::build::ffmpeg::{build_ffmpeg_transcode_command, build_ffmpeg_transcode_pass1_command};
 use crate::build::test_support::{test_menu_with_action, test_project};
 use crate::build::{
     execute_build_plan, generate_build_plan, BuildJob, BuildPlan, BuildProgress, BuildSummary,
@@ -162,6 +163,129 @@ fn execute_build_plan_skips_empty_text_subtitle_passes() {
             .as_ref()
             .is_some_and(|line| line.contains("had no cues"))),
         "expected progress updates to mention the skipped subtitle pass"
+    );
+
+    fs::remove_dir_all(&output_dir).unwrap();
+}
+
+#[test]
+#[ignore = "requires ffmpeg on PATH"]
+fn execute_build_plan_smoke_runs_two_pass_transcode_sequentially() {
+    // Real-subprocess regression test for the pass1 -> pass2 sequencing
+    // added for two-pass title encoding: pass 1 must actually run and write
+    // its -passlogfile stats *before* pass 2 starts, or pass 2 fails to find
+    // them. Unit tests on the generated argv can't catch ordering bugs in
+    // the executor; this exercises real ffmpeg end to end.
+    let Some(ffmpeg_bin) = find_tool_on_path("ffmpeg") else {
+        eprintln!("Skipping smoke test because `ffmpeg` is not available on PATH.");
+        return;
+    };
+
+    let output_dir = unique_temp_dir("build-smoke-two-pass");
+    let source_path = output_dir.join("source.mp4");
+    let titles_dir = output_dir.join("_spindle_work").join("titles");
+    fs::create_dir_all(&titles_dir).unwrap();
+
+    let ffmpeg_status = Command::new(&ffmpeg_bin)
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=640x360:d=1.5",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+        ])
+        .arg(&source_path)
+        .status()
+        .expect("ffmpeg should launch for smoke test fixture generation");
+    assert!(
+        ffmpeg_status.success(),
+        "ffmpeg fixture generation failed with status {ffmpeg_status}"
+    );
+
+    let mut project = test_project();
+    project.assets[0].source_path = source_path.display().to_string();
+    project.assets[0].duration_secs = Some(1.5);
+    project.disc.titlesets[0].titles[0].audio_mappings = vec![];
+
+    let title = &project.disc.titlesets[0].titles[0];
+    let asset = &project.assets[0];
+    let video_info = Some(&asset.video_streams[0]);
+    let output_path = titles_dir.join("title-1.mpg");
+
+    let mut pass1_command = build_ffmpeg_transcode_pass1_command(
+        &asset.source_path,
+        &output_path,
+        title,
+        &project.disc,
+        video_info,
+        1_500_000.0,
+    );
+    pass1_command[0] = ffmpeg_bin.to_string_lossy().into_owned();
+
+    let mut command = build_ffmpeg_transcode_command(
+        &asset.source_path,
+        &output_path,
+        title,
+        asset,
+        &project.disc,
+        video_info,
+        1_500_000.0,
+        true,
+    );
+    command[0] = ffmpeg_bin.to_string_lossy().into_owned();
+
+    let plan = BuildPlan {
+        jobs: vec![BuildJob::TranscodeTitle {
+            title_id: "title-1".to_string(),
+            title_name: "Main Feature".to_string(),
+            source_path: asset.source_path.clone(),
+            output_path: output_path.display().to_string(),
+            pass1_command: Some(pass1_command),
+            command,
+            label: "Transcode \"Main Feature\"".to_string(),
+            duration_secs: Some(1.5),
+        }],
+        output_directory: output_dir.display().to_string(),
+        working_directory: output_dir.join("_spindle_work").display().to_string(),
+        dvdauthor_xml: String::new(),
+        summary: BuildSummary {
+            total_jobs: 1,
+            transcode_jobs: 1,
+            titles_count: 1,
+            menus_count: 0,
+            generate_iso: false,
+            estimated_commands: vec![],
+        },
+    };
+
+    let result = execute_build_plan(&plan, |_| {});
+
+    if !result.success {
+        panic!(
+            "expected two-pass smoke build to succeed\n{}",
+            result.log_lines.join("\n")
+        );
+    }
+
+    assert!(
+        output_path.exists(),
+        "expected pass 2 to produce the final title output"
+    );
+
+    let ffprobe_bin =
+        find_tool_on_path("ffprobe").expect("ffprobe should be alongside ffmpeg on PATH");
+    let probe_status = Command::new(ffprobe_bin)
+        .args(["-v", "error"])
+        .arg(&output_path)
+        .status()
+        .expect("ffprobe should launch");
+    assert!(
+        probe_status.success(),
+        "expected pass 2 output to be a valid, readable MPEG file"
     );
 
     fs::remove_dir_all(&output_dir).unwrap();

--- a/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
@@ -22,6 +22,7 @@ pub(crate) const MAX_VIDEO_RATE_BPS: f64 = 9_000_000.0;
 /// requests. Video and audio together must fit under it.
 pub(crate) const MUX_RATE_BPS: f64 = 10_080_000.0;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_ffmpeg_transcode_command(
     source_path: &str,
     output_path: &Path,
@@ -30,6 +31,7 @@ pub(crate) fn build_ffmpeg_transcode_command(
     disc: &Disc,
     video_info: Option<&VideoStreamInfo>,
     video_bitrate_bps: f64,
+    two_pass: bool,
 ) -> Vec<String> {
     let video_bitrate_bps = if video_bitrate_bps > 0.0 {
         video_bitrate_bps.min(MAX_VIDEO_RATE_BPS)
@@ -41,6 +43,23 @@ pub(crate) fn build_ffmpeg_transcode_command(
 
     cmd.extend(["-i".to_string(), source_path.to_string()]);
 
+    // ffmpeg requires every -i input to be declared before any output-file
+    // option (-c:v, -b:v, -map for the output mapping, etc.) — interleaving
+    // a later -i after output options have already started confuses its
+    // parser into misattributing the next -map to the new input rather than
+    // the output. The synthesized silent-audio input must therefore be
+    // declared here, immediately after the real source, not down near the
+    // rest of the audio options where it used to live.
+    let synthesise_silent_audio = title.audio_mappings.is_empty();
+    if synthesise_silent_audio {
+        cmd.extend([
+            "-f".to_string(),
+            "lavfi".to_string(),
+            "-i".to_string(),
+            "anullsrc=r=48000:cl=stereo".to_string(),
+        ]);
+    }
+
     if let Some(ref vm) = title.video_mapping {
         cmd.extend(["-map".to_string(), format!("0:{}", vm.source_stream_index)]);
     }
@@ -49,41 +68,11 @@ pub(crate) fn build_ffmpeg_transcode_command(
         raster: VideoRaster::FullD1,
         aspect: AspectMode::SixteenByNine,
     });
-    let (width, height) = profile.raster.resolution(disc.standard);
+    let (output_fps, vf) = build_title_video_filter(profile, disc, video_info);
 
-    let source_fps = video_info.and_then(|v| v.frame_rate);
-    let output_fps = choose_output_fps(source_fps, disc.standard);
+    cmd.extend(["-vf".to_string(), vf]);
 
-    let mut vf_parts: Vec<String> = Vec::new();
-
-    if video_info.is_some_and(is_hdr_source) {
-        vf_parts.push(
-            "zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,\
-             tonemap=hable,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
-                .to_string(),
-        );
-    }
-
-    let source_dar = video_info
-        .and_then(source_display_aspect_ratio)
-        .unwrap_or_else(|| width as f64 / height as f64);
-    let (target_dar_num, target_dar_den) = output_display_aspect_ratio_parts(profile.aspect);
-    let target_dar = target_dar_num as f64 / target_dar_den as f64;
-    let target_sar = dvd_sample_aspect_ratio(width, height, target_dar_num, target_dar_den);
-
-    vf_parts.push(build_dvd_scale_filter(
-        width,
-        height,
-        source_dar,
-        target_dar,
-        &target_sar,
-    ));
-
-    if source_fps.is_some_and(|fps| (fps - output_fps).abs() > 0.1) {
-        vf_parts.push(format!("fps={}", fps_rational_str(output_fps)));
-    }
-
-    cmd.extend(["-vf".to_string(), vf_parts.join(",")]);
+    let bv_str = format!("{}k", (video_bitrate_bps / 1000.0).round() as i64);
 
     cmd.extend([
         "-c:v".to_string(),
@@ -91,11 +80,47 @@ pub(crate) fn build_ffmpeg_transcode_command(
         "-r".to_string(),
         fps_rational_str(output_fps).to_string(),
         "-b:v".to_string(),
-        format!("{}k", (video_bitrate_bps / 1000.0).round() as i64),
-        "-maxrate".to_string(),
-        format!("{}k", (maxrate_bps / 1000.0).round() as i64),
-        "-bufsize".to_string(),
-        "1835k".to_string(),
+        bv_str.clone(),
+    ]);
+
+    if two_pass {
+        // Two-pass: pass 1 (see build_ffmpeg_transcode_pass1_command) already
+        // analysed the whole title, so the encoder allocates bits per actual
+        // scene complexity here rather than needing a CBR floor — that's
+        // what makes two-pass both more accurate *and* better quality than
+        // forced CBR. -maxrate stays at the wide safety ceiling so complex
+        // scenes can still burst.
+        cmd.extend([
+            "-pass".to_string(),
+            "2".to_string(),
+            "-passlogfile".to_string(),
+            ffmpeg_passlogfile_prefix(output_path),
+            "-maxrate".to_string(),
+            format!("{}k", (maxrate_bps / 1000.0).round() as i64),
+            "-bufsize".to_string(),
+            "1835k".to_string(),
+        ]);
+    } else {
+        // Single-pass: force near-CBR (-minrate == -maxrate == -b:v) so the
+        // encoder can't drift in either direction. Without this, single-pass
+        // mpeg2video is free to undershoot the target substantially on
+        // low-complexity content (observed dropping to ~64% of target on a
+        // real animated feature) or, if only a floor were added without
+        // matching the ceiling, overshoot on content with complexity bursts.
+        // This is the safe baseline; two-pass (above) is the better option
+        // when quality-per-byte matters, since it doesn't need a CBR floor
+        // to hit its target accurately.
+        cmd.extend([
+            "-minrate".to_string(),
+            bv_str.clone(),
+            "-maxrate".to_string(),
+            bv_str,
+            "-bufsize".to_string(),
+            "1835k".to_string(),
+        ]);
+    }
+
+    cmd.extend([
         "-g".to_string(),
         if disc.standard == VideoStandard::Pal {
             "12"
@@ -189,12 +214,8 @@ pub(crate) fn build_ffmpeg_transcode_command(
         ]);
     }
 
-    if title.audio_mappings.is_empty() {
+    if synthesise_silent_audio {
         cmd.extend([
-            "-f".to_string(),
-            "lavfi".to_string(),
-            "-i".to_string(),
-            "anullsrc=r=48000:cl=stereo".to_string(),
             "-map".to_string(),
             "1:a".to_string(),
             "-shortest".to_string(),
@@ -211,6 +232,132 @@ pub(crate) fn build_ffmpeg_transcode_command(
         "-muxrate".to_string(),
         (MUX_RATE_BPS as i64).to_string(),
         output_path.display().to_string(),
+    ]);
+
+    cmd
+}
+
+/// Shared HDR-tonemap / scale-pad-setsar / fps-conform video filter chain
+/// used by both the real title transcode and its two-pass analysis pass.
+/// Returns `(output_fps, vf_filter_string)`.
+fn build_title_video_filter(
+    profile: VideoOutputProfile,
+    disc: &Disc,
+    video_info: Option<&VideoStreamInfo>,
+) -> (f64, String) {
+    let (width, height) = profile.raster.resolution(disc.standard);
+
+    let source_fps = video_info.and_then(|v| v.frame_rate);
+    let output_fps = choose_output_fps(source_fps, disc.standard);
+
+    let mut vf_parts: Vec<String> = Vec::new();
+
+    if video_info.is_some_and(is_hdr_source) {
+        vf_parts.push(
+            "zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,\
+             tonemap=hable,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
+                .to_string(),
+        );
+    }
+
+    let source_dar = video_info
+        .and_then(source_display_aspect_ratio)
+        .unwrap_or_else(|| width as f64 / height as f64);
+    let (target_dar_num, target_dar_den) = output_display_aspect_ratio_parts(profile.aspect);
+    let target_dar = target_dar_num as f64 / target_dar_den as f64;
+    let target_sar = dvd_sample_aspect_ratio(width, height, target_dar_num, target_dar_den);
+
+    vf_parts.push(build_dvd_scale_filter(
+        width,
+        height,
+        source_dar,
+        target_dar,
+        &target_sar,
+    ));
+
+    if source_fps.is_some_and(|fps| (fps - output_fps).abs() > 0.1) {
+        vf_parts.push(format!("fps={}", fps_rational_str(output_fps)));
+    }
+
+    (output_fps, vf_parts.join(","))
+}
+
+/// Deterministic ffmpeg `-passlogfile` prefix for a title's two-pass stats,
+/// placed alongside the title's output file so it's cleaned up with the rest
+/// of the build workspace. ffmpeg appends `-0.log` to this prefix itself.
+fn ffmpeg_passlogfile_prefix(output_path: &Path) -> String {
+    let stem = output_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("title");
+    output_path
+        .with_file_name(format!("{stem}_2pass"))
+        .display()
+        .to_string()
+}
+
+/// Build the analysis-only first pass of a two-pass title encode: the same
+/// video filter chain and bitrate target as the real encode
+/// (`build_ffmpeg_transcode_command` with `two_pass: true`), but with audio
+/// and subtitles stripped and the output discarded via the null muxer. Must
+/// run before the second pass so the `-passlogfile` stats it writes are
+/// available for the real encode to read.
+pub(crate) fn build_ffmpeg_transcode_pass1_command(
+    source_path: &str,
+    output_path: &Path,
+    title: &Title,
+    disc: &Disc,
+    video_info: Option<&VideoStreamInfo>,
+    video_bitrate_bps: f64,
+) -> Vec<String> {
+    let video_bitrate_bps = if video_bitrate_bps > 0.0 {
+        video_bitrate_bps.min(MAX_VIDEO_RATE_BPS)
+    } else {
+        DEFAULT_VIDEO_BITRATE_BPS
+    };
+    let maxrate_bps = MAX_VIDEO_RATE_BPS.max(video_bitrate_bps);
+
+    let profile = title.video_output_profile.unwrap_or(VideoOutputProfile {
+        raster: VideoRaster::FullD1,
+        aspect: AspectMode::SixteenByNine,
+    });
+    let (output_fps, vf) = build_title_video_filter(profile, disc, video_info);
+
+    let mut cmd = vec!["ffmpeg".to_string(), "-y".to_string()];
+    cmd.extend(["-i".to_string(), source_path.to_string()]);
+
+    if let Some(ref vm) = title.video_mapping {
+        cmd.extend(["-map".to_string(), format!("0:{}", vm.source_stream_index)]);
+    }
+
+    cmd.extend(["-vf".to_string(), vf]);
+
+    cmd.extend([
+        "-c:v".to_string(),
+        "mpeg2video".to_string(),
+        "-r".to_string(),
+        fps_rational_str(output_fps).to_string(),
+        "-b:v".to_string(),
+        format!("{}k", (video_bitrate_bps / 1000.0).round() as i64),
+        "-maxrate".to_string(),
+        format!("{}k", (maxrate_bps / 1000.0).round() as i64),
+        "-bufsize".to_string(),
+        "1835k".to_string(),
+        "-g".to_string(),
+        if disc.standard == VideoStandard::Pal {
+            "12"
+        } else {
+            "18"
+        }
+        .to_string(),
+        "-pass".to_string(),
+        "1".to_string(),
+        "-passlogfile".to_string(),
+        ffmpeg_passlogfile_prefix(output_path),
+        "-an".to_string(),
+        "-f".to_string(),
+        "null".to_string(),
+        "-".to_string(),
     ]);
 
     cmd
@@ -472,6 +619,7 @@ mod tests {
             &project.disc,
             None,
             0.0,
+            false,
         );
 
         let bv_arg = cmd
@@ -480,6 +628,161 @@ mod tests {
             .nth(1)
             .expect("-b:v value");
         assert_eq!(bv_arg, "6000k");
+    }
+
+    #[test]
+    fn ffmpeg_single_pass_forces_symmetric_cbr_below_the_safety_ceiling() {
+        // Regression test: single-pass mpeg2video must not just float a
+        // -minrate floor while leaving -maxrate at the independent 9 Mbps
+        // safety ceiling — that asymmetry (floor at target, ceiling far
+        // above it) can only ever push the realized average bitrate UP from
+        // target, risking overshoot on content with complexity bursts. True
+        // CBR (minrate == maxrate == target) is required so the encoder
+        // can't drift in either direction. Uses a below-ceiling target
+        // (5759k, matching a real reported undershoot case) so maxrate
+        // would differ from the target if the old asymmetric logic were
+        // still in place.
+        let project = test_project();
+        let title = &project.disc.titlesets[0].titles[0];
+        let asset = &project.assets[0];
+
+        let cmd = super::build_ffmpeg_transcode_command(
+            &asset.source_path,
+            std::path::Path::new("/tmp/out.mpg"),
+            title,
+            asset,
+            &project.disc,
+            Some(&asset.video_streams[0]),
+            5_759_000.0,
+            false,
+        );
+
+        let bv_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-b:v")
+            .nth(1)
+            .expect("-b:v value")
+            .clone();
+        let minrate_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-minrate")
+            .nth(1)
+            .expect("-minrate value");
+        let maxrate_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-maxrate")
+            .nth(1)
+            .expect("-maxrate value");
+
+        assert_eq!(bv_arg, "5759k");
+        assert_eq!(
+            minrate_arg, &bv_arg,
+            "minrate must equal the target bitrate"
+        );
+        assert_eq!(maxrate_arg, &bv_arg, "maxrate must also equal the target bitrate (true CBR), not the independent safety ceiling");
+        assert!(
+            !cmd.contains(&"-pass".to_string()),
+            "single-pass must not set -pass"
+        );
+    }
+
+    #[test]
+    fn ffmpeg_two_pass_omits_cbr_floor_and_sets_pass2_passlogfile() {
+        // Two-pass doesn't need a CBR floor to hit its target accurately —
+        // pass 1's lookahead already informs accurate allocation — and
+        // forcing one would defeat the point of allocating more bits to
+        // complex scenes. -maxrate should stay at the wide safety ceiling.
+        let project = test_project();
+        let title = &project.disc.titlesets[0].titles[0];
+        let asset = &project.assets[0];
+
+        let cmd = super::build_ffmpeg_transcode_command(
+            &asset.source_path,
+            std::path::Path::new("/tmp/out.mpg"),
+            title,
+            asset,
+            &project.disc,
+            Some(&asset.video_streams[0]),
+            5_759_000.0,
+            true,
+        );
+
+        assert!(
+            !cmd.contains(&"-minrate".to_string()),
+            "two-pass must not force a CBR floor"
+        );
+
+        let maxrate_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-maxrate")
+            .nth(1)
+            .expect("-maxrate value");
+        assert_eq!(
+            maxrate_arg, "9000k",
+            "two-pass should keep the wide safety ceiling, not clamp to the target"
+        );
+
+        let pass_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-pass")
+            .nth(1)
+            .expect("-pass value");
+        assert_eq!(pass_arg, "2");
+
+        assert!(
+            cmd.contains(&"-passlogfile".to_string()),
+            "expected -passlogfile for pass 2 to read pass 1's stats"
+        );
+    }
+
+    #[test]
+    fn ffmpeg_pass1_command_is_video_only_analysis_discarded_via_null_muxer() {
+        let project = test_project();
+        let title = &project.disc.titlesets[0].titles[0];
+        let asset = &project.assets[0];
+
+        let cmd = super::build_ffmpeg_transcode_pass1_command(
+            &asset.source_path,
+            std::path::Path::new("/tmp/out.mpg"),
+            title,
+            &project.disc,
+            Some(&asset.video_streams[0]),
+            5_759_000.0,
+        );
+
+        assert!(
+            cmd.contains(&"-an".to_string()),
+            "pass 1 must disable audio"
+        );
+        assert!(
+            !cmd.iter().any(|a| a == "-c:a" || a.starts_with("-c:a:")),
+            "pass 1 must not configure any audio codec"
+        );
+
+        let pass_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-pass")
+            .nth(1)
+            .expect("-pass value");
+        assert_eq!(pass_arg, "1");
+
+        assert_eq!(cmd.last().map(String::as_str), Some("-"));
+        let f_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-f")
+            .nth(1)
+            .expect("-f value");
+        assert_eq!(f_arg, "null", "pass 1 output must be discarded");
+
+        let bv_arg = cmd
+            .iter()
+            .skip_while(|a| *a != "-b:v")
+            .nth(1)
+            .expect("-b:v value");
+        assert_eq!(
+            bv_arg, "5759k",
+            "pass 1 must target the same bitrate as the real encode"
+        );
     }
 
     #[test]

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
@@ -8,7 +8,10 @@ use std::collections::HashMap;
 use crate::models::*;
 
 use super::authoring::generate_dvdauthor_xml;
-use super::ffmpeg::{build_ffmpeg_text_subtitle_prepare_command, build_ffmpeg_transcode_command};
+use super::ffmpeg::{
+    build_ffmpeg_text_subtitle_prepare_command, build_ffmpeg_transcode_command,
+    build_ffmpeg_transcode_pass1_command,
+};
 use super::menu::{
     authorable_menus, build_ffmpeg_menu_command, generate_spumux_xml, menu_scene_png_path,
 };
@@ -169,6 +172,7 @@ pub fn generate_build_plan_with_options(
                 .get(title.id.as_str())
                 .copied()
                 .unwrap_or(0.0);
+            let two_pass = project.build_settings.two_pass_video_encoding;
             let mut command = build_ffmpeg_transcode_command(
                 &asset.source_path,
                 &output_path,
@@ -177,8 +181,24 @@ pub fn generate_build_plan_with_options(
                 &project.disc,
                 video_info,
                 video_bitrate_bps,
+                two_pass,
             );
             command[0] = tools.ffmpeg.clone();
+
+            let pass1_command = if two_pass {
+                let mut cmd = build_ffmpeg_transcode_pass1_command(
+                    &asset.source_path,
+                    &output_path,
+                    title,
+                    &project.disc,
+                    video_info,
+                    video_bitrate_bps,
+                );
+                cmd[0] = tools.ffmpeg.clone();
+                Some(cmd)
+            } else {
+                None
+            };
 
             if !has_text_subtitles {
                 transcode_cache.insert(cache_key, output_path.clone());
@@ -190,6 +210,7 @@ pub fn generate_build_plan_with_options(
                 title_name: title.name.clone(),
                 source_path: asset.source_path.clone(),
                 output_path: output_path.display().to_string(),
+                pass1_command,
                 command,
                 label: format!("Transcode \"{}\"", title.name),
                 duration_secs: asset.duration_secs,

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
@@ -132,6 +132,48 @@ fn build_plan_renders_text_subtitles_after_base_transcode() {
 }
 
 #[test]
+fn build_plan_populates_pass1_command_when_two_pass_encoding_is_enabled() {
+    let mut project = test_project();
+    project.build_settings.two_pass_video_encoding = true;
+
+    let plan = generate_build_plan(&project, "/tmp/dvd_output", false).unwrap();
+
+    let pass1_command = plan.jobs.iter().find_map(|job| match job {
+        BuildJob::TranscodeTitle { pass1_command, .. } => Some(pass1_command),
+        _ => None,
+    });
+
+    let pass1_command = pass1_command
+        .expect("expected a TranscodeTitle job")
+        .as_ref()
+        .expect("expected pass1_command to be populated when two_pass_video_encoding is on");
+
+    assert!(
+        pass1_command.contains(&"-pass".to_string()),
+        "expected pass 1 command to set -pass 1"
+    );
+}
+
+#[test]
+fn build_plan_omits_pass1_command_when_two_pass_encoding_is_disabled() {
+    let project = test_project();
+    assert!(!project.build_settings.two_pass_video_encoding);
+
+    let plan = generate_build_plan(&project, "/tmp/dvd_output", false).unwrap();
+
+    let pass1_command = plan.jobs.iter().find_map(|job| match job {
+        BuildJob::TranscodeTitle { pass1_command, .. } => Some(pass1_command),
+        _ => None,
+    });
+
+    assert_eq!(
+        pass1_command.expect("expected a TranscodeTitle job"),
+        &None,
+        "expected no pass1_command when two_pass_video_encoding is off"
+    );
+}
+
+#[test]
 fn build_plan_preserves_mixed_subtitle_stream_order() {
     let mut project = test_project();
     project.assets[0].subtitle_streams.push(SubtitleStreamInfo {

--- a/plugins/tauri-plugin-spindle-project/src/build/types.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/types.rs
@@ -45,6 +45,11 @@ pub enum BuildJob {
         title_name: String,
         source_path: String,
         output_path: String,
+        /// When two-pass encoding is enabled, the analysis-only first pass
+        /// run before `command` (the real encode). Its output is discarded;
+        /// it only writes the `-passlogfile` stats `command` reads.
+        #[serde(default)]
+        pass1_command: Option<Vec<String>>,
         command: Vec<String>,
         label: String,
         /// Source asset duration in seconds, used for step-progress estimation.

--- a/plugins/tauri-plugin-spindle-project/src/models/build_settings.rs
+++ b/plugins/tauri-plugin-spindle-project/src/models/build_settings.rs
@@ -15,6 +15,14 @@ pub struct BuildSettings {
     pub allocation_strategy: AllocationStrategy,
     #[serde(default)]
     pub subtitle_render_mode: SubtitleRenderMode,
+    /// Two-pass title-video encoding: analyzes the whole title first, then
+    /// allocates bits per actual scene complexity on the real encode. Gets
+    /// both more accurate output sizing (closely tracking the disc-capacity
+    /// budget) and better quality-per-byte than single-pass, at the cost of
+    /// roughly doubling per-title encode time. Off by default so existing
+    /// projects keep their current (faster) build time unless a user opts in.
+    #[serde(default)]
+    pub two_pass_video_encoding: bool,
 }
 
 impl Default for BuildSettings {
@@ -26,6 +34,7 @@ impl Default for BuildSettings {
             safety_margin_bytes: 50_000_000,
             allocation_strategy: AllocationStrategy::DurationWeighted,
             subtitle_render_mode: SubtitleRenderMode::TwoPass,
+            two_pass_video_encoding: false,
         }
     }
 }

--- a/plugins/tauri-plugin-spindle-project/src/models/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/models/mod.rs
@@ -393,6 +393,7 @@ mod tests {
             settings.allocation_strategy,
             AllocationStrategy::DurationWeighted
         );
+        assert!(!settings.two_pass_video_encoding);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Closes #92: single-pass mpeg2 transcoding could undershoot its target bitrate substantially on low-complexity content (64% of target observed on a real animated feature), wasting disc capacity the Planner's estimate assumed would be used
- **Single-pass baseline is now true CBR** (`-minrate == -maxrate == -b:v`) so the encoder can't drift in either direction — safe by default for every build
- **Two-pass encoding** (opt-in via a new "Two-pass encoding" checkbox in Overview → Project Settings, `buildSettings.twoPassVideoEncoding`, default off): an analysis-only pass 1 runs first (discarded output, just `-passlogfile` stats), so the real encode allocates bits per actual scene complexity instead of needing a CBR floor — more accurate sizing *and* better quality-per-byte, at ~2x per-title encode time
- Closes #94: discovered while writing a real-ffmpeg smoke test for the above — the silent-audio fallback (titles with no audio track) generated an ffmpeg command real `ffmpeg` rejects outright (`Option map ... cannot be applied to input url anullsrc=...`), since the synthesized audio input was declared *after* video output options had already started. Never caught before because no existing test exercised that branch against a real ffmpeg binary. Fixed by declaring the input immediately after the real source.

## Test plan
- [x] `cargo test -p tauri-plugin-spindle-project` — 205 passed (200 pre-existing + 5 new), 4 ignored real-ffmpeg smoke tests
- [x] `cargo test -p tauri-plugin-spindle-project -- --ignored` — new two-pass smoke test passes against real ffmpeg, also exercises the anullsrc fix (fixture has no audio track)
- [x] `cargo clippy -p tauri-plugin-spindle-project --all-targets` (clean)
- [x] `cargo fmt -p tauri-plugin-spindle-project -- --check` (clean)
- [x] `pnpm vitest run` — 228 passed (227 pre-existing + 1 new)
- [x] `pnpm exec tsc --noEmit` (clean)
- [x] `pnpm exec prettier --check` (clean)
- [x] Independent code review (no @codex review — Codex usage limits exhausted)

Closes #92.
Closes #94.
