### PR TITLE
fix(css): centre capped-width pages on wide windows

### DIFF
--- a/apps/spindle/src/pages/BuildPage.css
+++ b/apps/spindle/src/pages/BuildPage.css
@@ -2,6 +2,7 @@
 
 .build {
 	max-width: 800px;
+	margin-inline: auto;
 }
 
 /* ── Controls ─────────────────────────────────────────────── */

--- a/apps/spindle/src/pages/ChaptersPage.css
+++ b/apps/spindle/src/pages/ChaptersPage.css
@@ -2,6 +2,7 @@
 
 .chapters {
 	max-width: 1200px;
+	margin-inline: auto;
 }
 
 /* ── Layout ───────────────────────────────────────────────── */

--- a/apps/spindle/src/pages/LogsPage.css
+++ b/apps/spindle/src/pages/LogsPage.css
@@ -2,6 +2,7 @@
 
 .logs {
 	max-width: 960px;
+	margin-inline: auto;
 }
 
 /* ── Report ───────────────────────────────────────────────── */

--- a/apps/spindle/src/pages/OverviewPage.css
+++ b/apps/spindle/src/pages/OverviewPage.css
@@ -2,6 +2,7 @@
 
 .overview {
 	max-width: 960px;
+	margin-inline: auto;
 }
 
 .page-header {

--- a/apps/spindle/src/pages/PlannerPage.css
+++ b/apps/spindle/src/pages/PlannerPage.css
@@ -2,6 +2,7 @@
 
 .planner {
 	max-width: 960px;
+	margin-inline: auto;
 }
 
 /* ── Capacity card ────────────────────────────────────────── */

--- a/apps/spindle/src/pages/SettingsPage.css
+++ b/apps/spindle/src/pages/SettingsPage.css
@@ -2,6 +2,7 @@
 
 .settings {
 	max-width: 720px;
+	margin-inline: auto;
 }
 
 /* ── Section cards ────────────────────────────────────────── */

--- a/apps/spindle/src/pages/TitlesPage.css
+++ b/apps/spindle/src/pages/TitlesPage.css
@@ -2,6 +2,7 @@
 
 .titles {
 	max-width: 1200px;
+	margin-inline: auto;
 	overflow-x: hidden;
 }
 


### PR DESCRIPTION
Fixes #91.

## Summary

- All seven page root classes (`build`, `chapters`, `logs`, `overview`, `planner`, `settings`, `titles`) had a `max-width` but no `margin-inline: auto`, so content was pinned to the left edge on wide windows instead of centring.
- Added `margin-inline: auto` to each root class. One-line change per file.

## Test plan

- [ ] Open the app on a wide window (>1200 px); all pages should be centred with equal margins on both sides.
- [ ] Narrower windows (below each page's `max-width`) should be unaffected — content fills the available width as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3tSFK3P9vGwbNNtb4AYQG