### PR TITLE
feat(planner): show per-title audio bitrate in title breakdown

### DIFF
--- a/apps/spindle/src/pages/PlannerPage.test.tsx
+++ b/apps/spindle/src/pages/PlannerPage.test.tsx
@@ -122,7 +122,7 @@ function buildCapacity(overrides: Partial<CapacityEstimate> = {}): CapacityEstim
 		estimatedOutputBytes: 3_600_000_000,
 		usagePct: 80,
 		isOverCapacity: false,
-		titleBitrates: [{ titleId: 'title-1', bitsPerSecond: 8_000_000 }],
+		titleBitrates: [{ titleId: 'title-1', bitsPerSecond: 8_000_000, audioBitsPerSecond: 448_000 }],
 		floorInfeasible: false,
 		...overrides,
 	};
@@ -176,6 +176,7 @@ describe('PlannerPage', () => {
 		expect(screen.getByText('feature.mkv')).toBeInTheDocument();
 		expect(screen.getByText('80.0%')).toBeInTheDocument();
 		expect(screen.getByText('8.00 Mbps video')).toBeInTheDocument();
+		expect(screen.getByText('448 kbps audio')).toBeInTheDocument();
 		expect(screen.getByText('100.0% of disc')).toBeInTheDocument();
 	});
 

--- a/apps/spindle/src/pages/PlannerPage.tsx
+++ b/apps/spindle/src/pages/PlannerPage.tsx
@@ -81,9 +81,7 @@ export function PlannerPage() {
 		titleBitrates,
 		floorInfeasible,
 	} = capacity;
-	const titleBitrateById = new Map(
-		titleBitrates.map((alloc) => [alloc.titleId, alloc.bitsPerSecond]),
-	);
+	const titleBitrateById = new Map(titleBitrates.map((alloc) => [alloc.titleId, alloc]));
 
 	return (
 		<div className="planner">
@@ -206,7 +204,14 @@ export function PlannerPage() {
 											<span>{formatDuration(duration)}</span>
 											<span>{formatBytes(sourceSize)}</span>
 											{titleRate != null && (
-												<span className="text-muted">{formatBitrate(titleRate)} video</span>
+												<span className="text-muted">
+													{formatBitrate(titleRate.bitsPerSecond)} video
+												</span>
+											)}
+											{titleRate != null && titleRate.audioBitsPerSecond > 0 && (
+												<span className="text-muted">
+													{formatBitrate(titleRate.audioBitsPerSecond)} audio
+												</span>
 											)}
 											<span className="text-muted">{durationPct.toFixed(1)}% of disc</span>
 											{title.pinnedBitrateBps !== null ? (

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -501,6 +501,8 @@ export interface PropertyCheck {
 export interface TitleBitrateAllocation {
 	titleId: string;
 	bitsPerSecond: number;
+	/** Sum of all audio track bitrates for this title. Shown alongside video in the Planner breakdown. */
+	audioBitsPerSecond: number;
 }
 
 /** Disc-capacity usage and the per-title bitrate budget the build pipeline

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -58,6 +58,10 @@ pub struct CapacityEstimate {
 pub struct TitleBitrateAllocation {
     pub title_id: String,
     pub bits_per_second: f64,
+    /// Sum of all audio track bitrates for this title, as estimated by
+    /// `estimate_title_audio_bitrate_bps`. Exposed so the Planner UI can
+    /// show audio alongside video in the per-title breakdown.
+    pub audio_bits_per_second: f64,
 }
 
 /// Estimate encoded disc size and bitrate budget from total title duration,
@@ -425,6 +429,7 @@ fn allocate_title_bitrates(
             TitleBitrateAllocation {
                 title_id: title.id.clone(),
                 bits_per_second,
+                audio_bits_per_second: *audio_bps,
             }
         })
         .collect();


### PR DESCRIPTION
Fixes #70.

## Summary

- `TitleBitrateAllocation` in `capacity.rs` gains an `audio_bits_per_second` field — the value was already computed per-title by `estimate_title_audio_bitrate_bps` and used to reserve disc budget, but was thrown away before the struct was returned.
- Mirrored as `audioBitsPerSecond` in the TypeScript binding (`guest-js/index.ts`).
- Planner title rows now display `X.XX Mbps audio` (or `NNN kbps audio`) alongside the existing video stat. The audio line is suppressed when `audioBitsPerSecond` is 0 (title with no asset).

## Test plan

- [ ] Open a project with EAC3 5.1 audio — Planner should show e.g. `448 kbps audio` next to the video line for each title.
- [ ] Title with no asset should show no audio stat.
- [ ] Existing capacity math and budget numbers should be unaffected (audio was already factored in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3tSFK3P9vGwbNNtb4AYQG