### PR TITLE
style(titles): consolidate duplicate .titles__track-lang CSS rule

### DIFF
--- a/apps/spindle/src/pages/TitlesPage.css
+++ b/apps/spindle/src/pages/TitlesPage.css
@@ -355,26 +355,16 @@
 	border: 1px solid var(--border-subtle);
 	border-radius: var(--radius-sm);
 	color: var(--text-primary);
-	font-size: var(--text-sm);
-	padding: var(--space-2) var(--space-3);
-	width: 100%;
-}
-
-.titles__track-lang:focus {
-	outline: none;
-	border-color: var(--brand-orange);
-}
-
-.titles__track-lang {
-	background: var(--bg-input);
-	border: 1px solid var(--border-subtle);
-	border-radius: var(--radius-sm);
-	color: var(--text-primary);
 	font-family: var(--font-mono);
 	font-size: var(--text-xs);
 	padding: var(--space-1) var(--space-2);
 	width: 48px;
 	text-align: center;
+}
+
+.titles__track-lang:focus {
+	outline: none;
+	border-color: var(--brand-orange);
 }
 
 .titles__track-flag {


### PR DESCRIPTION
## Summary

`.titles__track-lang` was defined twice in `TitlesPage.css`: a dead full-width/`text-sm` block (overridden immediately by the block below it) followed by the intended 48px/mono/`text-xs` block. Consolidate into one block and move the `:focus` rule to follow it.

No visual change — the second block was already winning the cascade.

Caught during review of #74.

## Test plan
- [x] `pnpm format:check` passes
- [x] Visual spot-check: lang input still renders as a narrow mono code field