### PR TITLE
fix(planner): suppress audio stat for zero-duration title allocations

### DIFF
--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -429,7 +429,7 @@ fn allocate_title_bitrates(
             TitleBitrateAllocation {
                 title_id: title.id.clone(),
                 bits_per_second,
-                audio_bits_per_second: *audio_bps,
+                audio_bits_per_second: if *duration > 0.0 { *audio_bps } else { 0.0 },
             }
         })
         .collect();


### PR DESCRIPTION
Codex follow-up to #101.

## Summary

Titles with no assigned asset (duration = 0) were getting `audio_bits_per_second` set to the 192 kbps silent-fallback rate from `estimate_title_audio_bitrate_bps`, causing the Planner to display "192 kbps audio" next to "No asset / 0:00" rows even though that audio is never actually counted in the budget estimate.

Fix: gate `audio_bits_per_second` on `duration > 0`, matching the same guard that already zeroes out `bits_per_second` for these rows in `allocate_title_bitrates`.

## Test plan

- [ ] Title with no assigned asset → no audio stat shown in Planner breakdown.
- [ ] Title with an assigned asset and audio mappings → audio stat still appears correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3tSFK3P9vGwbNNtb4AYQG