### PR TITLE
fix(build): skip-unsupported-streams no longer drops text subtitles

### DIFF
--- a/plugins/tauri-plugin-spindle-project/src/build/planner/helpers.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/helpers.rs
@@ -64,8 +64,13 @@ pub(super) fn generate_text_subtitle_spumux_xml(
     )
 }
 
-/// Remove subtitle mappings that the escape hatch should skip during build.
-pub(super) fn strip_unsupported_subtitle_mappings(project: &mut SpindleProjectFile) {
+/// Remove subtitle mappings whose source codec is genuinely unknown/unrecognised.
+///
+/// `Bitmap` and `Text` subtitle types both have working build pipelines
+/// (bitmap passthrough and `RenderTextSubtitles` respectively), so they are
+/// kept. Only `SubtitleType::Unknown` — codecs ffprobe returned but Spindle
+/// has no handler for — are stripped.
+pub(super) fn strip_unknown_codec_subtitle_mappings(project: &mut SpindleProjectFile) {
     let assets: HashMap<&str, &Asset> = project.assets.iter().map(|a| (a.id.as_str(), a)).collect();
 
     for titleset in &mut project.disc.titlesets {
@@ -77,7 +82,8 @@ pub(super) fn strip_unsupported_subtitle_mappings(project: &mut SpindleProjectFi
             {
                 title.subtitle_mappings.retain(|sm| {
                     asset.subtitle_streams.iter().any(|s| {
-                        s.index == sm.source_stream_index && s.subtitle_type == SubtitleType::Bitmap
+                        s.index == sm.source_stream_index
+                            && s.subtitle_type != SubtitleType::Unknown
                     })
                 });
             }

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
@@ -25,7 +25,7 @@ mod toolchain;
 
 use helpers::{
     ensure_supported_menu_backend, generate_text_subtitle_spumux_xml,
-    strip_unsupported_subtitle_mappings,
+    strip_unknown_codec_subtitle_mappings,
 };
 use paths::BuildPaths;
 use toolchain::ResolvedToolchain;
@@ -47,7 +47,7 @@ pub fn generate_build_plan_with_options(
 ) -> crate::Result<BuildPlan> {
     let mut owned_project = project.clone();
     if skip_unsupported_streams {
-        strip_unsupported_subtitle_mappings(&mut owned_project);
+        strip_unknown_codec_subtitle_mappings(&mut owned_project);
     }
     let project = &owned_project;
 

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
@@ -245,7 +245,9 @@ fn build_plan_preserves_mixed_subtitle_stream_order() {
 }
 
 #[test]
-fn build_plan_skip_unsupported_streams_removes_text_subtitles() {
+fn build_plan_skip_unsupported_streams_keeps_text_subtitles() {
+    // Regression test for liminal-hq/spindle#93: text subtitles have a working
+    // RenderTextSubtitles pipeline and must not be dropped by the escape hatch.
     let mut project = test_project();
     project.assets[0].subtitle_streams.push(SubtitleStreamInfo {
         index: 2,
@@ -270,19 +272,57 @@ fn build_plan_skip_unsupported_streams_removes_text_subtitles() {
         generate_build_plan_with_options(&project, "/tmp/dvd_output", false, true, false).unwrap();
 
     assert!(
+        plan.jobs
+            .iter()
+            .any(|job| matches!(job, BuildJob::RenderTextSubtitles { .. })),
+        "skip unsupported streams must not strip text subtitle render jobs"
+    );
+}
+
+#[test]
+fn build_plan_skip_unsupported_streams_removes_unknown_codec_subtitles() {
+    // Only SubtitleType::Unknown streams — codecs Spindle has no handler for —
+    // should be stripped by the escape hatch.
+    let mut project = test_project();
+    project.assets[0].subtitle_streams.push(SubtitleStreamInfo {
+        index: 2,
+        codec: "some_future_codec".to_string(),
+        language: Some("eng".to_string()),
+        subtitle_type: SubtitleType::Unknown,
+        title: None,
+    });
+    project.disc.titlesets[0].titles[0]
+        .subtitle_mappings
+        .push(SubtitleTrackMapping {
+            id: "sm-unknown".to_string(),
+            source_stream_index: 2,
+            label: "English".to_string(),
+            language: "eng".to_string(),
+            order_index: 0,
+            is_default: false,
+            is_forced: false,
+        });
+
+    let plan =
+        generate_build_plan_with_options(&project, "/tmp/dvd_output", false, true, false).unwrap();
+
+    // After stripping, no subtitle jobs of any kind should appear.
+    assert!(
         !plan
             .jobs
             .iter()
             .any(|job| matches!(job, BuildJob::RenderTextSubtitles { .. })),
-        "skip unsupported streams should strip text subtitle render jobs"
+        "unknown-codec subtitle mapping should produce no RenderTextSubtitles job"
     );
+    let transcode = plan
+        .jobs
+        .iter()
+        .find(|j| matches!(j, BuildJob::TranscodeTitle { .. }))
+        .expect("expected a TranscodeTitle job");
+    let cmd = transcode.command().unwrap();
     assert!(
-        plan.jobs
-            .iter()
-            .any(|job| matches!(job, BuildJob::TranscodeTitle {
-            output_path, ..
-        } if output_path.ends_with("title-1.mpg"))),
-        "text subtitle stripping should fall back to the direct title output path"
+        !cmd.iter().any(|a| a.starts_with("-c:s")),
+        "unknown-codec subtitle mapping should produce no -c:s flag in the transcode command"
     );
 }
 


### PR DESCRIPTION
## Summary

`strip_unsupported_subtitle_mappings` was retaining only `SubtitleType::Bitmap` streams, silently stripping every SRT/ASS/WebVTT subtitle track even though Spindle has a fully-working `RenderTextSubtitles` pipeline for them.

The filter now retains everything except `SubtitleType::Unknown` — codecs ffprobe identified but Spindle has no handler for. Bitmap passthrough and text rendering are both kept.

- Rename helper to `strip_unknown_codec_subtitle_mappings` to reflect the narrower scope
- Replace the now-inverted planner test with two regression tests: text subtitles survive the escape hatch; unknown-codec tracks are still stripped

Closes #93.

## Test plan
- [x] `cargo test -p tauri-plugin-spindle-project` (213/213 passing)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`