### PR TITLE
fix(settings): update skip-streams toggle label and description

### DIFF
--- a/apps/spindle/src/pages/SettingsPage.test.tsx
+++ b/apps/spindle/src/pages/SettingsPage.test.tsx
@@ -169,7 +169,7 @@ describe('SettingsPage', () => {
 		checkToolchain.mockClear();
 
 		fireEvent.click(
-			screen.getByText('Skip unsupported streams').closest('label')!.querySelector('input')!,
+			screen.getByText('Skip unknown-codec streams').closest('label')!.querySelector('input')!,
 		);
 
 		expect(setDevSkipUnsupportedStreams).toHaveBeenCalledWith(true);

--- a/apps/spindle/src/pages/SettingsPage.tsx
+++ b/apps/spindle/src/pages/SettingsPage.tsx
@@ -231,8 +231,8 @@ export function SettingsPage() {
 						<div className="settings__toggle-text">
 							<span className="settings__toggle-label">Skip unknown-codec streams</span>
 							<span className="settings__toggle-desc text-muted">
-								Strip subtitle mappings whose codec is unrecognised (not bitmap or text) instead
-								of letting the build fail. Text subtitles are still rendered normally.
+								Strip subtitle mappings whose codec is unrecognised (not bitmap or text) instead of
+								letting the build fail. Text subtitles are still rendered normally.
 							</span>
 						</div>
 						<input

--- a/apps/spindle/src/pages/SettingsPage.tsx
+++ b/apps/spindle/src/pages/SettingsPage.tsx
@@ -229,10 +229,10 @@ export function SettingsPage() {
 					</label>
 					<label className="settings__toggle-row">
 						<div className="settings__toggle-text">
-							<span className="settings__toggle-label">Skip unsupported streams</span>
+							<span className="settings__toggle-label">Skip unknown-codec streams</span>
 							<span className="settings__toggle-desc text-muted">
-								Automatically strip text-based subtitle mappings during build instead of blocking.
-								Useful when sources only have text subtitles and you want to author without them.
+								Strip subtitle mappings whose codec is unrecognised (not bitmap or text) instead
+								of letting the build fail. Text subtitles are still rendered normally.
 							</span>
 						</div>
 						<input


### PR DESCRIPTION
## Summary

Follow-up to #98 / #93, caught in Codex review.

The "Skip unsupported streams" toggle label and description said it would strip text-based subtitle mappings. Since #98 changed the behaviour so only unknown-codec streams are stripped, the copy was now actively misleading — a user enabling the toggle based on the description would expect text subtitles to be dropped, but they'd still be rendered.

- Label: "Skip unsupported streams" → "Skip unknown-codec streams"
- Description: rewritten to accurately describe what the toggle does
- Settings test selector updated to match

## Test plan
- [x] `pnpm test:js` (233/233 passing)
- [x] `pnpm format:check`