### PR TITLE
Build motion menus to playable DVDs and preview them in the editor

### DIFF
--- a/apps/spindle/src/components/menus/InspectorPanel.tsx
+++ b/apps/spindle/src/components/menus/InspectorPanel.tsx
@@ -16,6 +16,7 @@ import type {
 	FontEntry,
 	FormatProfile,
 	MenuRole,
+	PlaybackAction,
 } from '../../types/project';
 import { LayersPanel } from './LayersPanel';
 import { CollapsibleSection } from './InspectorCollapsibleSection';
@@ -82,6 +83,16 @@ export interface InspectorPanelProps {
 	onUpdateMotionDurationSecs?: (secs: number | null) => void;
 	/** Update the motion menu loop count. */
 	onUpdateMotionLoopCount?: (count: number) => void;
+	/** Update the motion menu loop start time. */
+	onUpdateMotionLoopStart?: (secs: number) => void;
+	/** Update the motion menu intro start time. */
+	onUpdateMotionIntroStart?: (secs: number) => void;
+	/** Update the motion menu intro duration. */
+	onUpdateMotionIntroDuration?: (secs: number | null) => void;
+	/** Update the motion menu timeout action. */
+	onUpdateMotionTimeoutAction?: (action: PlaybackAction | null) => void;
+	/** Set the loop start time from the current preview playhead position. */
+	onSetLoopStartFromPlayhead?: () => void;
 	/** Run automatic navigation generation for the current menu. */
 	onAutoNav?: () => void;
 	/** Export a DAR-corrected render preview PNG for the current menu. */
@@ -131,6 +142,11 @@ export function InspectorPanel({
 	onUpdateMotionAudioAsset,
 	onUpdateMotionDurationSecs,
 	onUpdateMotionLoopCount,
+	onUpdateMotionLoopStart,
+	onUpdateMotionIntroStart,
+	onUpdateMotionIntroDuration,
+	onUpdateMotionTimeoutAction,
+	onSetLoopStartFromPlayhead,
 	onAutoNav,
 	onExportRenderPreview,
 	buttonPreviewState,
@@ -189,6 +205,11 @@ export function InspectorPanel({
 							onUpdateMotionAudioAsset={onUpdateMotionAudioAsset}
 							onUpdateMotionDurationSecs={onUpdateMotionDurationSecs}
 							onUpdateMotionLoopCount={onUpdateMotionLoopCount}
+							onUpdateMotionLoopStart={onUpdateMotionLoopStart}
+							onUpdateMotionIntroStart={onUpdateMotionIntroStart}
+							onUpdateMotionIntroDuration={onUpdateMotionIntroDuration}
+							onUpdateMotionTimeoutAction={onUpdateMotionTimeoutAction}
+							onSetLoopStartFromPlayhead={onSetLoopStartFromPlayhead}
 							onAutoNav={onAutoNav}
 							onExportRenderPreview={onExportRenderPreview}
 							displayAspect={displayAspect ?? 'four-by-three'}

--- a/apps/spindle/src/components/menus/MenuEditor.tsx
+++ b/apps/spindle/src/components/menus/MenuEditor.tsx
@@ -9,6 +9,7 @@ import type { CSSProperties } from 'react';
 import { save } from '@tauri-apps/plugin-dialog';
 import { exportMenuRenderPreview, listAvailableFonts } from 'tauri-plugin-spindle-project-api';
 import { useProjectStore } from '../../store/project-store';
+import { useMenuPlaybackStore } from '../../store/menu-playback-store';
 import type { DisplayDensity } from '../../hooks/useDisplayDensity';
 import type {
 	AspectMode,
@@ -17,6 +18,7 @@ import type {
 	MenuButton,
 	MenuHighlightColours,
 	MenuRole,
+	PlaybackAction,
 	SpindleProjectFile,
 	SceneNode,
 } from '../../types/project';
@@ -483,6 +485,41 @@ export function MenuEditor({
 		}));
 	};
 
+	const handleMotionLoopStartChange = (secs: number) => {
+		updateMenuDocument(menu.id, (document) => ({
+			...document,
+			timing: { ...document.timing, loopStartSecs: Math.max(0, secs) },
+		}));
+	};
+
+	const handleMotionIntroStartChange = (secs: number) => {
+		updateMenuDocument(menu.id, (document) => ({
+			...document,
+			timing: { ...document.timing, introStartSecs: Math.max(0, secs) },
+		}));
+	};
+
+	const handleMotionIntroDurationChange = (secs: number | null) => {
+		// A cleared input writes 0.0 (no intro authored), mirroring
+		// `handleMotionDurationChange`'s loop-duration sentinel.
+		updateMenuDocument(menu.id, (document) => ({
+			...document,
+			timing: { ...document.timing, introDurationSecs: Math.max(0, secs ?? 0.0) },
+		}));
+	};
+
+	const handleMotionTimeoutActionChange = (action: PlaybackAction | null) => {
+		updateMenuDocument(menu.id, (document) => ({
+			...document,
+			interaction: { ...document.interaction, timeoutAction: action },
+		}));
+	};
+
+	const handleSetLoopStartFromPlayhead = () => {
+		const currentTime = useMenuPlaybackStore.getState().currentTime;
+		handleMotionLoopStartChange(currentTime);
+	};
+
 	const handleDisplayAspectChange = (aspect: AspectMode) => {
 		updateMenuDocument(menu.id, (document) => ({
 			...document,
@@ -772,6 +809,8 @@ export function MenuEditor({
 								backgroundLabel={backgroundAssetLabel}
 								backgroundColour={menu.authoredDocument?.scene.background.colour ?? null}
 								backgroundAsset={backgroundAsset}
+								backgroundIsMotion={menu.authoredDocument?.backgroundMode === 'motion'}
+								backgroundInitialTimeSecs={menu.authoredDocument?.timing.loopStartSecs ?? 0}
 								defaultButtonId={defaultFocusId}
 								previewMode={previewMode}
 								highlightColours={highlightColours}
@@ -817,6 +856,11 @@ export function MenuEditor({
 								onUpdateMotionAudioAsset={handleMotionAudioChange}
 								onUpdateMotionDurationSecs={handleMotionDurationChange}
 								onUpdateMotionLoopCount={handleMotionLoopCountChange}
+								onUpdateMotionLoopStart={handleMotionLoopStartChange}
+								onUpdateMotionIntroStart={handleMotionIntroStartChange}
+								onUpdateMotionIntroDuration={handleMotionIntroDurationChange}
+								onUpdateMotionTimeoutAction={handleMotionTimeoutActionChange}
+								onSetLoopStartFromPlayhead={handleSetLoopStartFromPlayhead}
 								onAutoNav={onAutoNav}
 								onExportRenderPreview={
 									menu.authoredDocument ? handleExportRenderPreview : undefined

--- a/apps/spindle/src/components/menus/MenuLevelInspector.tsx
+++ b/apps/spindle/src/components/menus/MenuLevelInspector.tsx
@@ -15,6 +15,7 @@ import type {
 	Menu,
 	MenuDomain,
 	MenuRole,
+	PlaybackAction,
 	Asset,
 	AspectMode,
 	FormatProfile,
@@ -26,6 +27,7 @@ import { actionToString, stringToAction } from './inspectorHelpers';
 import { computeDiagnostics } from './inspectorDiagnostics';
 import { terminologyFor } from '../../format/terminology';
 import { DEFAULT_DVD_FORMAT_PROFILE } from '../../format/useFormatProfile';
+import { useMenuPlaybackStore } from '../../store/menu-playback-store';
 
 /** Every `MenuRole`, in a stable display order for the role picker. */
 const ROLE_ORDER: MenuRole[] = ['root', 'title-select', 'chapter', 'setup', 'extras', 'popup'];
@@ -51,6 +53,11 @@ export function MenuLevelInspector({
 	onUpdateMotionAudioAsset,
 	onUpdateMotionDurationSecs,
 	onUpdateMotionLoopCount,
+	onUpdateMotionLoopStart,
+	onUpdateMotionIntroStart,
+	onUpdateMotionIntroDuration,
+	onUpdateMotionTimeoutAction,
+	onSetLoopStartFromPlayhead,
 	onAutoNav,
 	onExportRenderPreview,
 	displayAspect,
@@ -79,6 +86,11 @@ export function MenuLevelInspector({
 	onUpdateMotionAudioAsset?: (assetId: string | null) => void;
 	onUpdateMotionDurationSecs?: (secs: number | null) => void;
 	onUpdateMotionLoopCount?: (count: number) => void;
+	onUpdateMotionLoopStart?: (secs: number) => void;
+	onUpdateMotionIntroStart?: (secs: number) => void;
+	onUpdateMotionIntroDuration?: (secs: number | null) => void;
+	onUpdateMotionTimeoutAction?: (action: PlaybackAction | null) => void;
+	onSetLoopStartFromPlayhead?: () => void;
 	onAutoNav?: () => void;
 	onExportRenderPreview?: () => void;
 	displayAspect: AspectMode;
@@ -113,6 +125,9 @@ export function MenuLevelInspector({
 			asset.videoStreams.length > 0 || asset.fileName.match(/\.(png|jpg|jpeg|bmp|tiff?)$/i),
 	);
 	const audioAssets = assets.filter((asset) => asset.audioStreams.length > 0);
+	const playbackDuration = useMenuPlaybackStore((s) => s.duration);
+	const playbackCurrentTime = useMenuPlaybackStore((s) => s.currentTime);
+	const playbackSeek = useMenuPlaybackStore((s) => s.seek);
 	const [backgroundTab, setBackgroundTab] = useState<'solid' | 'image' | 'video' | 'audio'>(
 		document?.backgroundMode === 'motion' ? 'video' : 'solid',
 	);
@@ -281,10 +296,6 @@ export function MenuLevelInspector({
 						className={`inspector-panel__fieldset ${document?.backgroundMode !== 'motion' ? 'inspector-panel__fieldset--disabled' : ''}`}
 					>
 						<div className="inspector-panel__sub-label">Motion Settings</div>
-						<p className="inspector-panel__hint text-muted">
-							These controls preserve authored intent, but motion-menu build and runtime support are
-							still blocked until the next backend slice lands.
-						</p>
 						<div className="inspector-panel__grid-2">
 							<label className="inspector-panel__field">
 								<span className="inspector-panel__field-label">Duration</span>
@@ -324,6 +335,92 @@ export function MenuLevelInspector({
 								</div>
 							</label>
 						</div>
+						<div className="inspector-panel__grid-2">
+							<label className="inspector-panel__field">
+								<span className="inspector-panel__field-label">Loop start</span>
+								<div className="inspector-panel__inline-unit">
+									<input
+										className="inspector-panel__input inspector-panel__input--num"
+										type="number"
+										min="0"
+										step="0.1"
+										value={document?.timing.loopStartSecs ?? 0}
+										onChange={(e) => onUpdateMotionLoopStart?.(Number(e.target.value))}
+										disabled={document?.backgroundMode !== 'motion'}
+									/>
+									<span className="inspector-panel__unit">s</span>
+								</div>
+							</label>
+							<div className="inspector-panel__field">
+								<span className="inspector-panel__field-label">&nbsp;</span>
+								<button
+									type="button"
+									className="btn btn--sm btn--ghost"
+									onClick={onSetLoopStartFromPlayhead}
+									disabled={document?.backgroundMode !== 'motion'}
+									title="Set loop start to the current preview playhead position"
+								>
+									Set loop start from playhead
+								</button>
+							</div>
+						</div>
+						<div className="inspector-panel__grid-2">
+							<label className="inspector-panel__field">
+								<span className="inspector-panel__field-label">Intro start</span>
+								<div className="inspector-panel__inline-unit">
+									<input
+										className="inspector-panel__input inspector-panel__input--num"
+										type="number"
+										min="0"
+										step="0.1"
+										value={document?.timing.introStartSecs ?? 0}
+										onChange={(e) => onUpdateMotionIntroStart?.(Number(e.target.value))}
+										disabled={document?.backgroundMode !== 'motion'}
+									/>
+									<span className="inspector-panel__unit">s</span>
+								</div>
+							</label>
+							<label className="inspector-panel__field">
+								<span className="inspector-panel__field-label">Intro duration</span>
+								<div className="inspector-panel__inline-unit">
+									<input
+										className="inspector-panel__input inspector-panel__input--num"
+										type="number"
+										min="0"
+										step="0.1"
+										value={
+											document && document.timing.introDurationSecs > 0
+												? document.timing.introDurationSecs
+												: ''
+										}
+										onChange={(e) =>
+											onUpdateMotionIntroDuration?.(
+												e.target.value === '' ? null : Number(e.target.value),
+											)
+										}
+										disabled={document?.backgroundMode !== 'motion'}
+									/>
+									<span className="inspector-panel__unit">s</span>
+								</div>
+							</label>
+						</div>
+						<label className="inspector-panel__field">
+							<span className="inspector-panel__field-label">Timeout action</span>
+							<select
+								className="inspector-panel__select"
+								value={actionToString(document?.interaction.timeoutAction ?? null)}
+								onChange={(e) => onUpdateMotionTimeoutAction?.(stringToAction(e.target.value))}
+								disabled={document?.backgroundMode !== 'motion'}
+							>
+								<option value="">No timeout action</option>
+								<ActionOptions
+									allTitles={allTitles}
+									allMenus={allMenus}
+									currentMenuId={currentMenuId}
+									menuDomain={menuDomain}
+								/>
+							</select>
+						</label>
 						<label className="inspector-panel__field">
 							<span className="inspector-panel__field-label">Audio asset</span>
 							<select
@@ -339,6 +436,21 @@ export function MenuLevelInspector({
 									</option>
 								))}
 							</select>
+						</label>
+						<label className="inspector-panel__field">
+							<span className="inspector-panel__field-label">
+								Scrub {playbackDuration > 0 ? `(${playbackDuration.toFixed(1)}s)` : ''}
+							</span>
+							<input
+								className="inspector-panel__range"
+								type="range"
+								min={0}
+								max={playbackDuration || 0}
+								step={0.1}
+								value={Math.min(playbackCurrentTime, playbackDuration || 0)}
+								onChange={(e) => playbackSeek(Number(e.target.value))}
+								disabled={document?.backgroundMode !== 'motion' || playbackDuration <= 0}
+							/>
 						</label>
 					</div>
 				</CollapsibleSection>

--- a/apps/spindle/src/components/menus/SceneCanvas.tsx
+++ b/apps/spindle/src/components/menus/SceneCanvas.tsx
@@ -1086,6 +1086,8 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 	const [loadFailed, setLoadFailed] = useState(false);
 	const posterUrl = useThumbnailBlobUrl(asset);
 	const registerVideo = useMenuPlaybackStore((s) => s.registerVideo);
+	const reportTime = useMenuPlaybackStore((s) => s.reportTime);
+	const reportDuration = useMenuPlaybackStore((s) => s.reportDuration);
 
 	useEffect(() => {
 		setLoadFailed(false);
@@ -1123,7 +1125,10 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 			poster={posterUrl ?? undefined}
 			onLoadedMetadata={(e) => {
 				e.currentTarget.currentTime = initialTimeSecs;
+				reportDuration(e.currentTarget.duration);
 			}}
+			onDurationChange={(e) => reportDuration(e.currentTarget.duration)}
+			onTimeUpdate={(e) => reportTime(e.currentTarget.currentTime)}
 			onError={() => setLoadFailed(true)}
 		/>
 	);

--- a/apps/spindle/src/components/menus/SceneCanvas.tsx
+++ b/apps/spindle/src/components/menus/SceneCanvas.tsx
@@ -17,6 +17,7 @@ import type {
 	FormatProfile,
 } from '../../types/project';
 import { DEFAULT_DVD_FORMAT_PROFILE } from '../../format/useFormatProfile';
+import { useMenuPlaybackStore } from '../../store/menu-playback-store';
 
 // The canvas's fixed interactive coordinate space width. This is *not* yet
 // sourced from `FormatProfile.designSizes` (1024 for DVD-Video) — every menu
@@ -60,8 +61,15 @@ export interface SceneCanvasProps {
 	backgroundLabel: string | null;
 	/** Solid background colour (CSS hex) when no asset is assigned. */
 	backgroundColour: string | null;
-	/** Background image asset to render behind scene nodes. */
+	/** Background image or video asset to render behind scene nodes. */
 	backgroundAsset?: Asset | null;
+	/** When true and `backgroundAsset` has a video stream, render it as a
+	 * looping `<video>` instead of a static image. */
+	backgroundIsMotion?: boolean;
+	/** Source-relative seconds to seek the background `<video>` to once its
+	 * metadata loads — the menu's authored `timing.loopStartSecs` in design
+	 * mode. Ignored for still backgrounds. */
+	backgroundInitialTimeSecs?: number;
 	defaultButtonId: string | null;
 	/** When true, render in navigation preview mode with highlight colours. */
 	previewMode: boolean;
@@ -93,6 +101,8 @@ export function SceneCanvas({
 	backgroundLabel,
 	backgroundColour,
 	backgroundAsset = null,
+	backgroundIsMotion = false,
+	backgroundInitialTimeSecs = 0,
 	defaultButtonId,
 	previewMode,
 	highlightColours,
@@ -115,6 +125,8 @@ export function SceneCanvas({
 				backgroundLabel={backgroundLabel}
 				backgroundColour={backgroundColour}
 				backgroundAsset={backgroundAsset}
+				backgroundIsMotion={backgroundIsMotion}
+				backgroundInitialTimeSecs={backgroundInitialTimeSecs}
 				defaultButtonId={defaultButtonId}
 				highlightColours={highlightColours}
 				honestPreview={honestPreview}
@@ -136,6 +148,8 @@ export function SceneCanvas({
 			backgroundLabel={backgroundLabel}
 			backgroundColour={backgroundColour}
 			backgroundAsset={backgroundAsset}
+			backgroundIsMotion={backgroundIsMotion}
+			backgroundInitialTimeSecs={backgroundInitialTimeSecs}
 			defaultButtonId={defaultButtonId}
 			honestPreview={honestPreview}
 			showNavLines={showNavLines}
@@ -161,6 +175,8 @@ function DesignCanvas({
 	backgroundLabel,
 	backgroundColour,
 	backgroundAsset,
+	backgroundIsMotion,
+	backgroundInitialTimeSecs,
 	defaultButtonId,
 	honestPreview,
 	showNavLines,
@@ -180,6 +196,8 @@ function DesignCanvas({
 	backgroundLabel: string | null;
 	backgroundColour: string | null;
 	backgroundAsset: Asset | null;
+	backgroundIsMotion: boolean;
+	backgroundInitialTimeSecs: number;
 	defaultButtonId: string | null;
 	honestPreview: boolean;
 	showNavLines: boolean;
@@ -506,7 +524,13 @@ function DesignCanvas({
 			}}
 			onClick={() => onSelectNode(null)}
 		>
-			{backgroundAsset && <BackgroundImage asset={backgroundAsset} />}
+			{backgroundAsset && (
+				<BackgroundMedia
+					asset={backgroundAsset}
+					isMotion={backgroundIsMotion}
+					initialTimeSecs={backgroundInitialTimeSecs}
+				/>
+			)}
 			{backgroundLabel && (
 				<div className="scene-canvas__bg-label text-muted">{backgroundLabel}</div>
 			)}
@@ -653,6 +677,8 @@ function NavigationPreview({
 	backgroundLabel,
 	backgroundColour,
 	backgroundAsset,
+	backgroundIsMotion,
+	backgroundInitialTimeSecs,
 	defaultButtonId,
 	highlightColours,
 	honestPreview,
@@ -667,6 +693,8 @@ function NavigationPreview({
 	backgroundLabel: string | null;
 	backgroundColour: string | null;
 	backgroundAsset: Asset | null;
+	backgroundIsMotion: boolean;
+	backgroundInitialTimeSecs: number;
 	defaultButtonId: string | null;
 	highlightColours: MenuHighlightColours;
 	honestPreview: boolean;
@@ -785,7 +813,13 @@ function NavigationPreview({
 				...(backgroundColour ? { backgroundColor: backgroundColour } : {}),
 			}}
 		>
-			{backgroundAsset && <BackgroundImage asset={backgroundAsset} />}
+			{backgroundAsset && (
+				<BackgroundMedia
+					asset={backgroundAsset}
+					isMotion={backgroundIsMotion}
+					initialTimeSecs={backgroundInitialTimeSecs}
+				/>
+			)}
 			{backgroundLabel && (
 				<div className="scene-canvas__bg-label text-muted">{backgroundLabel}</div>
 			)}
@@ -980,6 +1014,118 @@ function RenderedSceneNode({
 					))
 				: null}
 		</div>
+	);
+}
+
+/**
+ * Background renderer for a menu's assigned background asset — a looping
+ * `<video>` for motion menus whose asset has a video stream, otherwise a
+ * still `<img>` (see design decision D5).
+ */
+function BackgroundMedia({
+	asset,
+	isMotion = false,
+	initialTimeSecs = 0,
+}: {
+	asset: Asset;
+	isMotion?: boolean;
+	initialTimeSecs?: number;
+}) {
+	if (isMotion && asset.videoStreams.length > 0) {
+		return <BackgroundVideo asset={asset} initialTimeSecs={initialTimeSecs} />;
+	}
+	return <BackgroundImage asset={asset} />;
+}
+
+/** Load a menu background asset's cached thumbnail as a blob URL, or `null`
+ * when there is no cached thumbnail or the read fails. Used as the poster
+ * frame for `BackgroundVideo` so the canvas shows something before the
+ * video's own first frame decodes. */
+function useThumbnailBlobUrl(asset: Asset): string | null {
+	const [url, setUrl] = useState<string | null>(null);
+
+	useEffect(() => {
+		let revokedUrl: string | null = null;
+		let cancelled = false;
+
+		async function load() {
+			if (!asset.thumbnailPath) {
+				setUrl(null);
+				return;
+			}
+			const fileName = asset.thumbnailPath.split(/[/\\]/).pop();
+			if (!fileName) {
+				setUrl(null);
+				return;
+			}
+			try {
+				const bytes = await readFile(`thumbnails/${fileName}`, {
+					baseDir: BaseDirectory.AppCache,
+				});
+				if (cancelled) return;
+				const blob = new Blob([bytes], { type: 'image/jpeg' });
+				const objectUrl = URL.createObjectURL(blob);
+				revokedUrl = objectUrl;
+				setUrl(objectUrl);
+			} catch {
+				if (!cancelled) setUrl(null);
+			}
+		}
+		void load();
+
+		return () => {
+			cancelled = true;
+			if (revokedUrl) URL.revokeObjectURL(revokedUrl);
+		};
+	}, [asset.id, asset.thumbnailPath]);
+
+	return url;
+}
+
+function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTimeSecs: number }) {
+	const [loadFailed, setLoadFailed] = useState(false);
+	const posterUrl = useThumbnailBlobUrl(asset);
+	const registerVideo = useMenuPlaybackStore((s) => s.registerVideo);
+
+	useEffect(() => {
+		setLoadFailed(false);
+	}, [asset.id]);
+
+	// Unregister the video from the playback store on unmount (e.g. switching
+	// away from this menu or out of design mode) so a stale element reference
+	// doesn't linger.
+	useEffect(() => {
+		return () => registerVideo(null);
+	}, [registerVideo]);
+
+	if (loadFailed) {
+		return (
+			<div className="scene-canvas__image-placeholder" aria-hidden="true">
+				<div className="scene-canvas__image-placeholder-sun" />
+				<div className="scene-canvas__image-placeholder-horizon" />
+				<div className="scene-canvas__image-overlay">
+					<span className="scene-canvas__image-kicker">Background</span>
+					<span className="scene-canvas__image-caption">Preview unavailable</span>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<video
+			ref={registerVideo}
+			className="scene-canvas__bg-image"
+			src={convertFileSrc(asset.sourcePath)}
+			muted
+			loop
+			playsInline
+			preload="auto"
+			poster={posterUrl ?? undefined}
+			onLoadedMetadata={(e) => {
+				e.currentTarget.currentTime = initialTimeSecs;
+			}}
+			onError={() => setLoadFailed(true)}
+		/>
 	);
 }
 

--- a/apps/spindle/src/components/menus/SceneCanvas.tsx
+++ b/apps/spindle/src/components/menus/SceneCanvas.tsx
@@ -1088,6 +1088,7 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 	const registerVideo = useMenuPlaybackStore((s) => s.registerVideo);
 	const reportTime = useMenuPlaybackStore((s) => s.reportTime);
 	const reportDuration = useMenuPlaybackStore((s) => s.reportDuration);
+	const reportPlaying = useMenuPlaybackStore((s) => s.reportPlaying);
 	const videoElRef = useRef<HTMLVideoElement | null>(null);
 	// Whether this mount has already retried a load failure once — the
 	// asset-scope grant (`allowAssetScope`, project-store's openProject/
@@ -1135,6 +1136,7 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 			className="scene-canvas__bg-image"
 			src={convertFileSrc(asset.sourcePath)}
 			muted
+			autoPlay
 			loop
 			playsInline
 			preload="auto"
@@ -1145,6 +1147,8 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 			}}
 			onDurationChange={(e) => reportDuration(e.currentTarget.duration)}
 			onTimeUpdate={(e) => reportTime(e.currentTarget.currentTime)}
+			onPlay={() => reportPlaying(true)}
+			onPause={() => reportPlaying(false)}
 			onError={() => {
 				if (!retriedRef.current) {
 					retriedRef.current = true;

--- a/apps/spindle/src/components/menus/SceneCanvas.tsx
+++ b/apps/spindle/src/components/menus/SceneCanvas.tsx
@@ -1088,9 +1088,25 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 	const registerVideo = useMenuPlaybackStore((s) => s.registerVideo);
 	const reportTime = useMenuPlaybackStore((s) => s.reportTime);
 	const reportDuration = useMenuPlaybackStore((s) => s.reportDuration);
+	const videoElRef = useRef<HTMLVideoElement | null>(null);
+	// Whether this mount has already retried a load failure once — the
+	// asset-scope grant (`allowAssetScope`, project-store's openProject/
+	// importAssets/relinkAsset) can still be landing when this element starts
+	// loading, so one retry avoids a permanent "Preview unavailable" for a
+	// background that's actually fine.
+	const retriedRef = useRef(false);
+
+	const setVideoRef = useCallback(
+		(el: HTMLVideoElement | null) => {
+			videoElRef.current = el;
+			registerVideo(el);
+		},
+		[registerVideo],
+	);
 
 	useEffect(() => {
 		setLoadFailed(false);
+		retriedRef.current = false;
 	}, [asset.id]);
 
 	// Unregister the video from the playback store on unmount (e.g. switching
@@ -1115,7 +1131,7 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 
 	return (
 		<video
-			ref={registerVideo}
+			ref={setVideoRef}
 			className="scene-canvas__bg-image"
 			src={convertFileSrc(asset.sourcePath)}
 			muted
@@ -1129,7 +1145,14 @@ function BackgroundVideo({ asset, initialTimeSecs }: { asset: Asset; initialTime
 			}}
 			onDurationChange={(e) => reportDuration(e.currentTarget.duration)}
 			onTimeUpdate={(e) => reportTime(e.currentTarget.currentTime)}
-			onError={() => setLoadFailed(true)}
+			onError={() => {
+				if (!retriedRef.current) {
+					retriedRef.current = true;
+					setTimeout(() => videoElRef.current?.load(), 300);
+					return;
+				}
+				setLoadFailed(true);
+			}}
 		/>
 	);
 }

--- a/apps/spindle/src/components/menus/SceneEditor.test.tsx
+++ b/apps/spindle/src/components/menus/SceneEditor.test.tsx
@@ -588,6 +588,10 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 	BaseDirectory: { AppCache: 13 },
 }));
 
+vi.mock('@tauri-apps/api/core', () => ({
+	convertFileSrc: vi.fn((path: string) => `asset://localhost/${path}`),
+}));
+
 describe('SceneCanvas', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -1111,6 +1115,127 @@ describe('SceneCanvas', () => {
 		expect(container.querySelector('.scene-canvas__viewport')).toHaveStyle({
 			aspectRatio: '16 / 9',
 		});
+	});
+
+	// ── BackgroundMedia (design decision D5) ────────────────────────────────
+
+	const stillBackgroundAsset: Asset = {
+		...imageAsset,
+		id: 'asset-bg-still',
+		fileName: 'menu-bg.png',
+		sourcePath: '/tmp/menu-bg.png',
+		thumbnailPath: null,
+	};
+
+	const motionBackgroundAsset: Asset = {
+		...imageAsset,
+		id: 'asset-bg-video',
+		fileName: 'menu-bg.mp4',
+		sourcePath: '/tmp/menu-bg.mp4',
+		thumbnailPath: null,
+		videoStreams: [
+			{
+				index: 0,
+				codec: 'h264',
+				width: 1920,
+				height: 1080,
+				frameRate: 30,
+				aspectRatio: null,
+				scanType: null,
+				bitrateBps: null,
+				title: null,
+				colorTransfer: null,
+				colorPrimaries: null,
+				dolbyVisionProfile: null,
+			},
+		],
+	};
+
+	it('renders a still <img> background when the asset has no video stream', () => {
+		const { container } = render(
+			<SceneCanvas
+				buttons={buttons}
+				canvasHeight={480}
+				sceneNodes={[]}
+				onUpdateButton={vi.fn()}
+				onUpdateSceneNode={vi.fn()}
+				showSafeArea={false}
+				backgroundLabel={null}
+				backgroundColour={null}
+				backgroundAsset={stillBackgroundAsset}
+				defaultButtonId={null}
+				previewMode={false}
+				highlightColours={DEFAULT_HIGHLIGHT_COLOURS}
+				honestPreview={false}
+				showNavLines={false}
+				selectedNodeId={null}
+				onSelectNode={vi.fn()}
+			/>,
+		);
+
+		const img = container.querySelector('img.scene-canvas__bg-image');
+		expect(img).not.toBeNull();
+		expect(img?.getAttribute('src')).toBe('asset://localhost//tmp/menu-bg.png');
+		expect(container.querySelector('video')).toBeNull();
+	});
+
+	it('renders a still <img> background for a motion-capable asset when backgroundIsMotion is false', () => {
+		const { container } = render(
+			<SceneCanvas
+				buttons={buttons}
+				canvasHeight={480}
+				sceneNodes={[]}
+				onUpdateButton={vi.fn()}
+				onUpdateSceneNode={vi.fn()}
+				showSafeArea={false}
+				backgroundLabel={null}
+				backgroundColour={null}
+				backgroundAsset={motionBackgroundAsset}
+				backgroundIsMotion={false}
+				defaultButtonId={null}
+				previewMode={false}
+				highlightColours={DEFAULT_HIGHLIGHT_COLOURS}
+				honestPreview={false}
+				showNavLines={false}
+				selectedNodeId={null}
+				onSelectNode={vi.fn()}
+			/>,
+		);
+
+		expect(container.querySelector('video')).toBeNull();
+		expect(container.querySelector('img.scene-canvas__bg-image')).not.toBeNull();
+	});
+
+	it('renders a looping <video> background via convertFileSrc when the menu is a motion menu', () => {
+		const { container } = render(
+			<SceneCanvas
+				buttons={buttons}
+				canvasHeight={480}
+				sceneNodes={[]}
+				onUpdateButton={vi.fn()}
+				onUpdateSceneNode={vi.fn()}
+				showSafeArea={false}
+				backgroundLabel={null}
+				backgroundColour={null}
+				backgroundAsset={motionBackgroundAsset}
+				backgroundIsMotion={true}
+				backgroundInitialTimeSecs={2.5}
+				defaultButtonId={null}
+				previewMode={false}
+				highlightColours={DEFAULT_HIGHLIGHT_COLOURS}
+				honestPreview={false}
+				showNavLines={false}
+				selectedNodeId={null}
+				onSelectNode={vi.fn()}
+			/>,
+		);
+
+		const video = container.querySelector('video.scene-canvas__bg-image');
+		expect(video).not.toBeNull();
+		expect(video?.getAttribute('src')).toBe('asset://localhost//tmp/menu-bg.mp4');
+		expect(video).toHaveAttribute('muted');
+		expect(video).toHaveAttribute('loop');
+		expect(container.querySelector('img.scene-canvas__bg-image')).toBeNull();
 	});
 
 	it('creates generated menus with the standard-appropriate authored design height', () => {

--- a/apps/spindle/src/components/menus/inspectorDiagnostics.ts
+++ b/apps/spindle/src/components/menus/inspectorDiagnostics.ts
@@ -89,17 +89,16 @@ export function computeDiagnostics(
 	}
 
 	// Motion menu timing safety gate — a loop start of 0.0 blocks the build.
-	if (doc?.backgroundMode === 'motion') {
-		if (doc.timing.loopStartSecs === 0.0) {
-			results.push({
-				severity: 'error',
-				message:
-					'Motion menu: loop start time is 0.0 s. Set a loop start point before building — this will block the build.',
-			});
-		}
+	// The generic "background will be rendered as looping MPEG video" info
+	// notice that used to sit alongside this is gone now that motion builds
+	// are supported and the inspector has real controls for this (loop
+	// start/intro fields, scrub row) — see `MenuLevelInspector`'s Motion
+	// Settings section.
+	if (doc?.backgroundMode === 'motion' && doc.timing.loopStartSecs === 0.0) {
 		results.push({
-			severity: 'info',
-			message: 'Motion menu: background will be rendered as looping MPEG video.',
+			severity: 'error',
+			message:
+				'Motion menu: loop start time is 0.0 s. Set a loop start point before building — this will block the build.',
 		});
 	}
 

--- a/apps/spindle/src/pages/AssetsPage.test.tsx
+++ b/apps/spindle/src/pages/AssetsPage.test.tsx
@@ -10,11 +10,19 @@ import { createDefaultProject } from '../types/project';
 import { AssetsPage } from './AssetsPage';
 import type { Asset } from 'tauri-plugin-spindle-project-api';
 
-const { mockReadFile } = vi.hoisted(() => ({ mockReadFile: vi.fn() }));
+const { mockReadFile, mockConvertFileSrc } = vi.hoisted(() => ({
+	mockReadFile: vi.fn(),
+	mockConvertFileSrc: vi.fn((path: string) => `asset://localhost/${path}`),
+}));
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
 	BaseDirectory: { AppCache: 0 },
 	readFile: mockReadFile,
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+	convertFileSrc: mockConvertFileSrc,
+	invoke: vi.fn(),
 }));
 
 function buildAsset(overrides: Partial<Asset> = {}): Asset {
@@ -237,8 +245,7 @@ describe('AssetsPage', () => {
 		expect(screen.getByText('Hide details')).toBeInTheDocument();
 	});
 
-	it('loads a still-image preview via readFile and renders an img element', async () => {
-		mockReadFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+	it('loads a still-image preview via convertFileSrc and renders an img element', async () => {
 		const project = createDefaultProject();
 		project.assets = [buildAsset({ fileName: 'cover.png', sourcePath: '/media/cover.png' })];
 		useProjectStore.setState({ project });
@@ -246,10 +253,13 @@ describe('AssetsPage', () => {
 		const { container } = render(<AssetsPage />);
 
 		await waitFor(() => {
-			expect(mockReadFile).toHaveBeenCalledWith('/media/cover.png');
+			expect(mockConvertFileSrc).toHaveBeenCalledWith('/media/cover.png');
 		});
+		expect(mockReadFile).not.toHaveBeenCalled();
 		await waitFor(() => {
-			expect(container.querySelector('img.assets__row-thumb')).not.toBeNull();
+			const img = container.querySelector('img.assets__row-thumb');
+			expect(img).not.toBeNull();
+			expect(img?.getAttribute('src')).toBe('asset://localhost//media/cover.png');
 		});
 	});
 

--- a/apps/spindle/src/pages/AssetsPage.tsx
+++ b/apps/spindle/src/pages/AssetsPage.tsx
@@ -5,6 +5,7 @@
 
 import { useEffect, useState } from 'react';
 import { BaseDirectory, readFile } from '@tauri-apps/plugin-fs';
+import { convertFileSrc } from '@tauri-apps/api/core';
 import { useProjectStore } from '../store/project-store';
 import { NoProjectState } from '../components/NoProjectState';
 import type {
@@ -295,27 +296,12 @@ function AssetThumbnail({ asset, variant }: { asset: Asset; variant: 'row' | 'de
 
 		async function loadThumbnail() {
 			if (isStillImageAsset) {
-				try {
-					const bytes = await readFile(asset.sourcePath);
-					if (cancelled) {
-						return;
-					}
-					const blob = new Blob([bytes], { type: mimeTypeForImageAsset(asset.fileName) });
-					const objectUrl = URL.createObjectURL(blob);
-					revokedUrl = objectUrl;
-					setThumbnailUrl(objectUrl);
-					setLoadFailed(false);
-				} catch (error) {
-					if (!cancelled) {
-						console.warn('[assets] Still-image preview load failed', {
-							assetId: asset.id,
-							sourcePath: asset.sourcePath,
-							error,
-						});
-						setThumbnailUrl(null);
-						setLoadFailed(true);
-					}
-				}
+				// The asset protocol scope is granted per-import/relink at load
+				// time (see `allowAssetScope` in project-store.ts) — reading raw
+				// bytes via the fs plugin here was out of its scope and only
+				// worked by accident for files under the static scope.
+				setThumbnailUrl(convertFileSrc(asset.sourcePath));
+				setLoadFailed(false);
 				return;
 			}
 
@@ -400,14 +386,6 @@ function AssetThumbnail({ asset, variant }: { asset: Asset; variant: 'row' | 'de
 			</div>
 		</div>
 	);
-}
-
-function mimeTypeForImageAsset(fileName: string): string {
-	if (/\.png$/i.test(fileName)) return 'image/png';
-	if (/\.jpe?g$/i.test(fileName)) return 'image/jpeg';
-	if (/\.bmp$/i.test(fileName)) return 'image/bmp';
-	if (/\.tiff?$/i.test(fileName)) return 'image/tiff';
-	return 'application/octet-stream';
 }
 
 function CompatibilityBadge({ compat }: { compat: CompatibilityAssessment | null }) {

--- a/apps/spindle/src/store/menu-playback-store.test.ts
+++ b/apps/spindle/src/store/menu-playback-store.test.ts
@@ -1,0 +1,101 @@
+// Tests for the transient menu-playback store.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useMenuPlaybackStore } from './menu-playback-store';
+
+const initialState = useMenuPlaybackStore.getState();
+
+function fakeVideoEl(overrides: Partial<HTMLVideoElement> = {}): HTMLVideoElement {
+	return {
+		currentTime: 0,
+		duration: 12,
+		paused: true,
+		play: vi.fn().mockResolvedValue(undefined),
+		pause: vi.fn(),
+		...overrides,
+	} as unknown as HTMLVideoElement;
+}
+
+describe('menu-playback-store', () => {
+	afterEach(() => {
+		useMenuPlaybackStore.setState(initialState, true);
+	});
+
+	it('starts with no video registered and playback idle', () => {
+		const state = useMenuPlaybackStore.getState();
+		expect(state.videoEl).toBeNull();
+		expect(state.currentTime).toBe(0);
+		expect(state.playing).toBe(false);
+		expect(state.duration).toBe(0);
+	});
+
+	it('registerVideo captures the element and its initial time/duration/paused state', () => {
+		const video = fakeVideoEl({ currentTime: 3, duration: 12, paused: false });
+
+		useMenuPlaybackStore.getState().registerVideo(video);
+
+		const state = useMenuPlaybackStore.getState();
+		expect(state.videoEl).toBe(video);
+		expect(state.currentTime).toBe(3);
+		expect(state.duration).toBe(12);
+		expect(state.playing).toBe(true);
+	});
+
+	it('registerVideo(null) clears the registered element and resets derived state', () => {
+		const video = fakeVideoEl({ currentTime: 3, duration: 12, paused: false });
+		useMenuPlaybackStore.getState().registerVideo(video);
+
+		useMenuPlaybackStore.getState().registerVideo(null);
+
+		const state = useMenuPlaybackStore.getState();
+		expect(state.videoEl).toBeNull();
+		expect(state.currentTime).toBe(0);
+		expect(state.duration).toBe(0);
+		expect(state.playing).toBe(false);
+	});
+
+	it('seek sets the registered video element currentTime and store currentTime', () => {
+		const video = fakeVideoEl();
+		useMenuPlaybackStore.getState().registerVideo(video);
+
+		useMenuPlaybackStore.getState().seek(5.5);
+
+		expect(video.currentTime).toBe(5.5);
+		expect(useMenuPlaybackStore.getState().currentTime).toBe(5.5);
+	});
+
+	it('seek is a no-op when no video is registered', () => {
+		expect(() => useMenuPlaybackStore.getState().seek(5)).not.toThrow();
+		expect(useMenuPlaybackStore.getState().currentTime).toBe(0);
+	});
+
+	it('play calls videoEl.play() and sets playing true', () => {
+		const video = fakeVideoEl();
+		useMenuPlaybackStore.getState().registerVideo(video);
+
+		useMenuPlaybackStore.getState().play();
+
+		expect(video.play).toHaveBeenCalledTimes(1);
+		expect(useMenuPlaybackStore.getState().playing).toBe(true);
+	});
+
+	it('pause calls videoEl.pause() and sets playing false', () => {
+		const video = fakeVideoEl({ paused: false });
+		useMenuPlaybackStore.getState().registerVideo(video);
+		useMenuPlaybackStore.getState().play();
+
+		useMenuPlaybackStore.getState().pause();
+
+		expect(video.pause).toHaveBeenCalledTimes(1);
+		expect(useMenuPlaybackStore.getState().playing).toBe(false);
+	});
+
+	it('play/pause are no-ops when no video is registered', () => {
+		expect(() => useMenuPlaybackStore.getState().play()).not.toThrow();
+		expect(() => useMenuPlaybackStore.getState().pause()).not.toThrow();
+		expect(useMenuPlaybackStore.getState().playing).toBe(false);
+	});
+});

--- a/apps/spindle/src/store/menu-playback-store.test.ts
+++ b/apps/spindle/src/store/menu-playback-store.test.ts
@@ -93,6 +93,40 @@ describe('menu-playback-store', () => {
 		expect(useMenuPlaybackStore.getState().playing).toBe(false);
 	});
 
+	it('reportTime updates currentTime, mirroring a video timeupdate event', () => {
+		const video = fakeVideoEl();
+		useMenuPlaybackStore.getState().registerVideo(video);
+
+		useMenuPlaybackStore.getState().reportTime(7.25);
+
+		expect(useMenuPlaybackStore.getState().currentTime).toBe(7.25);
+	});
+
+	it('reportDuration updates duration, mirroring a video loadedmetadata/durationchange event', () => {
+		const video = fakeVideoEl({ duration: 0 });
+		useMenuPlaybackStore.getState().registerVideo(video);
+		expect(useMenuPlaybackStore.getState().duration).toBe(0);
+
+		useMenuPlaybackStore.getState().reportDuration(42.5);
+
+		expect(useMenuPlaybackStore.getState().duration).toBe(42.5);
+	});
+
+	it('"Set loop start from playhead" reads the value reportTime last wrote, not a stale 0', () => {
+		// Regression test: before BackgroundVideo wired its `timeupdate` handler
+		// into `reportTime`, nothing ever updated `currentTime` after
+		// `registerVideo`, so MenuEditor's `handleSetLoopStartFromPlayhead` —
+		// which reads `useMenuPlaybackStore.getState().currentTime` directly —
+		// always saw 0 regardless of where playback actually was.
+		const video = fakeVideoEl();
+		useMenuPlaybackStore.getState().registerVideo(video);
+
+		useMenuPlaybackStore.getState().reportTime(8.4);
+
+		const loopStartFromPlayhead = useMenuPlaybackStore.getState().currentTime;
+		expect(loopStartFromPlayhead).toBe(8.4);
+	});
+
 	it('play/pause are no-ops when no video is registered', () => {
 		expect(() => useMenuPlaybackStore.getState().play()).not.toThrow();
 		expect(() => useMenuPlaybackStore.getState().pause()).not.toThrow();

--- a/apps/spindle/src/store/menu-playback-store.test.ts
+++ b/apps/spindle/src/store/menu-playback-store.test.ts
@@ -132,4 +132,27 @@ describe('menu-playback-store', () => {
 		expect(() => useMenuPlaybackStore.getState().pause()).not.toThrow();
 		expect(useMenuPlaybackStore.getState().playing).toBe(false);
 	});
+
+	it('reportPlaying(true) mirrors a video onPlay event, e.g. from muted autoPlay starting', () => {
+		// Regression test: muted `autoPlay` starts the element without going
+		// through `play()`, so `playing` must be updated from the video's own
+		// `onPlay`/`onPause` events, not only from the store's own actions.
+		const video = fakeVideoEl();
+		useMenuPlaybackStore.getState().registerVideo(video);
+		expect(useMenuPlaybackStore.getState().playing).toBe(false);
+
+		useMenuPlaybackStore.getState().reportPlaying(true);
+
+		expect(useMenuPlaybackStore.getState().playing).toBe(true);
+	});
+
+	it('reportPlaying(false) mirrors a video onPause event', () => {
+		const video = fakeVideoEl({ paused: false });
+		useMenuPlaybackStore.getState().registerVideo(video);
+		expect(useMenuPlaybackStore.getState().playing).toBe(true);
+
+		useMenuPlaybackStore.getState().reportPlaying(false);
+
+		expect(useMenuPlaybackStore.getState().playing).toBe(false);
+	});
 });

--- a/apps/spindle/src/store/menu-playback-store.ts
+++ b/apps/spindle/src/store/menu-playback-store.ts
@@ -29,6 +29,11 @@ export interface MenuPlaybackState {
 	/** Record the registered video's reported duration, e.g. from a
 	 * `loadedmetadata`/`durationchange` event. */
 	reportDuration: (durationSecs: number) => void;
+	/** Record the registered video's actual play/pause state, e.g. from
+	 * `onPlay`/`onPause` events. Keeps `playing` accurate when playback
+	 * starts or stops outside of `play()`/`pause()` — notably muted
+	 * `autoPlay` starting the element without either being called. */
+	reportPlaying: (playing: boolean) => void;
 	/** Seek the registered video to `tSecs` (source-relative). No-op if no
 	 * video is registered. */
 	seek: (tSecs: number) => void;
@@ -57,6 +62,10 @@ export const useMenuPlaybackStore = create<MenuPlaybackState>((set, get) => ({
 
 	reportDuration: (durationSecs) => {
 		set({ duration: Number.isFinite(durationSecs) ? durationSecs : 0 });
+	},
+
+	reportPlaying: (playing) => {
+		set({ playing });
 	},
 
 	seek: (tSecs) => {

--- a/apps/spindle/src/store/menu-playback-store.ts
+++ b/apps/spindle/src/store/menu-playback-store.ts
@@ -12,16 +12,23 @@ export interface MenuPlaybackState {
 	/** The `<video>` element currently registered by `BackgroundMedia`'s ref
 	 * callback, or `null` when no motion background is mounted. */
 	videoEl: HTMLVideoElement | null;
-	/** Source-relative playback position in seconds. Updated by a rAF loop
-	 * reading `videoEl.currentTime` (wired up in a later PR) — for now this
-	 * mirrors the last `seek()` target so the scrub row stays in sync. */
+	/** Source-relative playback position in seconds. Kept in sync by
+	 * `reportTime`, called from the registered video's `timeupdate` handler
+	 * (coarse, browser-native ~4Hz — a rAF loop for smoother scrubbing is a
+	 * later PR) as well as `seek()`. */
 	currentTime: number;
 	playing: boolean;
 	/** The video element's reported duration in seconds, or 0 before metadata
-	 * has loaded. */
+	 * has loaded. Kept in sync by `reportDuration`. */
 	duration: number;
 	/** Register (or clear, with `null`) the mounted preview `<video>` element. */
 	registerVideo: (el: HTMLVideoElement | null) => void;
+	/** Record the registered video's current playback position, e.g. from a
+	 * `timeupdate` event. */
+	reportTime: (tSecs: number) => void;
+	/** Record the registered video's reported duration, e.g. from a
+	 * `loadedmetadata`/`durationchange` event. */
+	reportDuration: (durationSecs: number) => void;
 	/** Seek the registered video to `tSecs` (source-relative). No-op if no
 	 * video is registered. */
 	seek: (tSecs: number) => void;
@@ -42,6 +49,14 @@ export const useMenuPlaybackStore = create<MenuPlaybackState>((set, get) => ({
 			duration: el?.duration || 0,
 			playing: el ? !el.paused : false,
 		});
+	},
+
+	reportTime: (tSecs) => {
+		set({ currentTime: Number.isFinite(tSecs) ? tSecs : 0 });
+	},
+
+	reportDuration: (durationSecs) => {
+		set({ duration: Number.isFinite(durationSecs) ? durationSecs : 0 });
 	},
 
 	seek: (tSecs) => {

--- a/apps/spindle/src/store/menu-playback-store.ts
+++ b/apps/spindle/src/store/menu-playback-store.ts
@@ -1,0 +1,67 @@
+// Transient playback state for a motion menu's preview <video> element.
+//
+// Deliberately NOT part of project-store: play/pause/seek/currentTime are
+// ephemeral UI state, not project data, and must never enter undo history.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+import { create } from 'zustand';
+
+export interface MenuPlaybackState {
+	/** The `<video>` element currently registered by `BackgroundMedia`'s ref
+	 * callback, or `null` when no motion background is mounted. */
+	videoEl: HTMLVideoElement | null;
+	/** Source-relative playback position in seconds. Updated by a rAF loop
+	 * reading `videoEl.currentTime` (wired up in a later PR) — for now this
+	 * mirrors the last `seek()` target so the scrub row stays in sync. */
+	currentTime: number;
+	playing: boolean;
+	/** The video element's reported duration in seconds, or 0 before metadata
+	 * has loaded. */
+	duration: number;
+	/** Register (or clear, with `null`) the mounted preview `<video>` element. */
+	registerVideo: (el: HTMLVideoElement | null) => void;
+	/** Seek the registered video to `tSecs` (source-relative). No-op if no
+	 * video is registered. */
+	seek: (tSecs: number) => void;
+	play: () => void;
+	pause: () => void;
+}
+
+export const useMenuPlaybackStore = create<MenuPlaybackState>((set, get) => ({
+	videoEl: null,
+	currentTime: 0,
+	playing: false,
+	duration: 0,
+
+	registerVideo: (el) => {
+		set({
+			videoEl: el,
+			currentTime: el?.currentTime ?? 0,
+			duration: el?.duration || 0,
+			playing: el ? !el.paused : false,
+		});
+	},
+
+	seek: (tSecs) => {
+		const { videoEl } = get();
+		if (!videoEl) return;
+		videoEl.currentTime = tSecs;
+		set({ currentTime: tSecs });
+	},
+
+	play: () => {
+		const { videoEl } = get();
+		if (!videoEl) return;
+		void videoEl.play();
+		set({ playing: true });
+	},
+
+	pause: () => {
+		const { videoEl } = get();
+		if (!videoEl) return;
+		videoEl.pause();
+		set({ playing: false });
+	},
+}));

--- a/apps/spindle/src/store/project-store.test.ts
+++ b/apps/spindle/src/store/project-store.test.ts
@@ -8,6 +8,31 @@ import { useProjectStore } from './project-store';
 import { createDefaultMenuCompilePolicy, createDefaultProject } from '../types/project';
 import type { Menu, MenuDocument } from '../types/project';
 
+function fakeAsset(overrides: Partial<import('../types/project').Asset> = {}) {
+	return {
+		id: crypto.randomUUID(),
+		fileName: 'clip.mp4',
+		sourcePath: '/media/clip.mp4',
+		fileSizeBytes: null,
+		durationSecs: null,
+		containerFormat: null,
+		videoStreams: [],
+		audioStreams: [],
+		subtitleStreams: [],
+		compatibility: null,
+		compatibilityDetail: null,
+		fingerprint: null,
+		warnings: [],
+		thumbnailPath: null,
+		thumbnailError: null,
+		sourceChapters: [],
+		// Non-null so `backfillAssetFormatTitles` (fired-and-forgotten by
+		// `openProject`) has nothing stale to re-inspect.
+		formatTitle: '',
+		...overrides,
+	};
+}
+
 function menuWithDocument(
 	id: string,
 	name: string,
@@ -295,5 +320,156 @@ describe('ProjectStore: updateMenuDocument', () => {
 			height: 480,
 			fill: '#0000ff',
 		});
+	});
+});
+
+describe('ProjectStore: asset scope grant ordering', () => {
+	// Regression tests: `openProject`/`importAssets`/`relinkAsset` must await
+	// `allowAssetScope` *before* publishing the new project state. A motion
+	// background's `<video>` starts loading the instant `project` state
+	// renders, and `BackgroundVideo`'s load-failure state is sticky, so
+	// publishing state first can permanently strand the preview on "Preview
+	// unavailable" while the grant is still in flight.
+
+	beforeEach(() => {
+		useProjectStore.setState({
+			project: null,
+			filePath: null,
+			isDirty: false,
+			validationIssues: [],
+			isLoading: false,
+			undoStack: [],
+			redoStack: [],
+		});
+		vi.clearAllMocks();
+	});
+
+	/** Mock `invoke` to resolve every command with `undefined` except the ones
+	 * explicitly listed, and to record when `allow_asset_scope` resolves. */
+	function mockInvokeWithScopeTracking(
+		events: string[],
+		handlers: Record<string, (args: any) => unknown> = {},
+	) {
+		return async (cmd: string, args?: any) => {
+			if (cmd === 'plugin:spindle-project|allow_asset_scope') {
+				events.push('scope-granted');
+				return undefined;
+			}
+			if (cmd in handlers) {
+				return handlers[cmd](args);
+			}
+			return undefined;
+		};
+	}
+
+	it('openProject grants the asset scope before publishing project state', async () => {
+		const project = createDefaultProject('Opened Project');
+		project.assets = [fakeAsset({ sourcePath: '/media/opened.mp4' })];
+
+		const { open, confirm } = await import('@tauri-apps/plugin-dialog');
+		vi.mocked(open).mockResolvedValue('/path/to/project.spindle');
+		vi.mocked(confirm).mockResolvedValue(true);
+
+		const { invoke } = await import('@tauri-apps/api/core');
+		const events: string[] = [];
+		vi.mocked(invoke).mockImplementation(
+			mockInvokeWithScopeTracking(events, {
+				read_text_file: () => JSON.stringify(project),
+				'plugin:spindle-project|parse_project': () => project,
+			}),
+		);
+
+		const unsubscribe = useProjectStore.subscribe((state, prevState) => {
+			if (state.project && !prevState.project) events.push('project-published');
+		});
+
+		await useProjectStore.getState().openProject();
+		unsubscribe();
+
+		expect(events).toEqual(['scope-granted', 'project-published']);
+	});
+
+	it('importAssets grants the asset scope before publishing the new assets', async () => {
+		const project = createDefaultProject('Import Target');
+		useProjectStore.setState({ project, filePath: '/path/to/project.spindle' });
+
+		const { open } = await import('@tauri-apps/plugin-dialog');
+		vi.mocked(open).mockResolvedValue(['/media/imported.mp4']);
+
+		const { invoke } = await import('@tauri-apps/api/core');
+		const events: string[] = [];
+		vi.mocked(invoke).mockImplementation(
+			mockInvokeWithScopeTracking(events, {
+				'plugin:spindle-project|inspect_asset': () =>
+					fakeAsset({ sourcePath: '/media/imported.mp4', fileName: 'imported.mp4' }),
+			}),
+		);
+
+		const unsubscribe = useProjectStore.subscribe((state, prevState) => {
+			if (
+				(state.project?.assets.length ?? 0) > 0 &&
+				(prevState.project?.assets.length ?? 0) === 0
+			) {
+				events.push('assets-published');
+			}
+		});
+
+		await useProjectStore.getState().importAssets();
+		unsubscribe();
+
+		expect(events).toEqual(['scope-granted', 'assets-published']);
+	});
+
+	it('relinkAsset grants the asset scope before publishing the new path', async () => {
+		const asset = fakeAsset({ id: 'asset-1', sourcePath: '/old/path.mp4' });
+		const project = createDefaultProject('Relink Target');
+		project.assets = [asset];
+		useProjectStore.setState({ project, filePath: '/path/to/project.spindle' });
+
+		const { open } = await import('@tauri-apps/plugin-dialog');
+		vi.mocked(open).mockResolvedValue('/new/path.mp4');
+
+		const { invoke } = await import('@tauri-apps/api/core');
+		const events: string[] = [];
+		vi.mocked(invoke).mockImplementation(mockInvokeWithScopeTracking(events));
+
+		const unsubscribe = useProjectStore.subscribe((state, prevState) => {
+			const newPath = state.project?.assets.find((a) => a.id === 'asset-1')?.sourcePath;
+			const oldPath = prevState.project?.assets.find((a) => a.id === 'asset-1')?.sourcePath;
+			if (newPath === '/new/path.mp4' && oldPath !== '/new/path.mp4') {
+				events.push('path-published');
+			}
+		});
+
+		await useProjectStore.getState().relinkAsset('asset-1');
+		unsubscribe();
+
+		expect(events).toEqual(['scope-granted', 'path-published']);
+	});
+
+	it('openProject still publishes project state when the scope grant fails', async () => {
+		const project = createDefaultProject('Grant Fails');
+		project.assets = [fakeAsset({ sourcePath: '/media/fails.mp4' })];
+
+		const { open, confirm } = await import('@tauri-apps/plugin-dialog');
+		vi.mocked(open).mockResolvedValue('/path/to/project.spindle');
+		vi.mocked(confirm).mockResolvedValue(true);
+
+		const { invoke } = await import('@tauri-apps/api/core');
+		vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+			if (cmd === 'plugin:spindle-project|allow_asset_scope') {
+				throw new Error('scope grant failed');
+			}
+			if (cmd === 'read_text_file') return JSON.stringify(project);
+			if (cmd === 'plugin:spindle-project|parse_project') return project;
+			return undefined;
+		});
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		await useProjectStore.getState().openProject();
+
+		expect(useProjectStore.getState().project?.project.name).toBe('Grant Fails');
+		expect(warnSpy).toHaveBeenCalled();
+		warnSpy.mockRestore();
 	});
 });

--- a/apps/spindle/src/store/project-store.ts
+++ b/apps/spindle/src/store/project-store.ts
@@ -434,6 +434,17 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				path: selected,
 				...projectTraceSummary(project),
 			});
+			// Grant the asset scope *before* publishing project state — a motion
+			// background's `<video>` starts loading the moment `project` state
+			// renders, and `BackgroundVideo`'s load-failure state is sticky, so
+			// publishing first can permanently strand it on "Preview unavailable"
+			// while the grant is still in flight. A grant failure must not block
+			// opening the project, though — warn and publish anyway.
+			try {
+				await allowAssetScope(project.assets.map((a) => a.sourcePath));
+			} catch (error) {
+				console.warn('[project-store] Failed to grant asset scope on open', { error });
+			}
 			set({
 				project,
 				filePath: selected,
@@ -442,11 +453,6 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				undoStack: [],
 				redoStack: [],
 			});
-			try {
-				await allowAssetScope(project.assets.map((a) => a.sourcePath));
-			} catch (error) {
-				console.warn('[project-store] Failed to grant asset scope on open', { error });
-			}
 			await ensureProjectAssetThumbnails(project);
 			void backfillAssetFormatTitles(project);
 		} finally {
@@ -614,6 +620,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			};
 		});
 
+		// Grant the asset scope before publishing the new assets into project
+		// state — see the matching comment in `openProject`.
+		try {
+			await allowAssetScope(paths);
+		} catch (error) {
+			console.warn('[project-store] Failed to grant asset scope on import', { error });
+		}
+
 		set({
 			project: {
 				...project,
@@ -621,12 +635,6 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			},
 			isDirty: true,
 		});
-
-		try {
-			await allowAssetScope(paths);
-		} catch (error) {
-			console.warn('[project-store] Failed to grant asset scope on import', { error });
-		}
 
 		// Trigger inspection and thumbnail extraction for each new asset
 		for (const asset of newAssets) {
@@ -725,7 +733,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		useAppSettingsStore.getState().setLastMediaDir(parentDir(newPath));
 		const newFileName = newPath.split(/[/\\]/).pop() ?? newPath;
 
-		// Update path immediately
+		// Grant the asset scope before publishing the new path into project
+		// state — see the matching comment in `openProject`.
+		try {
+			await allowAssetScope([newPath]);
+		} catch (error) {
+			console.warn('[project-store] Failed to grant asset scope on relink', { error });
+		}
+
 		set({
 			project: {
 				...project,
@@ -735,12 +750,6 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			},
 			isDirty: true,
 		});
-
-		try {
-			await allowAssetScope([newPath]);
-		} catch (error) {
-			console.warn('[project-store] Failed to grant asset scope on relink', { error });
-		}
 
 		// Re-inspect the relinked file
 		try {

--- a/apps/spindle/src/store/project-store.ts
+++ b/apps/spindle/src/store/project-store.ts
@@ -21,6 +21,7 @@ import {
 	autoGenerateMenuNav as autoGenerateMenuNavCommand,
 	checkToolchain as checkToolchainCommand,
 	getCacheDir,
+	allowAssetScope,
 } from 'tauri-plugin-spindle-project-api';
 import { useAppSettingsStore } from './app-settings-store';
 import type {
@@ -441,6 +442,11 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				undoStack: [],
 				redoStack: [],
 			});
+			try {
+				await allowAssetScope(project.assets.map((a) => a.sourcePath));
+			} catch (error) {
+				console.warn('[project-store] Failed to grant asset scope on open', { error });
+			}
 			await ensureProjectAssetThumbnails(project);
 			void backfillAssetFormatTitles(project);
 		} finally {
@@ -616,6 +622,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			isDirty: true,
 		});
 
+		try {
+			await allowAssetScope(paths);
+		} catch (error) {
+			console.warn('[project-store] Failed to grant asset scope on import', { error });
+		}
+
 		// Trigger inspection and thumbnail extraction for each new asset
 		for (const asset of newAssets) {
 			try {
@@ -646,6 +658,15 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			} catch {
 				// Inspection failed — asset stays as stub with null metadata
 			}
+		}
+
+		// Defensive parity with `openProject`: fills in any thumbnail that the
+		// per-asset extraction above didn't manage to produce (e.g. the
+		// project was mutated again mid-loop) rather than leaving it blank
+		// until the next reload.
+		const { project: afterImport } = get();
+		if (afterImport) {
+			await ensureProjectAssetThumbnails(afterImport);
 		}
 	},
 
@@ -714,6 +735,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			},
 			isDirty: true,
 		});
+
+		try {
+			await allowAssetScope([newPath]);
+		} catch (error) {
+			console.warn('[project-store] Failed to grant asset scope on relink', { error });
+		}
 
 		// Re-inspect the relinked file
 		try {

--- a/plugins/tauri-plugin-spindle-project/Cargo.toml
+++ b/plugins/tauri-plugin-spindle-project/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["/examples", "/dist-js", "/guest-js", "/node_modules"]
 links = "tauri-plugin-spindle-project"
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/plugins/tauri-plugin-spindle-project/build.rs
+++ b/plugins/tauri-plugin-spindle-project/build.rs
@@ -8,6 +8,7 @@ const COMMANDS: &[&str] = &[
     "inspect_asset",
     "extract_video_thumbnail",
     "extract_image_thumbnail",
+    "allow_asset_scope",
 ];
 
 fn main() {

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -608,9 +608,13 @@ export type BuildJob =
 			/** Motion menus with an authored intro: the separate compose command for
 			 * the intro segment, run before `command` (the loop segment). */
 			introCommand?: string[] | null;
-			/** Segment duration in seconds, and the signal the executor uses to run
-			 * with progress reporting. `null`/absent for still menus. */
+			/** Loop segment duration in seconds, and the signal the executor uses to
+			 * run with progress reporting. `null`/absent for still menus. */
 			durationSecs?: number | null;
+			/** Intro segment duration in seconds, used for `introCommand`'s progress
+			 * estimation instead of `durationSecs` (the loop's duration). `null`/
+			 * absent for still menus and motion menus without an intro. */
+			introDurationSecs?: number | null;
 			label: string;
 	  }
 	| {

--- a/plugins/tauri-plugin-spindle-project/guest-js/index.ts
+++ b/plugins/tauri-plugin-spindle-project/guest-js/index.ts
@@ -605,6 +605,12 @@ export type BuildJob =
 			menuName: string;
 			outputPath: string;
 			command: string[];
+			/** Motion menus with an authored intro: the separate compose command for
+			 * the intro segment, run before `command` (the loop segment). */
+			introCommand?: string[] | null;
+			/** Segment duration in seconds, and the signal the executor uses to run
+			 * with progress reporting. `null`/absent for still menus. */
+			durationSecs?: number | null;
 			label: string;
 	  }
 	| {
@@ -903,6 +909,16 @@ export async function listAvailableFonts(project: SpindleProjectFile): Promise<F
 /** Return the application cache directory for storing thumbnails and other transient data. */
 export async function getCacheDir(): Promise<string> {
 	return await invoke('plugin:spindle-project|get_cache_dir');
+}
+
+/**
+ * Grant the asset protocol's runtime scope read access to the given absolute
+ * file paths, without widening the app's static scope. Call on
+ * `openProject`/`importAssets`/relink with the paths of the assets involved
+ * — grants are runtime-only and reset on restart.
+ */
+export async function allowAssetScope(paths: string[]): Promise<void> {
+	await invoke('plugin:spindle-project|allow_asset_scope', { paths });
 }
 
 /** Export a diagnostics bundle as a JSON string for troubleshooting. */

--- a/plugins/tauri-plugin-spindle-project/permissions/autogenerated/commands/allow_asset_scope.toml
+++ b/plugins/tauri-plugin-spindle-project/permissions/autogenerated/commands/allow_asset_scope.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-allow-asset-scope"
+description = "Enables the allow_asset_scope command without any pre-configured scope."
+commands.allow = ["allow_asset_scope"]
+
+[[permission]]
+identifier = "deny-allow-asset-scope"
+description = "Denies the allow_asset_scope command without any pre-configured scope."
+commands.deny = ["allow_asset_scope"]

--- a/plugins/tauri-plugin-spindle-project/permissions/autogenerated/reference.md
+++ b/plugins/tauri-plugin-spindle-project/permissions/autogenerated/reference.md
@@ -22,6 +22,7 @@ Default permissions for the spindle-project plugin
 - `allow-export-diagnostics`
 - `allow-list-available-fonts`
 - `allow-export-menu-render-preview`
+- `allow-allow-asset-scope`
 
 ## Permission Table
 
@@ -31,6 +32,32 @@ Default permissions for the spindle-project plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`spindle-project:allow-allow-asset-scope`
+
+</td>
+<td>
+
+Enables the allow_asset_scope command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`spindle-project:deny-allow-asset-scope`
+
+</td>
+<td>
+
+Denies the allow_asset_scope command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>

--- a/plugins/tauri-plugin-spindle-project/permissions/default.toml
+++ b/plugins/tauri-plugin-spindle-project/permissions/default.toml
@@ -19,4 +19,5 @@ permissions = [
   "allow-export-diagnostics",
   "allow-list-available-fonts",
   "allow-export-menu-render-preview",
+  "allow-allow-asset-scope",
 ]

--- a/plugins/tauri-plugin-spindle-project/permissions/schemas/schema.json
+++ b/plugins/tauri-plugin-spindle-project/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the allow_asset_scope command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-allow-asset-scope",
+          "markdownDescription": "Enables the allow_asset_scope command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the allow_asset_scope command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-allow-asset-scope",
+          "markdownDescription": "Denies the allow_asset_scope command without any pre-configured scope."
+        },
+        {
           "description": "Enables the auto_generate_menu_nav command without any pre-configured scope.",
           "type": "string",
           "const": "allow-auto-generate-menu-nav",
@@ -511,10 +523,10 @@
           "markdownDescription": "Denies the validate_project command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-estimate-disc-capacity`\n- `allow-get-format-profile`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`",
+          "description": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-estimate-disc-capacity`\n- `allow-get-format-profile`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`\n- `allow-allow-asset-scope`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-estimate-disc-capacity`\n- `allow-get-format-profile`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`"
+          "markdownDescription": "Default permissions for the spindle-project plugin\n#### This default permission set includes:\n\n- `allow-create-project`\n- `allow-parse-project`\n- `allow-serialise-project`\n- `allow-validate-project`\n- `allow-estimate-disc-capacity`\n- `allow-get-format-profile`\n- `allow-inspect-asset`\n- `allow-extract-video-thumbnail`\n- `allow-extract-image-thumbnail`\n- `allow-get-cache-dir`\n- `allow-generate-build-plan`\n- `allow-execute-build`\n- `allow-cancel-build`\n- `allow-auto-generate-menu-nav`\n- `allow-check-toolchain`\n- `allow-export-diagnostics`\n- `allow-list-available-fonts`\n- `allow-export-menu-render-preview`\n- `allow-allow-asset-scope`"
         }
       ]
     }

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/menu.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/menu.rs
@@ -245,8 +245,14 @@ fn motion_post_body(
         .menu_ref
         .timeout_action()
         .expect("uses_counter implies a resolvable timeout action");
+    // Expand PlayAllInTitleset/PlayNextInTitleset the same way menu buttons
+    // do (see `expand_playall_button_action` above) before resolving: a
+    // titleset motion menu with a positive loop count can offer either as a
+    // timeout action, but the DVD command resolver rejects both directly.
+    let expanded_for_timeout = expand_playall_button_action(timeout_action, spec.disc, spec.domain);
+    let resolved_timeout_action = expanded_for_timeout.as_ref().unwrap_or(timeout_action);
     let timeout_cmd = playback_action_to_dvd_command_in_domain_result(
-        timeout_action,
+        resolved_timeout_action,
         spec.disc,
         spec.domain,
         Some(spec.menu_number),

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/menu.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/menu.rs
@@ -130,18 +130,48 @@ fn append_menu_pgc(xml: &mut String, spec: MenuPgcSpec<'_>) -> crate::Result<()>
         Some(entry) => xml.push_str(&format!("      <pgc entry=\"{entry}\">\n")),
         None => xml.push_str("      <pgc>\n"),
     }
-    if let Some(pre) = spec.pre_commands {
+
+    let is_motion = matches!(spec.menu_ref.background_mode(), BackgroundMode::Motion);
+    let base_name = sanitise_filename(&spec.menu_ref.menu.id);
+    let loop_count = spec.menu_ref.motion_loop_count();
+    let has_intro = spec.menu_ref.menu.doc().timing.intro_duration_secs > 0.0;
+    let loop_cell = if has_intro { 2 } else { 1 };
+    // Only the counting form of the <post> (K > 0 with a resolvable timeout
+    // action) touches the counter — g0 is already taken by menu dispatch
+    // (see `dvd_navigation.rs`), so this uses g1, verified unused elsewhere.
+    let uses_counter = is_motion && loop_count > 0 && spec.menu_ref.timeout_action().is_some();
+
+    if uses_counter || spec.pre_commands.is_some() {
         xml.push_str("        <pre>\n");
-        xml.push_str(pre);
+        if uses_counter {
+            xml.push_str("          g1 = 0;\n");
+        }
+        if let Some(pre) = spec.pre_commands {
+            xml.push_str(pre);
+        }
         xml.push_str("        </pre>\n");
     }
-    let menu_vob_path = spec
-        .menus_dir
-        .join(format!("{}.mpg", sanitise_filename(&spec.menu_ref.menu.id)));
-    xml.push_str(&format!(
-        "        <vob file=\"{}\" pause=\"inf\" />\n",
-        xml_escape(&menu_vob_path.display().to_string())
-    ));
+
+    if is_motion {
+        if has_intro {
+            let intro_vob_path = spec.menus_dir.join(format!("{base_name}_intro.mpg"));
+            xml.push_str(&format!(
+                "        <vob file=\"{}\" />\n",
+                xml_escape(&intro_vob_path.display().to_string())
+            ));
+        }
+        let loop_vob_path = spec.menus_dir.join(format!("{base_name}.mpg"));
+        xml.push_str(&format!(
+            "        <vob file=\"{}\" />\n",
+            xml_escape(&loop_vob_path.display().to_string())
+        ));
+    } else {
+        let menu_vob_path = spec.menus_dir.join(format!("{base_name}.mpg"));
+        xml.push_str(&format!(
+            "        <vob file=\"{}\" pause=\"inf\" />\n",
+            xml_escape(&menu_vob_path.display().to_string())
+        ));
+    }
     for button in spec.menu_ref.buttons() {
         match button.action {
             Some(action) => {
@@ -178,8 +208,58 @@ fn append_menu_pgc(xml: &mut String, spec: MenuPgcSpec<'_>) -> crate::Result<()>
             }
         }
     }
+
+    if is_motion {
+        let post_body = motion_post_body(&spec, loop_count, loop_cell, uses_counter)?;
+        xml.push_str("        <post>\n          ");
+        xml.push_str(&post_body);
+        xml.push_str("\n        </post>\n");
+    }
+
     xml.push_str("      </pgc>\n");
     Ok(())
+}
+
+/// Derive a motion menu's `<post>` body — evaluated when the loop cell's VOB
+/// finishes playing. See design decision D3:
+///
+/// - `K == 0` (infinite loop, no counting): `jump cell N;`.
+/// - `K > 0` with a resolvable timeout action: increment a per-entry counter
+///   (`g1`, reset to 0 in `<pre>` — see `append_menu_pgc`) and keep looping
+///   until it reaches `K`, then run the timeout action.
+/// - `K > 0` with no timeout action: there is nothing to fall through to, so
+///   this degrades to the same infinite `jump cell N;` as `K == 0` — a
+///   `<post>` must never fall off the end. `menu.motion-loop-count-without-timeout`
+///   flags this authored mismatch separately (see `validation/menu.rs`).
+fn motion_post_body(
+    spec: &MenuPgcSpec<'_>,
+    loop_count: u32,
+    loop_cell: usize,
+    uses_counter: bool,
+) -> crate::Result<String> {
+    if !uses_counter {
+        return Ok(format!("jump cell {loop_cell};"));
+    }
+
+    let timeout_action = spec
+        .menu_ref
+        .timeout_action()
+        .expect("uses_counter implies a resolvable timeout action");
+    let timeout_cmd = playback_action_to_dvd_command_in_domain_result(
+        timeout_action,
+        spec.disc,
+        spec.domain,
+        Some(spec.menu_number),
+    )?;
+    let timeout_cmd = if timeout_cmd.starts_with('{') {
+        timeout_cmd
+    } else {
+        format!("{timeout_cmd};")
+    };
+
+    Ok(format!(
+        "g1 = g1 + 1; if (g1 lt {loop_count}) {{ jump cell {loop_cell}; }} g1 = 0; {timeout_cmd}"
+    ))
 }
 
 /// Expand `PlayAllInTitleset` on a menu button to a concrete `Sequence` of

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/tests.rs
@@ -31,7 +31,7 @@ fn motion_test_menu(
         id: menu_id.to_string(),
         name: menu_name.to_string(),
         domain: MenuDomain::Vmgm,
-        role: MenuRole::TitleSelect,
+        role: Some(MenuRole::TitleSelect),
         scene: MenuScene {
             design_size: MenuSize::default(),
             background: SceneBackground {

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/tests.rs
@@ -1114,3 +1114,47 @@ fn motion_menu_pgc_degrades_to_infinite_loop_when_k_positive_but_no_timeout() {
         "the degraded infinite-loop form must not touch the unused counter, got:\n{xml}"
     );
 }
+
+#[test]
+fn motion_menu_pgc_expands_play_all_in_titleset_timeout_action() {
+    // A titleset motion menu with K > 0 can offer `PlayAllInTitleset` as its
+    // timeout action — the inspector allows it and validation accepts it —
+    // but the DVD command resolver rejects that virtual action directly. The
+    // `<post>` counting path must expand it the same way menu buttons do
+    // before resolving, or build-plan generation fails for an otherwise
+    // valid authored configuration.
+    let mut project = test_project();
+    project.disc.titlesets[0]
+        .titles
+        .push(make_title("title-2", "Episode 2", 1));
+    project.disc.titlesets[0].titles[0].order_index = 0;
+
+    let menu = motion_test_menu(
+        "ts-menu-1",
+        "Titleset Motion Menu",
+        MenuTiming {
+            intro_start_secs: 0.0,
+            intro_duration_secs: 0.0,
+            loop_start_secs: 2.0,
+            loop_duration_secs: 5.0,
+            loop_count: 3,
+            audio_asset_id: None,
+        },
+        Some(PlaybackAction::PlayAllInTitleset),
+    );
+    project.disc.titlesets[0].menus.push(menu);
+
+    let xml = generate_dvdauthor_xml(
+        &project,
+        std::path::Path::new("/tmp/titles"),
+        std::path::Path::new("/tmp/menus"),
+        std::path::Path::new("/tmp/dvd_root"),
+    )
+    .unwrap();
+
+    assert!(
+        xml.contains("jump title 1") && xml.contains("jump title 2"),
+        "PlayAllInTitleset as a timeout action should expand to a sequence \
+         jumping all titles, same as it does on a button, got:\n{xml}"
+    );
+}

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/tests.rs
@@ -9,10 +9,69 @@ use crate::build::test_support::{
     test_project,
 };
 use crate::models::{
-    AspectMode, AudioOutputTarget, AudioTrackMapping, ChapterPoint, CopyMode, PlaybackAction,
-    SubtitleStreamInfo, SubtitleTrackMapping, SubtitleType, Title, VideoOutputProfile, VideoRaster,
-    VideoTrackMapping,
+    AspectMode, AudioOutputTarget, AudioTrackMapping, BackgroundMode, ChapterPoint, CopyMode,
+    FocusNode, HighlightMode, Menu, MenuCompilePolicy, MenuDocument, MenuDomain,
+    MenuHighlightColours, MenuInteractionGraph, MenuRole, MenuScene, MenuSize, MenuTiming,
+    PlaybackAction, SceneBackground, SceneNode, SubtitleStreamInfo, SubtitleTrackMapping,
+    SubtitleType, Title, VideoOutputProfile, VideoRaster, VideoTrackMapping,
 };
+
+use super::generate_dvdauthor_xml;
+
+/// Build a motion menu document with one authored button and the given
+/// timing/timeout — the motion-PGC-authoring analogue of
+/// `test_support::test_menu_with_action`, which always builds a still menu.
+fn motion_test_menu(
+    menu_id: &str,
+    menu_name: &str,
+    timing: MenuTiming,
+    timeout_action: Option<PlaybackAction>,
+) -> Menu {
+    Menu::new(menu_id, menu_name).with_document(MenuDocument {
+        id: menu_id.to_string(),
+        name: menu_name.to_string(),
+        domain: MenuDomain::Vmgm,
+        role: MenuRole::TitleSelect,
+        scene: MenuScene {
+            design_size: MenuSize::default(),
+            background: SceneBackground {
+                asset_id: Some("motion-bg".to_string()),
+                colour: None,
+            },
+            nodes: vec![SceneNode::Button {
+                id: "btn-1".to_string(),
+                label: "Play".to_string(),
+                x: 120.0,
+                y: 320.0,
+                width: 240.0,
+                height: 48.0,
+                highlight_mode: HighlightMode::Static,
+                highlight_keyframes: vec![],
+                video_asset_id: None,
+                button_style: None,
+                label_style: None,
+            }],
+            guides: vec![],
+        },
+        interaction: MenuInteractionGraph {
+            default_focus_id: Some("btn-1".to_string()),
+            nodes: vec![FocusNode {
+                node_id: "btn-1".to_string(),
+                action: Some(PlaybackAction::PlayTitle {
+                    title_id: "title-1".to_string(),
+                }),
+                ..FocusNode::default()
+            }],
+            timeout_action,
+        },
+        timing,
+        highlight_colours: MenuHighlightColours::default(),
+        background_mode: BackgroundMode::Motion,
+        theme_ref: None,
+        generation_meta: None,
+        compile_policy: MenuCompilePolicy::default(),
+    })
+}
 
 fn make_title(id: &str, name: &str, order_index: u32) -> Title {
     Title {
@@ -862,5 +921,196 @@ fn menu_button_order_preserved_with_mixed_action_and_no_action_buttons() {
     assert!(
         buttons[2].contains("exit"),
         "Slot 3 should be the stop/exit button"
+    );
+}
+
+// ── Motion menu <post>/<vob> authoring (design decision D3) ────────────────
+
+#[test]
+fn still_menu_pgc_keeps_pause_inf_and_no_post() {
+    let mut project = test_project();
+    project.disc.global_menus.push(test_menu());
+
+    let xml = generate_dvdauthor_xml(
+        &project,
+        std::path::Path::new("/tmp/titles"),
+        std::path::Path::new("/tmp/menus"),
+        std::path::Path::new("/tmp/dvd_root"),
+    )
+    .unwrap();
+
+    assert!(
+        xml.contains("pause=\"inf\""),
+        "still menu vob should keep pause=\"inf\", got:\n{xml}"
+    );
+    // The titles section has its own unrelated `<post>` (end action), so
+    // scope this assertion to the menus section only.
+    let menus_section = xml
+        .split("<menus>")
+        .nth(1)
+        .and_then(|s| s.split("</menus>").next())
+        .expect("expected a <menus> section");
+    assert!(
+        !menus_section.contains("<post>"),
+        "still menu pgc should not emit a <post>, got:\n{xml}"
+    );
+}
+
+#[test]
+fn motion_menu_pgc_no_intro_uses_single_vob_without_pause_and_jumps_cell_one() {
+    let mut project = test_project();
+    let menu = motion_test_menu(
+        "menu-1",
+        "Motion Menu",
+        MenuTiming {
+            intro_start_secs: 0.0,
+            intro_duration_secs: 0.0,
+            loop_start_secs: 2.0,
+            loop_duration_secs: 5.0,
+            loop_count: 0,
+            audio_asset_id: None,
+        },
+        None,
+    );
+    project.disc.global_menus.push(menu);
+
+    let xml = generate_dvdauthor_xml(
+        &project,
+        std::path::Path::new("/tmp/titles"),
+        std::path::Path::new("/tmp/menus"),
+        std::path::Path::new("/tmp/dvd_root"),
+    )
+    .unwrap();
+
+    assert!(
+        !xml.contains("pause=\"inf\""),
+        "motion menu vob must not carry pause=\"inf\", got:\n{xml}"
+    );
+    assert!(
+        xml.contains("menu-1.mpg\" />"),
+        "expected an un-paused vob for the loop cell, got:\n{xml}"
+    );
+    assert!(
+        !xml.contains("menu-1_intro.mpg"),
+        "no intro was authored, so no intro vob should be emitted, got:\n{xml}"
+    );
+    assert!(
+        xml.contains("<post>\n          jump cell 1;\n        </post>"),
+        "K == 0 should lower to an infinite jump cell 1, got:\n{xml}"
+    );
+}
+
+#[test]
+fn motion_menu_pgc_with_intro_emits_two_vobs_and_targets_loop_cell_two() {
+    let mut project = test_project();
+    let menu = motion_test_menu(
+        "menu-1",
+        "Motion Menu",
+        MenuTiming {
+            intro_start_secs: 0.0,
+            intro_duration_secs: 1.5,
+            loop_start_secs: 2.0,
+            loop_duration_secs: 5.0,
+            loop_count: 0,
+            audio_asset_id: None,
+        },
+        None,
+    );
+    project.disc.global_menus.push(menu);
+
+    let xml = generate_dvdauthor_xml(
+        &project,
+        std::path::Path::new("/tmp/titles"),
+        std::path::Path::new("/tmp/menus"),
+        std::path::Path::new("/tmp/dvd_root"),
+    )
+    .unwrap();
+
+    let intro_pos = xml.find("menu-1_intro.mpg").expect("expected intro vob");
+    let loop_pos = xml.find("menu-1.mpg").expect("expected loop vob");
+    assert!(
+        intro_pos < loop_pos,
+        "intro vob (cell 1) must come before the loop vob (cell 2), got:\n{xml}"
+    );
+    assert!(
+        xml.contains("<post>\n          jump cell 2;\n        </post>"),
+        "with an intro, the loop cell is 2, got:\n{xml}"
+    );
+}
+
+#[test]
+fn motion_menu_pgc_counts_loop_and_falls_through_to_timeout_when_k_positive() {
+    let mut project = test_project();
+    let menu = motion_test_menu(
+        "menu-1",
+        "Motion Menu",
+        MenuTiming {
+            intro_start_secs: 0.0,
+            intro_duration_secs: 0.0,
+            loop_start_secs: 2.0,
+            loop_duration_secs: 5.0,
+            loop_count: 3,
+            audio_asset_id: None,
+        },
+        Some(PlaybackAction::PlayTitle {
+            title_id: "title-1".to_string(),
+        }),
+    );
+    project.disc.global_menus.push(menu);
+
+    let xml = generate_dvdauthor_xml(
+        &project,
+        std::path::Path::new("/tmp/titles"),
+        std::path::Path::new("/tmp/menus"),
+        std::path::Path::new("/tmp/dvd_root"),
+    )
+    .unwrap();
+
+    assert!(
+        xml.contains("<pre>\n          g1 = 0;\n"),
+        "re-entering the pgc must reset the loop counter, got:\n{xml}"
+    );
+    assert!(
+        xml.contains(
+            "<post>\n          g1 = g1 + 1; if (g1 lt 3) { jump cell 1; } g1 = 0; jump title 1;\n        </post>"
+        ),
+        "K > 0 with a timeout action should count and fall through, got:\n{xml}"
+    );
+}
+
+#[test]
+fn motion_menu_pgc_degrades_to_infinite_loop_when_k_positive_but_no_timeout() {
+    let mut project = test_project();
+    let menu = motion_test_menu(
+        "menu-1",
+        "Motion Menu",
+        MenuTiming {
+            intro_start_secs: 0.0,
+            intro_duration_secs: 0.0,
+            loop_start_secs: 2.0,
+            loop_duration_secs: 5.0,
+            loop_count: 3,
+            audio_asset_id: None,
+        },
+        None,
+    );
+    project.disc.global_menus.push(menu);
+
+    let xml = generate_dvdauthor_xml(
+        &project,
+        std::path::Path::new("/tmp/titles"),
+        std::path::Path::new("/tmp/menus"),
+        std::path::Path::new("/tmp/dvd_root"),
+    )
+    .unwrap();
+
+    assert!(
+        xml.contains("<post>\n          jump cell 1;\n        </post>"),
+        "K > 0 with no timeout must degrade to the same infinite jump as K == 0 \
+         (a <post> must never fall off the end), got:\n{xml}"
+    );
+    assert!(
+        !xml.contains("g1"),
+        "the degraded infinite-loop form must not touch the unused counter, got:\n{xml}"
     );
 }

--- a/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/capacity.rs
@@ -114,7 +114,12 @@ pub fn estimate_disc_capacity(project: &SpindleProjectFile) -> CapacityEstimate 
             let doc = menu.doc();
             if doc.background_mode == BackgroundMode::Motion {
                 if let Some(secs) = doc.motion_loop_duration() {
-                    return (MOTION_MENU_BITRATE_BPS * secs) / 8.0;
+                    // The build also emits a separate `{id}_intro.mpg` at the
+                    // same bitrate when an intro is authored (see
+                    // `plan_motion_segments`'s `has_intro`), so its bytes must
+                    // be counted too or the estimate understates real output.
+                    let intro_secs = doc.timing.intro_duration_secs.max(0.0);
+                    return (MOTION_MENU_BITRATE_BPS * (secs + intro_secs)) / 8.0;
                 }
             }
             STILL_MENU_BYTES
@@ -462,6 +467,45 @@ mod tests {
         let estimate = estimate_disc_capacity(&project);
 
         assert_eq!(estimate.estimated_menu_bytes, STILL_MENU_BYTES);
+    }
+
+    #[test]
+    fn motion_menu_with_intro_prices_higher_than_without() {
+        // Regression test: the build emits a separate `{id}_intro.mpg` at the
+        // same bitrate when `timing.intro_duration_secs > 0` (see
+        // `plan_motion_segments`'s `has_intro`), so the capacity estimate
+        // must include those bytes too, not just the loop segment.
+        let mut project = test_project();
+        let mut menu = test_menu();
+        menu.doc_mut().background_mode = BackgroundMode::Motion;
+        menu.doc_mut().timing.loop_duration_secs = 10.0;
+        menu.doc_mut().timing.intro_duration_secs = 0.0;
+        project.disc.titlesets[0].menus.push(menu.clone());
+
+        let without_intro = estimate_disc_capacity(&project);
+
+        menu.doc_mut().timing.intro_duration_secs = 5.0;
+        project.disc.titlesets[0].menus[0] = menu;
+
+        let with_intro = estimate_disc_capacity(&project);
+
+        assert!(
+            with_intro.estimated_menu_bytes > without_intro.estimated_menu_bytes,
+            "expected an authored intro segment to add bytes to the estimate, \
+             got with_intro={} without_intro={}",
+            with_intro.estimated_menu_bytes,
+            without_intro.estimated_menu_bytes
+        );
+        let expected_delta = (MOTION_MENU_BITRATE_BPS * 5.0) / 8.0;
+        assert!(
+            (with_intro.estimated_menu_bytes - without_intro.estimated_menu_bytes - expected_delta)
+                .abs()
+                < 1.0,
+            "expected the delta to equal the intro segment's own bytes at the motion bitrate, \
+             got delta={} expected={}",
+            with_intro.estimated_menu_bytes - without_intro.estimated_menu_bytes,
+            expected_delta
+        );
     }
 
     #[test]

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
@@ -113,6 +113,8 @@ where
             BuildJob::RenderMenu {
                 menu_id,
                 command,
+                intro_command,
+                duration_secs,
                 output_path: _,
                 standard,
                 highlight_image_path,
@@ -224,16 +226,94 @@ where
                     return failure(plan, log_lines, i, msg);
                 }
 
-                log_lines.push(format!("  $ {}", command.join(" ")));
-                match run_command(command) {
-                    Ok(output) => {
-                        if !output.is_empty() {
-                            log_lines.push(output);
+                if let Some(seg_duration) = duration_secs {
+                    // Motion menu: run the intro compose (when authored) then
+                    // the loop compose, both via the progress-reporting
+                    // ffmpeg runner — mirrors `TranscodeTitle`'s
+                    // `pass1_command` pattern.
+                    if let Some(intro_command) = intro_command {
+                        log_lines.push(format!("  $ {}", intro_command.join(" ")));
+                        on_progress(BuildProgress::job(
+                            i,
+                            total,
+                            label.clone(),
+                            BuildJobStatus::Running,
+                            None,
+                        ));
+                        match run_ffmpeg_command(
+                            intro_command,
+                            Some(*seg_duration),
+                            i,
+                            total,
+                            &label,
+                            "Motion menu intro compose",
+                            &mut on_progress,
+                        ) {
+                            Ok(output) => {
+                                if !output.is_empty() {
+                                    log_lines.push(output);
+                                }
+                            }
+                            Err(msg) => {
+                                log_lines.push(msg.clone());
+                                on_progress(BuildProgress::job(
+                                    i,
+                                    total,
+                                    label.clone(),
+                                    BuildJobStatus::Failed,
+                                    Some(msg.clone()),
+                                ));
+                                return failure(plan, log_lines, i, msg);
+                            }
                         }
                     }
-                    Err(msg) => {
-                        log_lines.push(msg.clone());
-                        return failure(plan, log_lines, i, msg);
+
+                    log_lines.push(format!("  $ {}", command.join(" ")));
+                    on_progress(BuildProgress::job(
+                        i,
+                        total,
+                        label.clone(),
+                        BuildJobStatus::Running,
+                        None,
+                    ));
+                    match run_ffmpeg_command(
+                        command,
+                        Some(*seg_duration),
+                        i,
+                        total,
+                        &label,
+                        "Motion menu loop compose",
+                        &mut on_progress,
+                    ) {
+                        Ok(output) => {
+                            if !output.is_empty() {
+                                log_lines.push(output);
+                            }
+                        }
+                        Err(msg) => {
+                            log_lines.push(msg.clone());
+                            on_progress(BuildProgress::job(
+                                i,
+                                total,
+                                label,
+                                BuildJobStatus::Failed,
+                                Some(msg.clone()),
+                            ));
+                            return failure(plan, log_lines, i, msg);
+                        }
+                    }
+                } else {
+                    log_lines.push(format!("  $ {}", command.join(" ")));
+                    match run_command(command) {
+                        Ok(output) => {
+                            if !output.is_empty() {
+                                log_lines.push(output);
+                            }
+                        }
+                        Err(msg) => {
+                            log_lines.push(msg.clone());
+                            return failure(plan, log_lines, i, msg);
+                        }
                     }
                 }
             }

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/mod.rs
@@ -115,6 +115,7 @@ where
                 command,
                 intro_command,
                 duration_secs,
+                intro_duration_secs,
                 output_path: _,
                 standard,
                 highlight_image_path,
@@ -240,9 +241,18 @@ where
                             BuildJobStatus::Running,
                             None,
                         ));
+                        // Use the intro's own duration for progress, not the
+                        // loop's `seg_duration` — an authored intro can run
+                        // for a very different length of time than the loop,
+                        // so reusing the loop duration misreports progress
+                        // (e.g. a 2s intro against a 30s loop reports ~7% at
+                        // completion). Fall back to `seg_duration` only if a
+                        // planner somehow omitted it, so progress reporting
+                        // degrades gracefully rather than panicking.
+                        let intro_seg_duration = intro_duration_secs.unwrap_or(*seg_duration);
                         match run_ffmpeg_command(
                             intro_command,
-                            Some(*seg_duration),
+                            Some(intro_seg_duration),
                             i,
                             total,
                             &label,

--- a/plugins/tauri-plugin-spindle-project/src/build/executor/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/executor/tests.rs
@@ -14,7 +14,10 @@ use crate::build::test_support::{test_menu_with_action, test_project};
 use crate::build::{
     execute_build_plan, generate_build_plan, BuildJob, BuildPlan, BuildProgress, BuildSummary,
 };
-use crate::models::{PlaybackAction, SubtitleRenderMode, SubtitleStreamInfo, SubtitleType};
+use crate::models::{
+    BackgroundMode, MenuTiming, PlaybackAction, SubtitleRenderMode, SubtitleStreamInfo,
+    SubtitleType,
+};
 
 use super::{reset_workspace_directory, subtitle_file_has_cues};
 
@@ -610,6 +613,222 @@ fn execute_build_plan_smoke_authors_text_subtitle_stream() {
             .any(|line| line.trim() == "dvd_subtitle"),
         "expected authored title MPEG to include a dvd_subtitle stream, got:\n{subtitle_codecs}"
     );
+
+    fs::remove_dir_all(&output_dir).unwrap();
+}
+
+#[test]
+#[ignore = "requires ffmpeg, ffprobe, spumux, and dvdauthor on PATH"]
+fn execute_build_plan_smoke_authors_motion_menu_intro_and_loop() {
+    // Real-subprocess regression test for the motion-menu backend (design
+    // decisions D1/D3): a single ffmpeg compose per segment (intro + loop),
+    // spumux run only on the loop segment, and a dvdauthor `<post>` that
+    // counts loops and falls through to the timeout action.
+    let Some(ffmpeg_bin) = find_tool_on_path("ffmpeg") else {
+        eprintln!("Skipping smoke test because `ffmpeg` is not available on PATH.");
+        return;
+    };
+    let Some(ffprobe_bin) = find_tool_on_path("ffprobe") else {
+        eprintln!("Skipping smoke test because `ffprobe` is not available on PATH.");
+        return;
+    };
+    if find_tool_on_path("spumux").is_none() || find_tool_on_path("dvdauthor").is_none() {
+        eprintln!(
+            "Skipping smoke test because `spumux` and/or `dvdauthor` are not available on PATH."
+        );
+        return;
+    }
+
+    let output_dir = unique_temp_dir("build-motion-menu-smoke");
+    let source_path = output_dir.join("source.mp4");
+    fs::create_dir_all(&output_dir).unwrap();
+
+    let ffmpeg_status = Command::new(&ffmpeg_bin)
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=duration=6:size=320x240:rate=30",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=6",
+            "-shortest",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+        ])
+        .arg(&source_path)
+        .status()
+        .expect("ffmpeg should launch for motion menu smoke test fixture generation");
+    assert!(
+        ffmpeg_status.success(),
+        "ffmpeg fixture generation failed with status {ffmpeg_status}"
+    );
+
+    let mut project = test_project();
+    project.assets[0].source_path = source_path.display().to_string();
+    project.assets[0].file_name = "source.mp4".to_string();
+    project.assets[0].duration_secs = Some(6.0);
+    project.assets[0].video_streams[0].width = 320;
+    project.assets[0].video_streams[0].height = 240;
+    project.assets[0].video_streams[0].frame_rate = Some(30.0);
+    // Trim the fixture's default chapter list to fit the 6s source — the
+    // default second chapter sits at 300s.
+    project.disc.titlesets[0].titles[0].chapters =
+        vec![project.disc.titlesets[0].titles[0].chapters[0].clone()];
+
+    let mut motion_menu = test_menu_with_action(
+        "menu-motion",
+        "Motion Main Menu",
+        PlaybackAction::PlayTitle {
+            title_id: "title-1".to_string(),
+        },
+    );
+    {
+        let doc = motion_menu.doc_mut();
+        doc.background_mode = BackgroundMode::Motion;
+        doc.scene.background.asset_id = Some("asset-1".to_string());
+        doc.timing = MenuTiming {
+            intro_start_secs: 0.0,
+            intro_duration_secs: 1.0,
+            loop_start_secs: 1.0,
+            loop_duration_secs: 3.0,
+            loop_count: 2,
+            audio_asset_id: None,
+        };
+        doc.interaction.timeout_action = Some(PlaybackAction::PlayTitle {
+            title_id: "title-1".to_string(),
+        });
+    }
+    project.disc.global_menus.push(motion_menu);
+
+    let plan = generate_build_plan(&project, output_dir.to_str().unwrap(), true).unwrap();
+
+    assert!(
+        plan.dvdauthor_xml.contains("<post>"),
+        "expected the motion menu's dvdauthor XML to contain a <post>, got:\n{}",
+        plan.dvdauthor_xml
+    );
+    assert!(
+        plan.dvdauthor_xml.contains("jump cell 2"),
+        "expected the loop <post> to target cell 2 (intro is cell 1), got:\n{}",
+        plan.dvdauthor_xml
+    );
+
+    let result = execute_build_plan(&plan, |_| {});
+    if !result.success {
+        panic!(
+            "expected motion menu smoke build to succeed\n{}",
+            result.log_lines.join("\n")
+        );
+    }
+
+    let menus_dir = PathBuf::from(&plan.working_directory).join("menus");
+    let loop_path = menus_dir.join("menu-motion.mpg");
+    let intro_path = menus_dir.join("menu-motion_intro.mpg");
+
+    assert!(loop_path.exists(), "expected the loop menu MPEG to exist");
+    assert!(intro_path.exists(), "expected the intro menu MPEG to exist");
+
+    // Probe duration plus the video/audio codec names specifically (rather
+    // than dumping every stream, which also picks up the DVD nav-packet
+    // and, on the loop segment only, the spumux subpicture stream — neither
+    // of which is what "both cells must share identical layout" is about).
+    let probe_stream_info = |path: &PathBuf| -> (f64, String, String) {
+        let duration_output = Command::new(&ffprobe_bin)
+            .args([
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "csv=p=0",
+            ])
+            .arg(path)
+            .output()
+            .expect("ffprobe should launch");
+        assert!(
+            duration_output.status.success(),
+            "ffprobe duration probe failed for {}: {}",
+            path.display(),
+            String::from_utf8_lossy(&duration_output.stderr)
+        );
+        let duration: f64 = String::from_utf8_lossy(&duration_output.stdout)
+            .trim()
+            .parse()
+            .unwrap_or_else(|e| panic!("expected a numeric duration for {}: {e}", path.display()));
+
+        let probe_codec = |select_stream: &str| -> String {
+            let output = Command::new(&ffprobe_bin)
+                .args([
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    select_stream,
+                    "-show_entries",
+                    "stream=codec_name",
+                    "-of",
+                    "csv=p=0",
+                ])
+                .arg(path)
+                .output()
+                .expect("ffprobe should launch");
+            assert!(
+                output.status.success(),
+                "ffprobe codec probe ({select_stream}) failed for {}: {}",
+                path.display(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            // Some ffprobe builds emit a stray trailing comma from the csv
+            // writer even with a single requested field (`p=0`).
+            String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .trim_end_matches(',')
+                .to_string()
+        };
+
+        (duration, probe_codec("v:0"), probe_codec("a:0"))
+    };
+
+    let (loop_duration, loop_video_codec, loop_audio_codec) = probe_stream_info(&loop_path);
+    assert!(
+        (2.5..=3.6).contains(&loop_duration),
+        "expected loop segment duration in [2.5, 3.6]s, got {loop_duration}"
+    );
+    assert_eq!(loop_video_codec, "mpeg2video");
+    assert_eq!(loop_audio_codec, "ac3");
+
+    let (intro_duration, intro_video_codec, intro_audio_codec) = probe_stream_info(&intro_path);
+    assert!(
+        (0.6..=1.4).contains(&intro_duration),
+        "expected intro segment duration in [0.6, 1.4]s, got {intro_duration}"
+    );
+    assert_eq!(
+        (intro_video_codec.as_str(), intro_audio_codec.as_str()),
+        (loop_video_codec.as_str(), loop_audio_codec.as_str()),
+        "expected the intro and loop segments to share the same video/audio codec \
+         layout (both cells must have identical streams or dvdauthor rejects the disc)"
+    );
+
+    // This project's only menu is a VMGM (global) menu, not a titleset menu,
+    // so the titleset has no menu VOB of its own — title content starts at
+    // VTS_01_1.VOB rather than VTS_01_0.VOB.
+    let title_vob_path = output_dir.join("DVD_DISC/VIDEO_TS/VTS_01_1.VOB");
+    assert!(
+        title_vob_path.exists(),
+        "expected VTS_01_1.VOB in authored output"
+    );
+    let vob_len = fs::metadata(&title_vob_path)
+        .expect("VTS_01_1.VOB should have metadata")
+        .len();
+    assert!(vob_len > 0, "expected VTS_01_1.VOB to be non-empty");
 
     fs::remove_dir_all(&output_dir).unwrap();
 }

--- a/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/ffmpeg.rs
@@ -530,11 +530,32 @@ fn is_hdr_source(info: &VideoStreamInfo) -> bool {
     )
 }
 
+/// DVD-Video colour-metadata flags for a motion-menu segment compose
+/// (`build_ffmpeg_motion_segment_command` — motion compose only; still/title
+/// colour tagging is a follow-up, see design decision D1). Tags the encoded
+/// mpeg2video stream with the analogue-broadcast primaries/transfer/matrix a
+/// DVD player assumes for each standard: SMPTE 170M for NTSC, ITU-R BT.470
+/// System B/G for PAL.
+pub(crate) fn dvd_colour_flags(standard: VideoStandard) -> Vec<String> {
+    let value = match standard {
+        VideoStandard::Ntsc => "smpte170m",
+        VideoStandard::Pal => "bt470bg",
+    };
+    vec![
+        "-color_primaries".to_string(),
+        value.to_string(),
+        "-color_trc".to_string(),
+        value.to_string(),
+        "-colorspace".to_string(),
+        value.to_string(),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use crate::build::generate_build_plan;
     use crate::build::test_support::test_project;
-    use crate::models::AudioOutputTarget;
+    use crate::models::{AudioOutputTarget, VideoStandard};
 
     #[test]
     fn ffmpeg_vf_has_scale_and_pad() {
@@ -906,6 +927,38 @@ mod tests {
         assert_eq!(
             ba_val, "192k",
             "expected the override bitrate, not AC3's 448k default"
+        );
+    }
+
+    #[test]
+    fn dvd_colour_flags_uses_smpte170m_for_ntsc() {
+        let flags = super::dvd_colour_flags(VideoStandard::Ntsc);
+        assert_eq!(
+            flags,
+            vec![
+                "-color_primaries".to_string(),
+                "smpte170m".to_string(),
+                "-color_trc".to_string(),
+                "smpte170m".to_string(),
+                "-colorspace".to_string(),
+                "smpte170m".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn dvd_colour_flags_uses_bt470bg_for_pal() {
+        let flags = super::dvd_colour_flags(VideoStandard::Pal);
+        assert_eq!(
+            flags,
+            vec![
+                "-color_primaries".to_string(),
+                "bt470bg".to_string(),
+                "-color_trc".to_string(),
+                "bt470bg".to_string(),
+                "-colorspace".to_string(),
+                "bt470bg".to_string(),
+            ]
         );
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/menu.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/menu.rs
@@ -40,22 +40,18 @@ impl<'a> AuthorableMenuRef<'a> {
         &self.menu.doc().highlight_colours
     }
 
-    #[allow(dead_code)]
     pub(crate) fn background_mode(&self) -> BackgroundMode {
         self.menu.resolved_background_mode()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn timeout_action(&self) -> Option<&PlaybackAction> {
         self.menu.doc().interaction.timeout_action.as_ref()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn motion_duration_secs(&self) -> Option<f64> {
         self.menu.resolved_motion_duration_secs()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn motion_loop_count(&self) -> u32 {
         self.menu.doc().timing.loop_count
     }

--- a/plugins/tauri-plugin-spindle-project/src/build/menu_motion.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/menu_motion.rs
@@ -335,7 +335,7 @@ mod tests {
             id: "menu-1".to_string(),
             name: "Motion Menu".to_string(),
             domain: MenuDomain::Vmgm,
-            role: MenuRole::TitleSelect,
+            role: Some(MenuRole::TitleSelect),
             scene: MenuScene {
                 design_size: MenuSize {
                     width: 720.0,

--- a/plugins/tauri-plugin-spindle-project/src/build/menu_motion.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/menu_motion.rs
@@ -1,0 +1,696 @@
+// Motion-menu ffmpeg segment composition: single-command trim + scene overlay
+// + audio + DVD mux per segment (intro/loop), and the audio-source/timing
+// planning that feeds it.
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: MIT
+
+//! Deliberately not a `MenuCompiler` trait yet — see design decision D2
+//! (`MenuCompiler` trait: deferred, minimal module seam). A future trait
+//! stage should map: `compose_background` -> [`build_ffmpeg_motion_segment_command`];
+//! `mux` -> the spumux/dvdauthor emission in [`super::menu::generate_spumux_xml`]
+//! and [`super::authoring::menu`]'s `<post>` derivation.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::models::*;
+
+use super::ffmpeg::{
+    dvd_active_dimensions, dvd_colour_flags, fps_rational_str, output_display_aspect_ratio_parts,
+    source_display_aspect_ratio,
+};
+use super::menu::AuthorableMenuRef;
+
+/// Where a motion segment's audio bed comes from — see design decision D1's
+/// three-way fallback chain.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum MotionAudioSource {
+    /// An explicitly authored audio asset, looped and windowed at
+    /// `offset_secs` into the continuous intro+loop timeline.
+    Bed { path: String, offset_secs: f64 },
+    /// No explicit bed — reuse the background video's own audio track,
+    /// already time-aligned by the same input-side `-ss`/`-t` trim as the
+    /// video stream.
+    BackgroundAudio,
+    /// Neither an authored bed nor usable background audio — synthesize
+    /// silence.
+    Silence,
+}
+
+/// Everything [`build_ffmpeg_motion_segment_command`] needs to compose one
+/// segment (intro or loop) of a motion menu.
+#[derive(Debug, Clone)]
+pub(crate) struct MotionSegmentSpec {
+    pub(crate) video_source_path: String,
+    pub(crate) video_start_secs: f64,
+    pub(crate) duration_secs: f64,
+    pub(crate) audio: MotionAudioSource,
+    pub(crate) scene_png_path: PathBuf,
+    pub(crate) output_path: PathBuf,
+}
+
+/// Plan the loop segment (always) and intro segment (only when
+/// `timing.intro_duration_secs > 0.0`) for a motion menu, resolving the
+/// background video asset and the audio-bed fallback chain.
+///
+/// Bed windows are continuous across the intro+loop timeline so first-play
+/// audio doesn't hiccup at the intro/loop boundary: intro plays
+/// `[0..introDur)`, loop plays `[introDur..introDur+loopDur)` (or
+/// `[0..loopDur)` when there is no intro).
+pub(crate) fn plan_motion_segments(
+    menu_ref: &AuthorableMenuRef<'_>,
+    assets: &HashMap<&str, &Asset>,
+    scene_png_path: &std::path::Path,
+    loop_output_path: &std::path::Path,
+    intro_output_path: &std::path::Path,
+) -> crate::Result<(MotionSegmentSpec, Option<MotionSegmentSpec>)> {
+    let background_asset_id = menu_ref.background_asset_id().ok_or_else(|| {
+        crate::Error::Build(format!(
+            "Motion menu \"{}\" has no background video asset assigned.",
+            menu_ref.name()
+        ))
+    })?;
+    let asset = assets.get(background_asset_id).ok_or_else(|| {
+        crate::Error::Build(format!(
+            "Background asset not found for motion menu \"{}\"",
+            menu_ref.name()
+        ))
+    })?;
+    if asset.video_streams.is_empty() {
+        return Err(crate::Error::Build(format!(
+            "Motion menu \"{}\" background asset has no video stream.",
+            menu_ref.name()
+        )));
+    }
+
+    let timing = &menu_ref.menu.doc().timing;
+    let loop_dur = menu_ref.motion_duration_secs().ok_or_else(|| {
+        crate::Error::Build(format!(
+            "Motion menu \"{}\" needs a loop duration greater than 0 seconds.",
+            menu_ref.name()
+        ))
+    })?;
+    let has_intro = timing.intro_duration_secs > 0.0;
+
+    let audio_for = |offset_secs: f64| -> MotionAudioSource {
+        if let Some(audio_asset_id) = timing.audio_asset_id.as_deref() {
+            if let Some(audio_asset) = assets.get(audio_asset_id) {
+                return MotionAudioSource::Bed {
+                    path: audio_asset.source_path.clone(),
+                    offset_secs,
+                };
+            }
+        }
+        if !asset.audio_streams.is_empty() {
+            MotionAudioSource::BackgroundAudio
+        } else {
+            MotionAudioSource::Silence
+        }
+    };
+
+    let loop_offset = if has_intro {
+        timing.intro_duration_secs
+    } else {
+        0.0
+    };
+
+    let loop_spec = MotionSegmentSpec {
+        video_source_path: asset.source_path.clone(),
+        video_start_secs: timing.loop_start_secs,
+        duration_secs: loop_dur,
+        audio: audio_for(loop_offset),
+        scene_png_path: scene_png_path.to_path_buf(),
+        output_path: loop_output_path.to_path_buf(),
+    };
+
+    let intro_spec = has_intro.then(|| MotionSegmentSpec {
+        video_source_path: asset.source_path.clone(),
+        video_start_secs: timing.intro_start_secs,
+        duration_secs: timing.intro_duration_secs,
+        audio: audio_for(0.0),
+        scene_png_path: scene_png_path.to_path_buf(),
+        output_path: intro_output_path.to_path_buf(),
+    });
+
+    Ok((loop_spec, intro_spec))
+}
+
+/// Build the single ffmpeg compose command for one motion-menu segment:
+/// input-side trim, background scale/pad into the DVD raster, scene-PNG
+/// overlay, an audio bed (bed asset / background audio / silence) always
+/// re-encoded to AC-3, closed-GOP mpeg2video, and DVD colour tagging.
+pub(crate) fn build_ffmpeg_motion_segment_command(
+    ffmpeg_bin: &str,
+    menu_ref: &AuthorableMenuRef<'_>,
+    assets: &HashMap<&str, &Asset>,
+    project: &SpindleProjectFile,
+    standard: VideoStandard,
+    spec: &MotionSegmentSpec,
+) -> crate::Result<Vec<String>> {
+    let aspect = menu_ref.display_aspect(project);
+    let target = RenderTarget::from_disc(&project.disc, aspect);
+    let width = target.raster_width;
+    let height = target.raster_height;
+    let sar = target.sar_string();
+    let aspect_str = match aspect {
+        AspectMode::FourByThree => "4:3",
+        AspectMode::SixteenByNine => "16:9",
+    };
+    let fps = fps_rational_str(standard.frame_rate());
+
+    let (target_dar_num, target_dar_den) = output_display_aspect_ratio_parts(aspect);
+    let target_dar = target_dar_num as f64 / target_dar_den as f64;
+
+    let background_asset_id = menu_ref.background_asset_id().ok_or_else(|| {
+        crate::Error::Build(format!(
+            "Motion menu \"{}\" has no background video asset assigned.",
+            menu_ref.name()
+        ))
+    })?;
+    let asset = assets.get(background_asset_id).ok_or_else(|| {
+        crate::Error::Build(format!(
+            "Background asset not found for motion menu \"{}\"",
+            menu_ref.name()
+        ))
+    })?;
+    let video_info = asset.video_streams.first().ok_or_else(|| {
+        crate::Error::Build(format!(
+            "Motion menu \"{}\" background asset has no video stream.",
+            menu_ref.name()
+        ))
+    })?;
+    let source_dar = source_display_aspect_ratio(video_info).unwrap_or(target_dar);
+    let (active_width, active_height) =
+        dvd_active_dimensions(width, height, source_dar, target_dar);
+    let pad_x = (width.saturating_sub(active_width)) / 2;
+    let pad_y = (height.saturating_sub(active_height)) / 2;
+
+    let mut cmd = vec![ffmpeg_bin.to_string(), "-y".to_string()];
+
+    // Input 0: background video, trimmed input-side (frame-accurate with
+    // re-encode) — never the `trim` filter.
+    cmd.extend([
+        "-ss".to_string(),
+        format!("{:.3}", spec.video_start_secs),
+        "-t".to_string(),
+        format!("{:.3}", spec.duration_secs),
+        "-i".to_string(),
+        spec.video_source_path.clone(),
+    ]);
+
+    let mut video_filters = vec![format!(
+        "[0:v]fps={fps},scale={active_width}:{active_height}:out_color_matrix=bt601,pad={width}:{height}:{pad_x}:{pad_y}[bg]"
+    )];
+    let audio_filter: String;
+    let scene_input_index: usize;
+
+    match &spec.audio {
+        MotionAudioSource::BackgroundAudio => {
+            cmd.extend([
+                "-loop".to_string(),
+                "1".to_string(),
+                "-i".to_string(),
+                spec.scene_png_path.display().to_string(),
+            ]);
+            scene_input_index = 1;
+            audio_filter = "[0:a]asetpts=PTS-STARTPTS,apad[aud]".to_string();
+        }
+        MotionAudioSource::Bed { path, offset_secs } => {
+            cmd.extend([
+                "-stream_loop".to_string(),
+                "-1".to_string(),
+                "-i".to_string(),
+                path.clone(),
+            ]);
+            cmd.extend([
+                "-loop".to_string(),
+                "1".to_string(),
+                "-i".to_string(),
+                spec.scene_png_path.display().to_string(),
+            ]);
+            scene_input_index = 2;
+            audio_filter = format!(
+                "[1:a]atrim=start={:.3}:duration={:.3},asetpts=PTS-STARTPTS,apad[aud]",
+                offset_secs, spec.duration_secs
+            );
+        }
+        MotionAudioSource::Silence => {
+            cmd.extend([
+                "-f".to_string(),
+                "lavfi".to_string(),
+                "-i".to_string(),
+                "anullsrc=r=48000:cl=stereo".to_string(),
+            ]);
+            cmd.extend([
+                "-loop".to_string(),
+                "1".to_string(),
+                "-i".to_string(),
+                spec.scene_png_path.display().to_string(),
+            ]);
+            scene_input_index = 2;
+            audio_filter = format!(
+                "[1:a]atrim=start=0:duration={:.3},asetpts=PTS-STARTPTS,apad[aud]",
+                spec.duration_secs
+            );
+        }
+    }
+
+    video_filters.push(format!(
+        "[bg][{scene_input_index}:v]overlay=0:0,setsar={sar}[menuout]"
+    ));
+    video_filters.push(audio_filter);
+
+    cmd.extend([
+        "-filter_complex".to_string(),
+        video_filters.join(";"),
+        "-map".to_string(),
+        "[menuout]".to_string(),
+        "-map".to_string(),
+        "[aud]".to_string(),
+        "-r".to_string(),
+        fps.to_string(),
+        "-c:v".to_string(),
+        "mpeg2video".to_string(),
+        "-b:v".to_string(),
+        "4000k".to_string(),
+        "-maxrate".to_string(),
+        "7000k".to_string(),
+        "-bufsize".to_string(),
+        "1835k".to_string(),
+        "-g".to_string(),
+        if standard == VideoStandard::Pal {
+            "12"
+        } else {
+            "18"
+        }
+        .to_string(),
+        "-flags".to_string(),
+        "+cgop".to_string(),
+        // ffmpeg's mpeg2video encoder can't combine closed GOPs with
+        // scene-change-triggered GOP breaks ("closed gop with scene change
+        // detection are not supported yet") — disabling scene-cut detection
+        // is what the encoder itself suggests, and keeps every GOP exactly
+        // `-g` frames long and closed, which is what the loop cut needs.
+        "-sc_threshold".to_string(),
+        "1000000000".to_string(),
+    ]);
+    cmd.extend(dvd_colour_flags(standard));
+    cmd.extend([
+        "-aspect".to_string(),
+        aspect_str.to_string(),
+        "-c:a".to_string(),
+        "ac3".to_string(),
+        "-b:a".to_string(),
+        "192k".to_string(),
+        "-ar".to_string(),
+        "48000".to_string(),
+        "-t".to_string(),
+        format!("{:.3}", spec.duration_secs),
+        "-f".to_string(),
+        "dvd".to_string(),
+        "-muxrate".to_string(),
+        "10080000".to_string(),
+        spec.output_path.display().to_string(),
+    ]);
+
+    Ok(cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::Path;
+
+    use crate::models::*;
+
+    use super::super::menu::{AuthorableMenuRef, MenuDomain as BuildMenuDomain};
+    use super::{
+        build_ffmpeg_motion_segment_command, plan_motion_segments, MotionAudioSource,
+        MotionSegmentSpec,
+    };
+
+    fn motion_menu_document() -> MenuDocument {
+        MenuDocument {
+            id: "menu-1".to_string(),
+            name: "Motion Menu".to_string(),
+            domain: MenuDomain::Vmgm,
+            role: MenuRole::TitleSelect,
+            scene: MenuScene {
+                design_size: MenuSize {
+                    width: 720.0,
+                    height: 480.0,
+                    aspect: AspectMode::SixteenByNine,
+                },
+                background: SceneBackground {
+                    asset_id: Some("bg-video".to_string()),
+                    colour: None,
+                },
+                nodes: vec![],
+                guides: vec![],
+            },
+            interaction: MenuInteractionGraph {
+                default_focus_id: None,
+                nodes: vec![],
+                timeout_action: None,
+            },
+            timing: MenuTiming {
+                intro_start_secs: 0.0,
+                intro_duration_secs: 1.5,
+                loop_start_secs: 2.0,
+                loop_duration_secs: 3.5,
+                loop_count: 2,
+                audio_asset_id: None,
+            },
+            highlight_colours: MenuHighlightColours::default(),
+            background_mode: BackgroundMode::Motion,
+            theme_ref: None,
+            generation_meta: None,
+            compile_policy: MenuCompilePolicy::default(),
+        }
+    }
+
+    fn video_asset(id: &str, with_audio: bool) -> Asset {
+        let mut asset = Asset::new(format!("{id}.mp4"), format!("/tmp/{id}.mp4"));
+        asset.id = id.to_string();
+        asset.video_streams = vec![VideoStreamInfo {
+            index: 0,
+            codec: "h264".to_string(),
+            width: 1920,
+            height: 1080,
+            frame_rate: Some(30.0),
+            aspect_ratio: None,
+            scan_type: None,
+            bitrate_bps: None,
+            title: None,
+            color_transfer: None,
+            color_primaries: None,
+            dolby_vision_profile: None,
+        }];
+        if with_audio {
+            asset.audio_streams = vec![AudioStreamInfo {
+                index: 1,
+                codec: "aac".to_string(),
+                channels: 2,
+                sample_rate: 48000,
+                language: None,
+                bitrate_bps: None,
+                title: None,
+            }];
+        }
+        asset
+    }
+
+    fn menu_with_document(doc: MenuDocument) -> Menu {
+        Menu::new(doc.id.clone(), doc.name.clone()).with_document(doc)
+    }
+
+    #[test]
+    fn plan_motion_segments_produces_intro_and_loop_with_continuous_bed_windows() {
+        let doc = motion_menu_document();
+        let menu = menu_with_document(doc);
+        let menu_ref = AuthorableMenuRef {
+            menu: &menu,
+            domain: BuildMenuDomain::Vmgm,
+        };
+        let asset = video_asset("bg-video", true);
+        let mut assets = HashMap::new();
+        assets.insert("bg-video", &asset);
+
+        let (loop_spec, intro_spec) = plan_motion_segments(
+            &menu_ref,
+            &assets,
+            Path::new("/tmp/menu_scene.png"),
+            Path::new("/tmp/menu_base.mpg"),
+            Path::new("/tmp/menu_intro.mpg"),
+        )
+        .unwrap();
+
+        assert_eq!(loop_spec.video_start_secs, 2.0);
+        assert_eq!(loop_spec.duration_secs, 3.5);
+        assert_eq!(loop_spec.audio, MotionAudioSource::BackgroundAudio);
+
+        let intro_spec = intro_spec.expect("expected an intro segment");
+        assert_eq!(intro_spec.video_start_secs, 0.0);
+        assert_eq!(intro_spec.duration_secs, 1.5);
+        assert_eq!(intro_spec.audio, MotionAudioSource::BackgroundAudio);
+    }
+
+    #[test]
+    fn plan_motion_segments_omits_intro_when_not_authored() {
+        let mut doc = motion_menu_document();
+        doc.timing.intro_duration_secs = 0.0;
+        let menu = menu_with_document(doc);
+        let menu_ref = AuthorableMenuRef {
+            menu: &menu,
+            domain: BuildMenuDomain::Vmgm,
+        };
+        let asset = video_asset("bg-video", true);
+        let mut assets = HashMap::new();
+        assets.insert("bg-video", &asset);
+
+        let (_loop_spec, intro_spec) = plan_motion_segments(
+            &menu_ref,
+            &assets,
+            Path::new("/tmp/menu_scene.png"),
+            Path::new("/tmp/menu_base.mpg"),
+            Path::new("/tmp/menu_intro.mpg"),
+        )
+        .unwrap();
+
+        assert!(intro_spec.is_none());
+    }
+
+    #[test]
+    fn plan_motion_segments_prefers_explicit_audio_bed_over_background_audio() {
+        let mut doc = motion_menu_document();
+        doc.timing.audio_asset_id = Some("bed-audio".to_string());
+        let menu = menu_with_document(doc);
+        let menu_ref = AuthorableMenuRef {
+            menu: &menu,
+            domain: BuildMenuDomain::Vmgm,
+        };
+        let bg_asset = video_asset("bg-video", true);
+        let mut bed_asset = Asset::new("bed.wav".to_string(), "/tmp/bed.wav".to_string());
+        bed_asset.id = "bed-audio".to_string();
+        bed_asset.audio_streams = vec![AudioStreamInfo {
+            index: 0,
+            codec: "pcm_s16le".to_string(),
+            channels: 2,
+            sample_rate: 48000,
+            language: None,
+            bitrate_bps: None,
+            title: None,
+        }];
+        let mut assets = HashMap::new();
+        assets.insert("bg-video", &bg_asset);
+        assets.insert("bed-audio", &bed_asset);
+
+        let (loop_spec, intro_spec) = plan_motion_segments(
+            &menu_ref,
+            &assets,
+            Path::new("/tmp/menu_scene.png"),
+            Path::new("/tmp/menu_base.mpg"),
+            Path::new("/tmp/menu_intro.mpg"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            loop_spec.audio,
+            MotionAudioSource::Bed {
+                path: "/tmp/bed.wav".to_string(),
+                offset_secs: 1.5,
+            }
+        );
+        assert_eq!(
+            intro_spec.unwrap().audio,
+            MotionAudioSource::Bed {
+                path: "/tmp/bed.wav".to_string(),
+                offset_secs: 0.0,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_motion_segments_falls_back_to_silence_when_no_bed_and_no_background_audio() {
+        let doc = motion_menu_document();
+        let menu = menu_with_document(doc);
+        let menu_ref = AuthorableMenuRef {
+            menu: &menu,
+            domain: BuildMenuDomain::Vmgm,
+        };
+        let asset = video_asset("bg-video", false);
+        let mut assets = HashMap::new();
+        assets.insert("bg-video", &asset);
+
+        let (loop_spec, _intro_spec) = plan_motion_segments(
+            &menu_ref,
+            &assets,
+            Path::new("/tmp/menu_scene.png"),
+            Path::new("/tmp/menu_base.mpg"),
+            Path::new("/tmp/menu_intro.mpg"),
+        )
+        .unwrap();
+
+        assert_eq!(loop_spec.audio, MotionAudioSource::Silence);
+    }
+
+    #[test]
+    fn plan_motion_segments_errors_when_background_asset_missing_video_stream() {
+        let doc = motion_menu_document();
+        let menu = menu_with_document(doc);
+        let menu_ref = AuthorableMenuRef {
+            menu: &menu,
+            domain: BuildMenuDomain::Vmgm,
+        };
+        let asset = Asset::new("bg-video.mp4".to_string(), "/tmp/bg-video.mp4".to_string());
+        let mut assets = HashMap::new();
+        assets.insert("bg-video", &asset);
+
+        let result = plan_motion_segments(
+            &menu_ref,
+            &assets,
+            Path::new("/tmp/menu_scene.png"),
+            Path::new("/tmp/menu_base.mpg"),
+            Path::new("/tmp/menu_intro.mpg"),
+        );
+
+        assert!(result.is_err());
+    }
+
+    fn command_for(spec: MotionSegmentSpec, standard: VideoStandard) -> Vec<String> {
+        let doc = motion_menu_document();
+        let menu = menu_with_document(doc);
+        let menu_ref = AuthorableMenuRef {
+            menu: &menu,
+            domain: BuildMenuDomain::Vmgm,
+        };
+        let asset = video_asset("bg-video", true);
+        let mut assets = HashMap::new();
+        assets.insert("bg-video", &asset);
+        let project = SpindleProjectFile::default();
+
+        build_ffmpeg_motion_segment_command("ffmpeg", &menu_ref, &assets, &project, standard, &spec)
+            .unwrap()
+    }
+
+    fn loop_spec(audio: MotionAudioSource) -> MotionSegmentSpec {
+        MotionSegmentSpec {
+            video_source_path: "/tmp/bg-video.mp4".to_string(),
+            video_start_secs: 2.0,
+            duration_secs: 3.5,
+            audio,
+            scene_png_path: std::path::PathBuf::from("/tmp/menu_scene.png"),
+            output_path: std::path::PathBuf::from("/tmp/menu_base.mpg"),
+        }
+    }
+
+    #[test]
+    fn command_uses_input_side_trim_not_trim_filter() {
+        let cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Ntsc,
+        );
+        let cmd_str = cmd.join(" ");
+
+        assert!(cmd_str.contains("-ss 2.000 -t 3.500 -i /tmp/bg-video.mp4"));
+        assert!(
+            !cmd_str.contains("trim="),
+            "must not use the trim filter, got: {cmd_str}"
+        );
+    }
+
+    #[test]
+    fn command_final_duration_reflects_segment_not_hardcoded_one_second() {
+        let cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Ntsc,
+        );
+        let t_arg = cmd
+            .iter()
+            .enumerate()
+            .rfind(|(_, a)| *a == "-t")
+            .map(|(i, _)| cmd[i + 1].clone())
+            .expect("-t value");
+        assert_eq!(
+            t_arg, "3.500",
+            "must cap output at the real segment duration, not the still-menu's hardcoded 1s"
+        );
+    }
+
+    #[test]
+    fn command_always_encodes_ac3_192k_48000() {
+        let cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Ntsc,
+        );
+        let cmd_str = cmd.join(" ");
+        assert!(cmd_str.contains("-c:a ac3 -b:a 192k -ar 48000"));
+    }
+
+    #[test]
+    fn command_falls_back_to_anullsrc_for_silence() {
+        let cmd = command_for(loop_spec(MotionAudioSource::Silence), VideoStandard::Ntsc);
+        let cmd_str = cmd.join(" ");
+        assert!(cmd_str.contains("-f lavfi -i anullsrc=r=48000:cl=stereo"));
+    }
+
+    #[test]
+    fn command_windows_the_bed_at_the_given_offset() {
+        let cmd = command_for(
+            loop_spec(MotionAudioSource::Bed {
+                path: "/tmp/bed.wav".to_string(),
+                offset_secs: 1.5,
+            }),
+            VideoStandard::Ntsc,
+        );
+        let cmd_str = cmd.join(" ");
+        assert!(cmd_str.contains("-stream_loop -1 -i /tmp/bed.wav"));
+        assert!(cmd_str.contains("atrim=start=1.500:duration=3.500"));
+    }
+
+    #[test]
+    fn command_includes_dvd_colour_flags_matching_standard() {
+        let ntsc_cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Ntsc,
+        );
+        assert!(ntsc_cmd.join(" ").contains("-color_primaries smpte170m"));
+
+        let pal_cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Pal,
+        );
+        assert!(pal_cmd.join(" ").contains("-color_primaries bt470bg"));
+    }
+
+    #[test]
+    fn command_scale_filter_tags_out_color_matrix_bt601() {
+        let cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Ntsc,
+        );
+        let cmd_str = cmd.join(" ");
+        assert!(cmd_str.contains("out_color_matrix=bt601"));
+    }
+
+    #[test]
+    fn command_requests_dvd_muxer_and_muxrate() {
+        let cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Ntsc,
+        );
+        let cmd_str = cmd.join(" ");
+        assert!(cmd_str.contains("-f dvd -muxrate 10080000"));
+    }
+
+    #[test]
+    fn command_sets_closed_gop_flag() {
+        let cmd = command_for(
+            loop_spec(MotionAudioSource::BackgroundAudio),
+            VideoStandard::Ntsc,
+        );
+        assert!(cmd.contains(&"-flags".to_string()));
+        assert!(cmd.contains(&"+cgop".to_string()));
+    }
+}

--- a/plugins/tauri-plugin-spindle-project/src/build/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/mod.rs
@@ -10,6 +10,7 @@ mod executor;
 mod ffmpeg;
 mod ffmpeg_progress;
 mod menu;
+mod menu_motion;
 mod navigation;
 mod planner;
 mod skia;

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/helpers.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/helpers.rs
@@ -10,36 +10,6 @@ use crate::models::*;
 
 use super::super::util::xml_escape;
 
-pub(super) fn ensure_supported_menu_backend(project: &SpindleProjectFile) -> crate::Result<()> {
-    let motion_menus: Vec<_> = project
-        .disc
-        .global_menus
-        .iter()
-        .chain(
-            project
-                .disc
-                .titlesets
-                .iter()
-                .flat_map(|titleset| titleset.menus.iter()),
-        )
-        .filter(|menu| matches!(menu.resolved_background_mode(), BackgroundMode::Motion))
-        .map(|menu| menu.name.clone())
-        .collect();
-
-    if motion_menus.is_empty() {
-        return Ok(());
-    }
-
-    Err(crate::Error::Build(format!(
-        "Motion menu build authoring is not implemented yet. Switch these menus back to still mode before building: {}",
-        motion_menus
-            .iter()
-            .map(|name| format!("\"{name}\""))
-            .collect::<Vec<_>>()
-            .join(", ")
-    )))
-}
-
 pub(super) fn generate_text_subtitle_spumux_xml(
     subtitle_path: &std::path::Path,
     standard: VideoStandard,

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
@@ -15,6 +15,7 @@ use super::ffmpeg::{
 use super::menu::{
     authorable_menus, build_ffmpeg_menu_command, generate_spumux_xml, menu_scene_png_path,
 };
+use super::menu_motion::{build_ffmpeg_motion_segment_command, plan_motion_segments};
 use super::types::{BuildJob, BuildPlan, BuildSummary, MenuOverlayButton};
 
 mod helpers;
@@ -23,10 +24,7 @@ mod paths;
 mod tests;
 mod toolchain;
 
-use helpers::{
-    ensure_supported_menu_backend, generate_text_subtitle_spumux_xml,
-    strip_unknown_codec_subtitle_mappings,
-};
+use helpers::{generate_text_subtitle_spumux_xml, strip_unknown_codec_subtitle_mappings};
 use paths::BuildPaths;
 use toolchain::ResolvedToolchain;
 
@@ -64,7 +62,6 @@ pub fn generate_build_plan_with_options(
     });
 
     let assets: HashMap<&str, &Asset> = project.assets.iter().map(|a| (a.id.as_str(), a)).collect();
-    ensure_supported_menu_backend(project)?;
 
     // Per-title average video bitrate, computed from the disc-wide capacity
     // budget so the transcode actually respects what the Planner/Overview
@@ -282,15 +279,54 @@ pub fn generate_build_plan_with_options(
     for menu_ref in authorable_menus(project) {
         let menu_paths = paths.menu_paths(&menu_ref.menu.id);
         let scene_png_path = menu_scene_png_path(&menu_paths.base_video_path);
-        let render_command = build_ffmpeg_menu_command(
-            &tools.ffmpeg,
-            &menu_ref,
-            &assets,
-            project,
-            project.disc.standard,
-            &menu_paths.base_video_path,
-            &scene_png_path,
-        )?;
+
+        let (render_command, intro_command, duration_secs) =
+            if matches!(menu_ref.background_mode(), BackgroundMode::Motion) {
+                // Hard error (rather than a silent still-mode fallback) when the
+                // authored background can't actually be composed — mirrors the
+                // scene-image-asset check below for `SceneNode::Image`.
+                let (loop_spec, intro_spec) = plan_motion_segments(
+                    &menu_ref,
+                    &assets,
+                    &scene_png_path,
+                    &menu_paths.base_video_path,
+                    &menu_paths.intro_video_path,
+                )?;
+                let loop_duration_secs = loop_spec.duration_secs;
+                let loop_command = build_ffmpeg_motion_segment_command(
+                    &tools.ffmpeg,
+                    &menu_ref,
+                    &assets,
+                    project,
+                    project.disc.standard,
+                    &loop_spec,
+                )?;
+                let intro_command = intro_spec
+                    .as_ref()
+                    .map(|spec| {
+                        build_ffmpeg_motion_segment_command(
+                            &tools.ffmpeg,
+                            &menu_ref,
+                            &assets,
+                            project,
+                            project.disc.standard,
+                            spec,
+                        )
+                    })
+                    .transpose()?;
+                (loop_command, intro_command, Some(loop_duration_secs))
+            } else {
+                let command = build_ffmpeg_menu_command(
+                    &tools.ffmpeg,
+                    &menu_ref,
+                    &assets,
+                    project,
+                    project.disc.standard,
+                    &menu_paths.base_video_path,
+                    &scene_png_path,
+                )?;
+                (command, None, None)
+            };
 
         let menu_aspect = menu_ref.display_aspect(project);
         let target = RenderTarget::from_disc(&project.disc, menu_aspect);
@@ -347,6 +383,8 @@ pub fn generate_build_plan_with_options(
             menu_name: menu_ref.name().to_string(),
             output_path: menu_paths.base_video_path.display().to_string(),
             command: render_command,
+            intro_command,
+            duration_secs,
             label: format!("Render menu \"{}\"", menu_ref.name()),
             standard: project.disc.standard,
             highlight_image_path: menu_paths.highlight_image_path.display().to_string(),

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/mod.rs
@@ -280,7 +280,7 @@ pub fn generate_build_plan_with_options(
         let menu_paths = paths.menu_paths(&menu_ref.menu.id);
         let scene_png_path = menu_scene_png_path(&menu_paths.base_video_path);
 
-        let (render_command, intro_command, duration_secs) =
+        let (render_command, intro_command, duration_secs, intro_duration_secs) =
             if matches!(menu_ref.background_mode(), BackgroundMode::Motion) {
                 // Hard error (rather than a silent still-mode fallback) when the
                 // authored background can't actually be composed — mirrors the
@@ -314,7 +314,13 @@ pub fn generate_build_plan_with_options(
                         )
                     })
                     .transpose()?;
-                (loop_command, intro_command, Some(loop_duration_secs))
+                let intro_duration_secs = intro_spec.as_ref().map(|spec| spec.duration_secs);
+                (
+                    loop_command,
+                    intro_command,
+                    Some(loop_duration_secs),
+                    intro_duration_secs,
+                )
             } else {
                 let command = build_ffmpeg_menu_command(
                     &tools.ffmpeg,
@@ -325,7 +331,7 @@ pub fn generate_build_plan_with_options(
                     &menu_paths.base_video_path,
                     &scene_png_path,
                 )?;
-                (command, None, None)
+                (command, None, None, None)
             };
 
         let menu_aspect = menu_ref.display_aspect(project);
@@ -385,6 +391,7 @@ pub fn generate_build_plan_with_options(
             command: render_command,
             intro_command,
             duration_secs,
+            intro_duration_secs,
             label: format!("Render menu \"{}\"", menu_ref.name()),
             standard: project.disc.standard,
             highlight_image_path: menu_paths.highlight_image_path.display().to_string(),

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/paths.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/paths.rs
@@ -22,6 +22,10 @@ pub(super) struct MenuPaths {
     pub(super) authored_video_path: PathBuf,
     pub(super) highlight_image_path: PathBuf,
     pub(super) select_image_path: PathBuf,
+    /// Motion-menu intro segment output — `{base}_intro.mpg`. Only written
+    /// to disk (and referenced by dvdauthor) when the menu authors an intro
+    /// (`timing.intro_duration_secs > 0.0`); unused for still menus.
+    pub(super) intro_video_path: PathBuf,
 }
 
 pub(super) struct TitlePaths {
@@ -107,6 +111,7 @@ impl BuildPaths {
             authored_video_path: self.menus_dir.join(format!("{base_name}.mpg")),
             highlight_image_path: self.menus_dir.join(format!("{base_name}_highlight.png")),
             select_image_path: self.menus_dir.join(format!("{base_name}_select.png")),
+            intro_video_path: self.menus_dir.join(format!("{base_name}_intro.mpg")),
         }
     }
 

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
@@ -412,12 +412,20 @@ fn build_plan_emits_motion_menu_compose_jobs() {
             command,
             intro_command,
             duration_secs,
+            intro_duration_secs,
             ..
         } => {
             assert_eq!(
                 *duration_secs,
                 Some(12.0),
                 "duration_secs should carry the loop segment's duration"
+            );
+            assert_eq!(
+                *intro_duration_secs,
+                Some(2.0),
+                "intro_duration_secs should carry the intro segment's own duration, \
+                 distinct from the loop's duration_secs, so the executor reports \
+                 intro compose progress against the right length"
             );
             assert!(
                 intro_command.is_some(),
@@ -449,6 +457,7 @@ fn build_plan_still_menu_render_job_has_no_motion_fields() {
         BuildJob::RenderMenu {
             intro_command,
             duration_secs,
+            intro_duration_secs,
             ..
         } => {
             assert!(
@@ -458,6 +467,10 @@ fn build_plan_still_menu_render_job_has_no_motion_fields() {
             assert!(
                 duration_secs.is_none(),
                 "still menus must not carry duration_secs"
+            );
+            assert!(
+                intro_duration_secs.is_none(),
+                "still menus must not carry intro_duration_secs"
             );
         }
         other => panic!("expected BuildJob::RenderMenu, got {other:?}"),

--- a/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/planner/tests.rs
@@ -389,18 +389,79 @@ fn build_plan_deduplicates_identical_transcodes_with_different_mapping_ids() {
 }
 
 #[test]
-fn build_plan_rejects_motion_menus_until_backend_support_lands() {
+fn build_plan_emits_motion_menu_compose_jobs() {
     let mut project = test_project();
     let mut menu = test_menu();
     menu.doc_mut().background_mode = BackgroundMode::Motion;
+    menu.doc_mut().scene.background.asset_id = Some("asset-1".to_string());
+    menu.doc_mut().timing.loop_start_secs = 1.0;
     menu.doc_mut().timing.loop_duration_secs = 12.0;
+    menu.doc_mut().timing.intro_duration_secs = 2.0;
     project.disc.global_menus.push(menu);
 
-    let err = generate_build_plan(&project, "/tmp/dvd_output", false).unwrap_err();
-    let msg = err.to_string();
+    let plan = generate_build_plan(&project, "/tmp/dvd_output", false).unwrap();
 
-    assert!(msg.contains("Motion menu build authoring is not implemented yet"));
-    assert!(msg.contains("\"Main Menu\""));
+    let render_menu = plan
+        .jobs
+        .iter()
+        .find(|j| matches!(j, BuildJob::RenderMenu { .. }))
+        .expect("expected a RenderMenu job");
+
+    match render_menu {
+        BuildJob::RenderMenu {
+            command,
+            intro_command,
+            duration_secs,
+            ..
+        } => {
+            assert_eq!(
+                *duration_secs,
+                Some(12.0),
+                "duration_secs should carry the loop segment's duration"
+            );
+            assert!(
+                intro_command.is_some(),
+                "an authored intro (intro_duration_secs > 0) should produce an intro_command"
+            );
+            assert!(
+                !command.is_empty(),
+                "the loop segment compose command should be populated"
+            );
+        }
+        other => panic!("expected BuildJob::RenderMenu, got {other:?}"),
+    }
+}
+
+#[test]
+fn build_plan_still_menu_render_job_has_no_motion_fields() {
+    let mut project = test_project();
+    project.disc.global_menus.push(test_menu());
+
+    let plan = generate_build_plan(&project, "/tmp/dvd_output", false).unwrap();
+
+    let render_menu = plan
+        .jobs
+        .iter()
+        .find(|j| matches!(j, BuildJob::RenderMenu { .. }))
+        .expect("expected a RenderMenu job");
+
+    match render_menu {
+        BuildJob::RenderMenu {
+            intro_command,
+            duration_secs,
+            ..
+        } => {
+            assert!(
+                intro_command.is_none(),
+                "still menus must not carry an intro_command"
+            );
+            assert!(
+                duration_secs.is_none(),
+                "still menus must not carry duration_secs"
+            );
+        }
+        other => panic!("expected BuildJob::RenderMenu, got {other:?}"),
+    }
 }
 
 #[test]

--- a/plugins/tauri-plugin-spindle-project/src/build/types.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/types.rs
@@ -55,12 +55,26 @@ pub enum BuildJob {
         /// Source asset duration in seconds, used for step-progress estimation.
         duration_secs: Option<f64>,
     },
-    /// Render a menu background to MPEG-2 still frame.
+    /// Render a menu background to MPEG-2 still frame (still menus) or the
+    /// looping-video segment compose(s) (motion menus — see `menu_motion.rs`).
     RenderMenu {
         menu_id: String,
         menu_name: String,
         output_path: String,
         command: Vec<String>,
+        /// Motion menus with an authored intro: the separate compose command
+        /// for the intro segment, run before `command` (the loop segment) and
+        /// written directly to its own final `{id}_intro.mpg` (no spumux
+        /// pass — see design decision D1). `None` for still menus and motion
+        /// menus without an intro.
+        #[serde(default)]
+        intro_command: Option<Vec<String>>,
+        /// Segment duration in seconds for progress estimation, and the
+        /// signal the executor uses to run `command`/`intro_command` via the
+        /// progress-reporting ffmpeg runner rather than the plain one (mirrors
+        /// `TranscodeTitle`'s `pass1_command` pattern). `None` for still menus.
+        #[serde(default)]
+        duration_secs: Option<f64>,
         label: String,
         standard: VideoStandard,
         highlight_image_path: String,

--- a/plugins/tauri-plugin-spindle-project/src/build/types.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/types.rs
@@ -69,12 +69,19 @@ pub enum BuildJob {
         /// menus without an intro.
         #[serde(default)]
         intro_command: Option<Vec<String>>,
-        /// Segment duration in seconds for progress estimation, and the
+        /// Loop segment duration in seconds for progress estimation, and the
         /// signal the executor uses to run `command`/`intro_command` via the
         /// progress-reporting ffmpeg runner rather than the plain one (mirrors
         /// `TranscodeTitle`'s `pass1_command` pattern). `None` for still menus.
         #[serde(default)]
         duration_secs: Option<f64>,
+        /// Intro segment duration in seconds, used for `intro_command`'s
+        /// progress estimation instead of the loop's `duration_secs` — an
+        /// authored intro can run for a very different length of time than
+        /// the loop, so reusing the loop duration misreports progress.
+        /// `None` for still menus and motion menus without an intro.
+        #[serde(default)]
+        intro_duration_secs: Option<f64>,
         label: String,
         standard: VideoStandard,
         highlight_image_path: String,

--- a/plugins/tauri-plugin-spindle-project/src/commands.rs
+++ b/plugins/tauri-plugin-spindle-project/src/commands.rs
@@ -346,6 +346,25 @@ pub(crate) async fn list_available_fonts<R: Runtime>(
     Ok(build::enumerate_fonts(&asset_refs))
 }
 
+/// Grant the asset protocol's runtime scope read access to the given
+/// absolute file paths, without widening the app's static
+/// `$APPCACHE/**`/`$APPDATA/**` scope (`tauri.conf.json`). Imported/relinked
+/// assets can live anywhere on disk, and `convertFileSrc` reads go through
+/// this protocol — see design decision D4. Grants are runtime-only and reset
+/// on restart; callers re-grant on `openProject`/`importAssets`/relink.
+#[command]
+pub(crate) async fn allow_asset_scope<R: Runtime>(
+    app: AppHandle<R>,
+    paths: Vec<String>,
+) -> Result<()> {
+    for path in &paths {
+        app.asset_protocol_scope().allow_file(path).map_err(|e| {
+            crate::Error::Build(format!("Failed to grant asset scope for \"{path}\": {e}"))
+        })?;
+    }
+    Ok(())
+}
+
 /// Return the application cache directory for storing thumbnails and other transient data.
 #[command]
 pub(crate) async fn get_cache_dir<R: Runtime>(app: AppHandle<R>) -> Result<String> {

--- a/plugins/tauri-plugin-spindle-project/src/commands.rs
+++ b/plugins/tauri-plugin-spindle-project/src/commands.rs
@@ -357,12 +357,25 @@ pub(crate) async fn allow_asset_scope<R: Runtime>(
     app: AppHandle<R>,
     paths: Vec<String>,
 ) -> Result<()> {
+    // Attempt every path rather than aborting on the first failure — a
+    // single bad path (e.g. one asset relocated/deleted out from under the
+    // project) must not leave every *later* path in the batch ungranted.
+    let mut failed_paths: Vec<String> = Vec::new();
     for path in &paths {
-        app.asset_protocol_scope().allow_file(path).map_err(|e| {
-            crate::Error::Build(format!("Failed to grant asset scope for \"{path}\": {e}"))
-        })?;
+        if let Err(e) = app.asset_protocol_scope().allow_file(path) {
+            eprintln!("Failed to grant asset scope for \"{path}\": {e}");
+            failed_paths.push(path.clone());
+        }
     }
-    Ok(())
+    if failed_paths.is_empty() {
+        Ok(())
+    } else {
+        Err(crate::Error::Build(format!(
+            "Failed to grant asset scope for {} path(s): {}",
+            failed_paths.len(),
+            failed_paths.join(", ")
+        )))
+    }
 }
 
 /// Return the application cache directory for storing thumbnails and other transient data.

--- a/plugins/tauri-plugin-spindle-project/src/lib.rs
+++ b/plugins/tauri-plugin-spindle-project/src/lib.rs
@@ -64,6 +64,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::export_diagnostics,
             commands::export_menu_render_preview,
             commands::list_available_fonts,
+            commands::allow_asset_scope,
         ])
         .setup(|app, api| {
             #[cfg(mobile)]

--- a/plugins/tauri-plugin-spindle-project/src/validation/menu.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/menu.rs
@@ -332,21 +332,6 @@ pub(super) fn validate_menus(
         validate_scene_nodes(&doc.scene.nodes, asset_ids, &menu.name, &menu.id, issues);
 
         if matches!(background_mode, BackgroundMode::Motion) {
-            issues.push(ValidationIssue {
-                severity: IssueSeverity::Warning,
-                code: "menu.motion-build-pending".to_string(),
-                message: format!(
-                    "Menu \"{}\" is authored as a motion menu, but the backend still blocks motion-menu builds until video-loop authoring is implemented.",
-                    menu.name
-                ),
-                context: Some(menu.id.clone()),
-                entity_type: Some("menu".to_string()),
-                entity_name: Some(menu.name.clone()),
-                suggested_fix: Some(
-                    "Keep authoring the motion timing and assets, but switch this menu back to still mode before building for now.".to_string(),
-                ),
-            });
-
             if background_asset_id.is_none() {
                 issues.push(ValidationIssue {
                     severity: IssueSeverity::Error,
@@ -473,6 +458,73 @@ pub(super) fn validate_menus(
                     }
                 }
             }
+
+            let background_asset = background_asset_id.and_then(|id| asset_map.get(id));
+            let source_duration_secs = background_asset.and_then(|asset| asset.duration_secs);
+
+            if let (Some(loop_duration_secs), Some(source_duration_secs)) =
+                (motion_duration_secs, source_duration_secs)
+            {
+                if motion_loop_start_secs + loop_duration_secs > source_duration_secs {
+                    issues.push(ValidationIssue {
+                        severity: IssueSeverity::Error,
+                        code: "menu.motion-loop-exceeds-source".to_string(),
+                        message: format!(
+                            "Motion menu \"{}\" loop window (start {:.2}s + duration {:.2}s) runs past the end of its background asset ({:.2}s).",
+                            menu.name, motion_loop_start_secs, loop_duration_secs, source_duration_secs
+                        ),
+                        context: Some(menu.id.clone()),
+                        entity_type: Some("menu".to_string()),
+                        entity_name: Some(menu.name.clone()),
+                        suggested_fix: Some(
+                            "Shorten the loop duration or move the loop start earlier so the window fits inside the source video."
+                                .to_string(),
+                        ),
+                    });
+                }
+            }
+
+            let intro_duration_secs = doc.timing.intro_duration_secs;
+            let intro_window_invalid = intro_duration_secs < 0.0
+                || (intro_duration_secs > 0.0
+                    && source_duration_secs.is_some_and(|source_duration_secs| {
+                        doc.timing.intro_start_secs + intro_duration_secs > source_duration_secs
+                    }));
+            if intro_window_invalid {
+                issues.push(ValidationIssue {
+                    severity: IssueSeverity::Error,
+                    code: "menu.motion-intro-invalid".to_string(),
+                    message: format!(
+                        "Motion menu \"{}\" intro window is invalid — either the duration is negative, or it runs past the end of the background asset.",
+                        menu.name
+                    ),
+                    context: Some(menu.id.clone()),
+                    entity_type: Some("menu".to_string()),
+                    entity_name: Some(menu.name.clone()),
+                    suggested_fix: Some(
+                        "Set a non-negative intro duration that fits inside the source video, starting from the intro start time."
+                            .to_string(),
+                    ),
+                });
+            }
+
+            if doc.timing.loop_count > 0 && doc.interaction.timeout_action.is_none() {
+                issues.push(ValidationIssue {
+                    severity: IssueSeverity::Warning,
+                    code: "menu.motion-loop-count-without-timeout".to_string(),
+                    message: format!(
+                        "Motion menu \"{}\" has a loop count of {}, but no timeout action — it will loop forever instead of stopping after {} plays.",
+                        menu.name, doc.timing.loop_count, doc.timing.loop_count
+                    ),
+                    context: Some(menu.id.clone()),
+                    entity_type: Some("menu".to_string()),
+                    entity_name: Some(menu.name.clone()),
+                    suggested_fix: Some(
+                        "Set a timeout action, or set the loop count to 0 for an intentional infinite loop."
+                            .to_string(),
+                    ),
+                });
+            }
         }
 
         validate_button_video_usage(menu, background_mode, asset_map, issues);
@@ -539,6 +591,354 @@ mod tests {
             generation_meta: None,
             compile_policy: MenuCompilePolicy::default(),
         }
+    }
+
+    fn motion_document(
+        timing: MenuTiming,
+        background_asset_id: Option<&str>,
+        timeout_action: Option<PlaybackAction>,
+    ) -> MenuDocument {
+        MenuDocument {
+            id: "menu-1".to_string(),
+            name: "Motion Menu".to_string(),
+            domain: MenuDomain::Vmgm,
+            role: MenuRole::TitleSelect,
+            scene: MenuScene {
+                design_size: MenuSize {
+                    width: 720.0,
+                    height: 480.0,
+                    aspect: AspectMode::SixteenByNine,
+                },
+                background: SceneBackground {
+                    asset_id: background_asset_id.map(|id| id.to_string()),
+                    colour: None,
+                },
+                nodes: vec![],
+                guides: vec![],
+            },
+            interaction: MenuInteractionGraph {
+                default_focus_id: None,
+                nodes: vec![],
+                timeout_action,
+            },
+            timing,
+            highlight_colours: MenuHighlightColours::default(),
+            background_mode: BackgroundMode::Motion,
+            theme_ref: None,
+            generation_meta: None,
+            compile_policy: MenuCompilePolicy::default(),
+        }
+    }
+
+    fn motion_video_asset(id: &str, duration_secs: f64) -> Asset {
+        let mut asset = Asset::new(format!("{id}.mp4"), format!("/tmp/{id}.mp4"));
+        asset.id = id.to_string();
+        asset.duration_secs = Some(duration_secs);
+        asset.video_streams = vec![VideoStreamInfo {
+            index: 0,
+            codec: "h264".to_string(),
+            width: 1920,
+            height: 1080,
+            frame_rate: Some(30.0),
+            aspect_ratio: None,
+            scan_type: None,
+            bitrate_bps: None,
+            title: None,
+            color_transfer: None,
+            color_primaries: None,
+            dolby_vision_profile: None,
+        }];
+        asset.audio_streams = vec![AudioStreamInfo {
+            index: 1,
+            codec: "aac".to_string(),
+            channels: 2,
+            sample_rate: 48000,
+            language: None,
+            bitrate_bps: None,
+            title: None,
+        }];
+        asset
+    }
+
+    #[test]
+    fn motion_build_pending_warning_is_gone() {
+        let menu = Menu::new("menu-1", "Motion Menu").with_document(motion_document(
+            MenuTiming {
+                intro_start_secs: 0.0,
+                intro_duration_secs: 0.0,
+                loop_start_secs: 1.0,
+                loop_duration_secs: 3.0,
+                loop_count: 0,
+                audio_asset_id: None,
+            },
+            Some("bg-video"),
+            None,
+        ));
+        let project = project_with_menu(menu);
+        let asset = motion_video_asset("bg-video", 10.0);
+        let asset_ids: HashSet<&str> = ["bg-video"].into_iter().collect();
+        let mut asset_map = HashMap::new();
+        asset_map.insert("bg-video", &asset);
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            !issues.iter().any(|i| i.code == "menu.motion-build-pending"),
+            "the motion-build-pending warning must be gone now that motion builds are supported, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn motion_loop_exceeds_source_is_flagged_when_window_runs_past_asset_duration() {
+        let menu = Menu::new("menu-1", "Motion Menu").with_document(motion_document(
+            MenuTiming {
+                intro_start_secs: 0.0,
+                intro_duration_secs: 0.0,
+                loop_start_secs: 8.0,
+                loop_duration_secs: 5.0, // 8 + 5 = 13, past the 10s source
+                loop_count: 0,
+                audio_asset_id: None,
+            },
+            Some("bg-video"),
+            None,
+        ));
+        let project = project_with_menu(menu);
+        let asset = motion_video_asset("bg-video", 10.0);
+        let asset_ids: HashSet<&str> = ["bg-video"].into_iter().collect();
+        let mut asset_map = HashMap::new();
+        asset_map.insert("bg-video", &asset);
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "menu.motion-loop-exceeds-source"
+                    && i.severity == IssueSeverity::Error),
+            "expected a motion-loop-exceeds-source error, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn motion_loop_within_source_is_not_flagged() {
+        let menu = Menu::new("menu-1", "Motion Menu").with_document(motion_document(
+            MenuTiming {
+                intro_start_secs: 0.0,
+                intro_duration_secs: 0.0,
+                loop_start_secs: 1.0,
+                loop_duration_secs: 3.0,
+                loop_count: 0,
+                audio_asset_id: None,
+            },
+            Some("bg-video"),
+            None,
+        ));
+        let project = project_with_menu(menu);
+        let asset = motion_video_asset("bg-video", 10.0);
+        let asset_ids: HashSet<&str> = ["bg-video"].into_iter().collect();
+        let mut asset_map = HashMap::new();
+        asset_map.insert("bg-video", &asset);
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.code == "menu.motion-loop-exceeds-source"),
+            "loop window fits inside the source, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn motion_intro_invalid_is_flagged_for_negative_duration() {
+        let menu = Menu::new("menu-1", "Motion Menu").with_document(motion_document(
+            MenuTiming {
+                intro_start_secs: 0.0,
+                intro_duration_secs: -1.0,
+                loop_start_secs: 1.0,
+                loop_duration_secs: 3.0,
+                loop_count: 0,
+                audio_asset_id: None,
+            },
+            Some("bg-video"),
+            None,
+        ));
+        let project = project_with_menu(menu);
+        let asset = motion_video_asset("bg-video", 10.0);
+        let asset_ids: HashSet<&str> = ["bg-video"].into_iter().collect();
+        let mut asset_map = HashMap::new();
+        asset_map.insert("bg-video", &asset);
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            issues.iter().any(
+                |i| i.code == "menu.motion-intro-invalid" && i.severity == IssueSeverity::Error
+            ),
+            "expected a motion-intro-invalid error for negative duration, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn motion_intro_invalid_is_flagged_when_intro_window_runs_past_source() {
+        let menu = Menu::new("menu-1", "Motion Menu").with_document(motion_document(
+            MenuTiming {
+                intro_start_secs: 8.0,
+                intro_duration_secs: 5.0, // 8 + 5 = 13, past the 10s source
+                loop_start_secs: 1.0,
+                loop_duration_secs: 3.0,
+                loop_count: 0,
+                audio_asset_id: None,
+            },
+            Some("bg-video"),
+            None,
+        ));
+        let project = project_with_menu(menu);
+        let asset = motion_video_asset("bg-video", 10.0);
+        let asset_ids: HashSet<&str> = ["bg-video"].into_iter().collect();
+        let mut asset_map = HashMap::new();
+        asset_map.insert("bg-video", &asset);
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "menu.motion-intro-invalid"
+                    && i.severity == IssueSeverity::Error),
+            "expected a motion-intro-invalid error for an out-of-range intro window, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn motion_loop_count_without_timeout_is_a_warning() {
+        let menu = Menu::new("menu-1", "Motion Menu").with_document(motion_document(
+            MenuTiming {
+                intro_start_secs: 0.0,
+                intro_duration_secs: 0.0,
+                loop_start_secs: 1.0,
+                loop_duration_secs: 3.0,
+                loop_count: 3,
+                audio_asset_id: None,
+            },
+            Some("bg-video"),
+            None,
+        ));
+        let project = project_with_menu(menu);
+        let asset = motion_video_asset("bg-video", 10.0);
+        let asset_ids: HashSet<&str> = ["bg-video"].into_iter().collect();
+        let mut asset_map = HashMap::new();
+        asset_map.insert("bg-video", &asset);
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "menu.motion-loop-count-without-timeout"
+                    && i.severity == IssueSeverity::Warning),
+            "expected a motion-loop-count-without-timeout warning, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn motion_loop_count_with_timeout_is_not_flagged() {
+        let menu = Menu::new("menu-1", "Motion Menu").with_document(motion_document(
+            MenuTiming {
+                intro_start_secs: 0.0,
+                intro_duration_secs: 0.0,
+                loop_start_secs: 1.0,
+                loop_duration_secs: 3.0,
+                loop_count: 3,
+                audio_asset_id: None,
+            },
+            Some("bg-video"),
+            Some(PlaybackAction::Stop),
+        ));
+        let project = project_with_menu(menu);
+        let asset = motion_video_asset("bg-video", 10.0);
+        let asset_ids: HashSet<&str> = ["bg-video"].into_iter().collect();
+        let mut asset_map = HashMap::new();
+        asset_map.insert("bg-video", &asset);
+        let all_title_ids = HashSet::new();
+        let all_menu_ids: HashSet<&str> = ["menu-1"].into_iter().collect();
+        let mut issues = Vec::new();
+
+        validate_menus(
+            &project,
+            &asset_ids,
+            &asset_map,
+            &all_title_ids,
+            &all_menu_ids,
+            &mut issues,
+        );
+
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.code == "menu.motion-loop-count-without-timeout"),
+            "a timeout action is authored, so this should not be flagged, got {issues:?}"
+        );
     }
 
     #[test]

--- a/plugins/tauri-plugin-spindle-project/src/validation/menu.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/menu.rs
@@ -602,7 +602,7 @@ mod tests {
             id: "menu-1".to_string(),
             name: "Motion Menu".to_string(),
             domain: MenuDomain::Vmgm,
-            role: MenuRole::TitleSelect,
+            role: Some(MenuRole::TitleSelect),
             scene: MenuScene {
                 design_size: MenuSize {
                     width: 720.0,


### PR DESCRIPTION
## Summary

### User-facing changes

- **Motion menus build to playable DVDs.** The planner block is gone: a motion menu becomes an optional intro cell plus a looping menu cell with an AC-3 audio bed (explicit bed asset, the background video's own audio, or silence), and `loopCount`/timeout actions are honoured on-disc via a `g1` loop counter that resets on every menu entry.
- **The editor canvas now plays motion backgrounds** — a muted, looping `<video>` seeked to the loop start — instead of showing "Preview unavailable". Still-image backgrounds render reliably too (see below).
- **New inspector controls**: Loop start, Intro start/duration, and Timeout action, plus a scrub row with "Set loop start from playhead". The loop-start diagnostic can finally be resolved in the UI.
- **Imported assets render regardless of where they live on disk.** A new `allow_asset_scope` command grants the webview access to exactly the source paths of imported project assets at open/import time — the static protocol scope stays narrow.

### Build pipeline

- One ffmpeg compose per segment (no intermediate encode generations): input-side trims, scene-PNG overlay, AC-3 mux, `-f dvd`. Closed GOPs (`-flags +cgop`, with the `-sc_threshold` workaround this ffmpeg build requires) keep the loop cut clean.
- BT.601 colour tagging (`dvd_colour_flags()`, `out_color_matrix=bt601`) lands on motion composes per the colour-management research; retrofitting still/title encodes is a follow-up.
- spumux runs on the loop cell only — buttons appear when the loop starts, the classic commercial-DVD behaviour.
- Validation: `menu.motion-build-pending` is gone; added `menu.motion-loop-exceeds-source`, `menu.motion-intro-invalid`, and `menu.motion-loop-count-without-timeout`.

### Deferred

- The `MenuCompiler` trait carve is deliberately deferred: the build system is a serializable job list, and a trait with a single implementor would force high-churn still-path rewiring for no user value. `build/menu_motion.rs` documents the mapping to the future trait stages so the carve is mechanical when a second backend lands. Rationale noted on #107.

Closes #107

## Test plan

- [x] `pnpm validate` in the dev container: format, tsc + vite build, 255 vitest, `cargo fmt --check`, clippy `-D warnings`, 278 nextest passed
- [x] Real-toolchain executor smoke test (`--run-ignored all` with ffmpeg/spumux/dvdauthor): motion menu with intro + loop + bed + `loopCount 2` + timeout authors successfully; ffprobe confirms segment durations and mpeg2video+ac3 layout in both cells; dvdauthor XML carries `<post>` with `jump cell 2`
- [ ] Manual VLC pass on the `Jetsons - Motion Menu Test` fixture (queued for the live verification round after the stack review)

---

### Stack

Part of the rich menu editor stack — merge bottom → top:

1. #116
2. #117
3. #118
4. #123 ⟵ **this PR**
5. #125
6. #126
7. #128
