### PR TITLE
Stop hard-wrapping markdown prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@
 ## Documentation
 
 - **Updates:** When user-facing behaviour, CLI options, or features change, update `README.md` and `SPEC.md`.
+- **No hard wrapping:** Never hard-wrap paragraph prose in markdown files — write each paragraph or list item as a single line and let viewers soft-wrap. Deliberate short standalone lines, one-liners, and separate bullets are intentional structure — never collapse them.
 
 ## Licence and Copyright
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ If host Rust tooling is unavailable, run commands in the `ghcr.io/liminal-hq/tau
 - **Commits**: Conventional Commits with markdown bodies (what/why, `test:` for test-only changes); write bodies to a file and `git commit -F` when they contain backticks.
 - **Licence headers** on new/substantially rewritten `.rs`/`.ts`/`.tsx` files in `src/` (one-line summary + `(c) Copyright 2026 Liminal HQ, Scott Morris` + `SPDX-License-Identifier: MIT`).
 - **Docs sync**: user-facing changes update `README.md` and `SPEC.md`.
+- **No hard wrapping**: write each markdown paragraph or list item as a single line and let viewers soft-wrap; deliberate short lines, one-liners, and bullets stay as-is.
 - **Git**: never push (especially force-push) unless explicitly asked; prefer the `gh` CLI for GitHub work.
 
 Keep this file and `AGENTS.md` in sync: when a convention changes there, update the summary here in the same PR.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1771,4 +1771,3 @@ The design system is implemented as CSS custom properties in `design-system.css`
 - **Rust**: Unit tests in `models.rs` cover JSON round-trips, serialisation format, domain values, and field initialisation.
 - **Frontend**: Vitest with happy-dom and testing-library. Tests cover type helpers, constants, and project creation defaults.
 - **No Rust toolchain locally**: Rust tests run via Docker (`ghcr.io/liminal-hq/tauri-dev-desktop:latest`).
-  .

--- a/docs/initial-planning/HDMV for Blu-ray Disc- implementable architecture research for a Rust libhdmv and Tauri v2 plugin.md
+++ b/docs/initial-planning/HDMV for Blu-ray Disc- implementable architecture research for a Rust libhdmv and Tauri v2 plugin.md
@@ -799,12 +799,17 @@ Demonstrates real-world integration and UX constraints: BD-J menu support depend
 **Tauri v2 documentation: plugin development + security (capabilities/permissions) + calling Rust.**  
 Defines the correct wrapper architecture for a plugin surface (crate + optional NPM bindings), and the security primitives (permissions/capabilities) that should constrain disc/ISO access and command exposure for a filesystem-heavy plugin.
 
-**lw/BluRay Wiki — StreamCodingInfo and CLPI format documentation.** Community-maintained binary format documentation for CLPI and MPLS structures, including HEVC stream coding type 0x24 and associated fields (DynamicRangeType, ColorSpace, HDRPlusFlag). Essential reference for implementing UHD BD stream info parsing.
+**lw/BluRay Wiki — StreamCodingInfo and CLPI format documentation.**  
+Community-maintained binary format documentation for CLPI and MPLS structures, including HEVC stream coding type 0x24 and associated fields (`DynamicRangeType`, `ColorSpace`, `HDRPlusFlag`). Essential reference for implementing UHD BD stream info parsing.
 
-**quietvoid/hdr10plus_tool (Rust) — HDR10+ metadata CLI.** Rust crate for extracting and injecting HDR10+ dynamic metadata (SMPTE ST 2094-40) in HEVC bitstreams. Potential dependency for Spindle's HDR metadata pipeline.
+**quietvoid/hdr10plus_tool (Rust) — HDR10+ metadata CLI.**  
+Rust crate for extracting and injecting HDR10+ dynamic metadata (SMPTE ST 2094-40) in HEVC bitstreams. Potential dependency for Spindle's HDR metadata pipeline.
 
-**quietvoid/dovi_tool (Rust) — Dolby Vision RPU metadata CLI.** Rust crate for manipulating Dolby Vision Reference Processing Unit data. Covers Profile 7 dual-layer extraction, injection, and conversion. Potential dependency for DV-aware authoring.
+**quietvoid/dovi_tool (Rust) — Dolby Vision RPU metadata CLI.**  
+Rust crate for manipulating Dolby Vision Reference Processing Unit data. Covers Profile 7 dual-layer extraction, injection, and conversion. Potential dependency for DV-aware authoring.
 
-**Dolby — "Dolby Vision UHD Blu-ray Authoring Workflow Guide" v1.1.** Professional documentation of DV Profile 7 authoring on UHD BD: base layer + enhancement layer architecture, MEL vs FEL variants, MPLS sub-path referencing, and backward compatibility with HDR10 players.
+**Dolby — "Dolby Vision UHD Blu-ray Authoring Workflow Guide" v1.1.**  
+Professional documentation of DV Profile 7 authoring on UHD BD: base layer + enhancement layer architecture, MEL vs FEL variants, MPLS sub-path referencing, and backward compatibility with HDR10 players.
 
-**jaminmc/tsMuxer (C++) — actively maintained tsMuxeR fork.** Continuation of the tsMuxeR project after the justdan96 repository was archived in April 2025. Supports HEVC muxing, HDR10, HDR10+, and Dolby Vision Profile 7 dual-layer for UHD BD-compatible BDMV structure generation.
+**jaminmc/tsMuxer (C++) — actively maintained tsMuxeR fork.**  
+Continuation of the tsMuxeR project after the justdan96 repository was archived in April 2025. Supports HEVC muxing, HDR10, HDR10+, and Dolby Vision Profile 7 dual-layer for UHD BD-compatible BDMV structure generation.

--- a/docs/initial-planning/HDMV for Blu-ray Disc- implementable architecture research for a Rust libhdmv and Tauri v2 plugin.md
+++ b/docs/initial-planning/HDMV for Blu-ray Disc- implementable architecture research for a Rust libhdmv and Tauri v2 plugin.md
@@ -799,17 +799,12 @@ Demonstrates real-world integration and UX constraints: BD-J menu support depend
 **Tauri v2 documentation: plugin development + security (capabilities/permissions) + calling Rust.**  
 Defines the correct wrapper architecture for a plugin surface (crate + optional NPM bindings), and the security primitives (permissions/capabilities) that should constrain disc/ISO access and command exposure for a filesystem-heavy plugin.
 
-**lw/BluRay Wiki — StreamCodingInfo and CLPI format documentation.**
-Community-maintained binary format documentation for CLPI and MPLS structures, including HEVC stream coding type 0x24 and associated fields (DynamicRangeType, ColorSpace, HDRPlusFlag). Essential reference for implementing UHD BD stream info parsing.
+**lw/BluRay Wiki — StreamCodingInfo and CLPI format documentation.** Community-maintained binary format documentation for CLPI and MPLS structures, including HEVC stream coding type 0x24 and associated fields (DynamicRangeType, ColorSpace, HDRPlusFlag). Essential reference for implementing UHD BD stream info parsing.
 
-**quietvoid/hdr10plus_tool (Rust) — HDR10+ metadata CLI.**
-Rust crate for extracting and injecting HDR10+ dynamic metadata (SMPTE ST 2094-40) in HEVC bitstreams. Potential dependency for Spindle's HDR metadata pipeline.
+**quietvoid/hdr10plus_tool (Rust) — HDR10+ metadata CLI.** Rust crate for extracting and injecting HDR10+ dynamic metadata (SMPTE ST 2094-40) in HEVC bitstreams. Potential dependency for Spindle's HDR metadata pipeline.
 
-**quietvoid/dovi_tool (Rust) — Dolby Vision RPU metadata CLI.**
-Rust crate for manipulating Dolby Vision Reference Processing Unit data. Covers Profile 7 dual-layer extraction, injection, and conversion. Potential dependency for DV-aware authoring.
+**quietvoid/dovi_tool (Rust) — Dolby Vision RPU metadata CLI.** Rust crate for manipulating Dolby Vision Reference Processing Unit data. Covers Profile 7 dual-layer extraction, injection, and conversion. Potential dependency for DV-aware authoring.
 
-**Dolby — "Dolby Vision UHD Blu-ray Authoring Workflow Guide" v1.1.**
-Professional documentation of DV Profile 7 authoring on UHD BD: base layer + enhancement layer architecture, MEL vs FEL variants, MPLS sub-path referencing, and backward compatibility with HDR10 players.
+**Dolby — "Dolby Vision UHD Blu-ray Authoring Workflow Guide" v1.1.** Professional documentation of DV Profile 7 authoring on UHD BD: base layer + enhancement layer architecture, MEL vs FEL variants, MPLS sub-path referencing, and backward compatibility with HDR10 players.
 
-**jaminmc/tsMuxer (C++) — actively maintained tsMuxeR fork.**
-Continuation of the tsMuxeR project after the justdan96 repository was archived in April 2025. Supports HEVC muxing, HDR10, HDR10+, and Dolby Vision Profile 7 dual-layer for UHD BD-compatible BDMV structure generation.
+**jaminmc/tsMuxer (C++) — actively maintained tsMuxeR fork.** Continuation of the tsMuxeR project after the justdan96 repository was archived in April 2025. Supports HEVC muxing, HDR10, HDR10+, and Dolby Vision Profile 7 dual-layer for UHD BD-compatible BDMV structure generation.

--- a/docs/initial-planning/toolchain_packaging_note.md
+++ b/docs/initial-planning/toolchain_packaging_note.md
@@ -134,10 +134,8 @@ Notes:
 - `binaries/` is gitignored; it is a build artefact populated before packaging
 - `binaries/` is for executables only; `resources/` is for non-executable files
 - keep names stable at the logical level (`dvdauthor`, `genisoimage`, etc.)
-- target-triple suffixes are stripped by Tauri at bundle time; at runtime the
-  binary is available as `dvdauthor`, `genisoimage`, etc. alongside the executable
-- on macOS, `genisoimage` is not in Homebrew; `mkisofs` (from cdrtools) fills
-  both roles and is copied under both sidecar names
+- target-triple suffixes are stripped by Tauri at bundle time; at runtime the binary is available as `dvdauthor`, `genisoimage`, etc. alongside the executable
+- on macOS, `genisoimage` is not in Homebrew; `mkisofs` (from cdrtools) fills both roles and is copied under both sidecar names
 
 ---
 
@@ -163,11 +161,9 @@ These are **recommended starting pins**, not eternal requirements.
 `genisoimage` and `mkisofs` both support UDF for DVD via:
 
 - `-udf` — plain UDF filesystem
-- `-dvd-video` — UDF Bridge (hybrid ISO 9660 + UDF 1.02), the correct on-disc
-  format for DVD-Video; this is what the Spindle build pipeline uses
+- `-dvd-video` — UDF Bridge (hybrid ISO 9660 + UDF 1.02), the correct on-disc format for DVD-Video; this is what the Spindle build pipeline uses
 
-`dvdauthor` and `spumux` produce the `VIDEO_TS` directory structure only; they
-do not create ISO images.
+`dvdauthor` and `spumux` produce the `VIDEO_TS` directory structure only; they do not create ISO images.
 
 ---
 
@@ -237,28 +233,22 @@ Instead, think of the binaries as **release inputs** prepared before packaging.
 
 `plugins/tauri-plugin-spindle-project/src/toolchain.rs` provides `resolve_tool(name)`:
 
-1. checks for the binary next to the running executable (where Tauri places
-   bundled sidecars in both `tauri dev` and release mode)
+1. checks for the binary next to the running executable (where Tauri places bundled sidecars in both `tauri dev` and release mode)
 2. falls back to the system PATH
 
-This means development still works with system-installed tools. Running
-`./scripts/install-sidecars.sh` sets up the PATH-based tools for local dev.
+This means development still works with system-installed tools. Running `./scripts/install-sidecars.sh` sets up the PATH-based tools for local dev.
 
-To test with real sidecars bundled, run `./scripts/collect-sidecars.sh` first
-to populate `src-tauri/binaries/` before running `tauri dev` or `tauri build`.
+To test with real sidecars bundled, run `./scripts/collect-sidecars.sh` first to populate `src-tauri/binaries/` before running `tauri dev` or `tauri build`.
 
 ### CI (quality pipeline)
 
-The quality CI (fmt, clippy, tests) does not need real binaries. Before each
-Rust job that triggers the Tauri build script, the CI runs:
+The quality CI (fmt, clippy, tests) does not need real binaries. Before each Rust job that triggers the Tauri build script, the CI runs:
 
 ```
 bash scripts/create-sidecar-stubs.sh x86_64-unknown-linux-gnu
 ```
 
-This places minimal stub executables in `src-tauri/binaries/` so that Tauri's
-build-time validation passes. Unit tests do not invoke the external tools, so
-stubs are sufficient.
+This places minimal stub executables in `src-tauri/binaries/` so that Tauri's build-time validation passes. Unit tests do not invoke the external tools, so stubs are sufficient.
 
 ### Release CI (not yet written — details to be worked out)
 
@@ -275,24 +265,18 @@ Each job:
 
 1. checkout
 2. install Rust toolchain
-3. `./scripts/collect-sidecars.sh` — runs natively on the runner, installs
-   tools via apt-get (Linux) or brew (macOS), copies binaries with target-triple
-   suffix; auto-detects the triple via `rustc -Vv`
+3. `./scripts/collect-sidecars.sh` — runs natively on the runner, installs tools via apt-get (Linux) or brew (macOS), copies binaries with target-triple suffix; auto-detects the triple via `rustc -Vv`
 4. `tauri build`
 5. upload/publish artefacts
 
-`collect-sidecars.sh` is designed to work in any environment — natively on a
-developer machine, inside a dev container, on a CI runner, or invoked inside
-Docker when tools are not available natively. It does not assume a specific
-container image.
+`collect-sidecars.sh` is designed to work in any environment — natively on a developer machine, inside a dev container, on a CI runner, or invoked inside Docker when tools are not available natively. It does not assume a specific container image.
 
 **Open decisions for release CI:**
 
 - macOS signing/notarisation (Developer ID, Gatekeeper)
 - Tauri updater configuration and update manifest signing
 - artefact upload destination (GitHub Releases, CDN, etc.)
-- whether to pin exact tool versions via checksums rather than installing
-  whatever apt/brew provides at build time
+- whether to pin exact tool versions via checksums rather than installing whatever apt/brew provides at build time
 
 **Windows:** dvdauthor has no Windows port. Windows builds are not supported
 for the DVD authoring pipeline.
@@ -308,8 +292,7 @@ Bundled now:
 - `dvdauthor` — DVD-Video authoring (VIDEO_TS structure)
 - `spumux` — DVD subtitle/highlight overlay (shipped with dvdauthor)
 - `genisoimage` — ISO 9660 / UDF Bridge image creation
-- `mkisofs` — same role; on Linux often the same binary as genisoimage;
-  on macOS comes from cdrtools
+- `mkisofs` — same role; on Linux often the same binary as genisoimage; on macOS comes from cdrtools
 
 Deferred (still PATH-based):
 

--- a/docs/initial-planning/toolchain_packaging_note.md
+++ b/docs/initial-planning/toolchain_packaging_note.md
@@ -278,8 +278,7 @@ Each job:
 - artefact upload destination (GitHub Releases, CDN, etc.)
 - whether to pin exact tool versions via checksums rather than installing whatever apt/brew provides at build time
 
-**Windows:** dvdauthor has no Windows port. Windows builds are not supported
-for the DVD authoring pipeline.
+**Windows:** dvdauthor has no Windows port. Windows builds are not supported for the DVD authoring pipeline.
 
 ---
 

--- a/docs/rich-menu-editor-plan.md
+++ b/docs/rich-menu-editor-plan.md
@@ -284,8 +284,7 @@ Each slice is independently shippable and lists what it must do differently beca
 - Drive `CompileMode`, `inspectorDiagnostics.ts`, and canvas chrome from the profile; delete `MAX_DVD_BUTTONS`, `DVD_PALETTE_COLOURS`, `MENU_WIDTH` constants.
 - Format badge in the menu editor header and menu rail.
 
-**BD-readiness:** this is the seam BD plugs into (`blu-ray-integration-plan.md`
-§1.9's conditional UI becomes "add a profile row").
+**BD-readiness:** this is the seam BD plugs into (`blu-ray-integration-plan.md` §1.9's conditional UI becomes "add a profile row").
 
 ### Slice B — Visual fidelity foundation
 

--- a/docs/rich-menu-editor-plan.md
+++ b/docs/rich-menu-editor-plan.md
@@ -144,10 +144,9 @@ Everything "rich" the user wants (motion, imagery, animated buttons) is _native_
        EV -->|"requestAnimationFrame\n(same evaluate, TS port + parity tests)"| PREV["Editor: animated\nPreview mode"]
    ```
 
-The DVD lowering is lossy by design (palette/contrast only, hold-steps); the diagnostics layer says exactly what survives, per Section 3.3.
+   The DVD lowering is lossy by design (palette/contrast only, hold-steps); the diagnostics layer says exactly what survives, per Section 3.3.
 
-3. **Menus carry a semantic role, not just a physical domain.** `MenuDomain::
-Vmgm | Titleset` is DVD's physical layout leaking into authored intent. Menus gain a `role` (root, title-select, chapter, setup, popup, extras); the DVD backend maps role → VMGM/VTSM placement, the BD backend maps role → Top Menu / popup IG stream. This reconciles with `blu-ray-integration-plan.md` §1.7 (`BdMenuType`) — role is the shared concept, `BdMenuType` and `MenuDomain` become backend mappings of it.
+3. **Menus carry a semantic role, not just a physical domain.** `MenuDomain::Vmgm | Titleset` is DVD's physical layout leaking into authored intent. Menus gain a `role` (root, title-select, chapter, setup, popup, extras); the DVD backend maps role → VMGM/VTSM placement, the BD backend maps role → Top Menu / popup IG stream. This reconciles with `blu-ray-integration-plan.md` §1.7 (`BdMenuType`) — role is the shared concept, `BdMenuType` and `MenuDomain` become backend mappings of it.
 
    ```rust
    /// What the user means this menu to be. Backends map role → physical
@@ -164,13 +163,13 @@ Vmgm | Titleset` is DVD's physical layout leaking into authored intent. Menus ga
    }
    ```
 
-`MenuDocument.role` is authoritative; `MenuDomain` stays only as the DVD backend's placement output. Existing projects infer a role on load, in order:
+   `MenuDocument.role` is authoritative; `MenuDomain` stays only as the DVD backend's placement output. Existing projects infer a role on load, in order:
    1. **Generation metadata, once it can discriminate.** Today it cannot: `createGeneratedMenuFromButtons` writes the same `generationMeta.generatorId: 'menu-workspace'` for chapter, audio, and subtitle menus (`menuGenerators.ts`). The role slice therefore also adds a `generatorKind` (or per-generator ids) to `MenuGenerationMeta`, written by the generators from then on.
    2. **Interaction-content detection for existing projects**, where metadata is uniform — counting actions after **recursively flattening `Sequence`**, because the setup generators wrap the stream setter in a `sequence` with an optional `showMenu` return (`menuGenerators.ts`): predominantly `PlayChapter` → `Chapter`; predominantly `SetAudioStream`/`SetSubtitleStream` → `Setup`; menu-name hints ("Chapter", "Audio", "Subtitle") as a weak tiebreaker only.
    3. Among `Vmgm` menus, only the disc's entry menu (the default/first global menu a player reaches via the title-menu key) → `Root` — a project can hold several VMGM pages (title-select, extras), and all remaining `Vmgm` menus infer `TitleSelect`.
    4. Everything else → `TitleSelect`.
 
-Inference is a one-time default — the inspector lets the user reassign any role afterwards.
+   Inference is a one-time default — the inspector lets the user reassign any role afterwards.
 
 4. **Constraint profiles, not constants.** Button limits, palette depth, raster, safe-area, and minimum font sizes become a per-format data table consumed by diagnostics, the compile preview, and validation — replacing hardcoded `MAX_DVD_BUTTONS = 36`, `DVD_PALETTE_COLOURS = 4` (`CompileMode.tsx`) and `MENU_WIDTH = 720` (`SceneCanvas.tsx`).
 5. **The editor speaks design-space only.** Retire the legacy `buttons` mirror and the 720-raster remnants; the authored document (already resolution-agnostic, with a 1920×1080 BluRay arm in `MenuSize::default_for`) becomes the single model.
@@ -186,10 +185,7 @@ The project already knows its `DiscFamily`; the menu workspace should wear it. T
 
 ### 3.1 Format context chrome
 
-- The menu editor header already shows `16:9 anamorphic DVD · 720 × 480 NTSC`.
-  Generalise this into a **format badge** sourced from the constraint profile:
-  DVD shows raster/standard/aspect; BD will show `1920 × 1080 · 23.976p ·
-BD-25`. The badge is also the entry point to the compile-policy inspector.
+- The menu editor header already shows `16:9 anamorphic DVD · 720 × 480 NTSC`. Generalise this into a **format badge** sourced from the constraint profile: DVD shows raster/standard/aspect; BD will show `1920 × 1080 · 23.976p · BD-25`. The badge is also the entry point to the compile-policy inspector.
 
   ```text
   DVD project                              BD project (later)
@@ -304,8 +300,7 @@ Intersecting issues: #28, #29, #53, #55, #63, #64.
 
 ### Slice C — Motion menu backend
 
-**Goal:** motion backgrounds and audio beds actually build; the plan-time
-block is removed.
+**Goal:** motion backgrounds and audio beds actually build; the plan-time block is removed.
 
 - Implement the pipeline in `motion-menus.md` (loop-segment extraction from `loopStartSecs`, scene PNG composited over looping video, AC-3 audio bed, intro cell + loop cell with `<post>` jump, loop-count/timeout via g-register post-commands).
 - Carve the **`MenuCompiler` boundary** while writing it: trait with `render_states → compose_background → mux` stages; the DVD implementation is the only one, but ffmpeg/dvdauthor types stop appearing in shared build code.
@@ -410,7 +405,7 @@ block is removed.
   </spu>
   ```
 
-If per-keyframe overlay swaps prove too coarse or bloaty in practice, the fallback is a lower-level DCSQ writer emitting palette/contrast updates directly (bypassing spumux for menus with animated tracks) — the DCSQ player-compatibility research issue covers evaluating both routes.
+  If per-keyframe overlay swaps prove too coarse or bloaty in practice, the fallback is a lower-level DCSQ writer emitting palette/contrast updates directly (bypassing spumux for menus with animated tracks) — the DCSQ player-compatibility research issue covers evaluating both routes.
 
 - Keyframe editor UI replaces the dead Static/Animated dropdown; Preview mode animates highlights over the loop.
 - Migration: existing `HighlightKeyframe` arrays lift into tracks on load.
@@ -427,8 +422,7 @@ If per-keyframe overlay swaps prove too coarse or bloaty in practice, the fallba
 
 ### Slice F — Themes & components
 
-**Goal:** `theme_ref` and the Templates rail stop being stubs; generated menus
-restyle without regeneration.
+**Goal:** `theme_ref` and the Templates rail stop being stubs; generated menus restyle without regeneration.
 
 - Theme document: typography set, button `ButtonStyleMap`, highlight palette, spacing tokens, background treatment. `theme_ref` resolves against project themes; unset properties inherit from the theme.
 
@@ -451,7 +445,7 @@ restyle without regeneration.
   }
   ```
 
-Resolution order per property: explicit node override → component default → theme token → model default. Only the explicit override is stored in the scene, which is what makes re-theming and regeneration non-destructive.
+  Resolution order per property: explicit node override → component default → theme token → model default. Only the explicit override is stored in the scene, which is what makes re-theming and regeneration non-destructive.
 
 - Templates rail lists starter themes; applying one is undoable and non-destructive (explicit overrides survive).
 - Generators become theme-aware (SPEC §14.8) and emit `generation_meta` so regeneration preserves overrides.

--- a/docs/rich-menu-editor-plan.md
+++ b/docs/rich-menu-editor-plan.md
@@ -2,24 +2,16 @@
 
 **Status:** planning · July 2026 · reviewed against Spindle v0.3.0
 
-This document plans the next generation of the menu authoring system: motion
-backgrounds, animated buttons, richer imagery and styling, timeline editing,
-and — critically — the design decisions that must be made _now_ so the same
-editor can author BDMV (Blu-ray) menus later without a rewrite.
+This document plans the next generation of the menu authoring system: motion backgrounds, animated buttons, richer imagery and styling, timeline editing, and — critically — the design decisions that must be made _now_ so the same editor can author BDMV (Blu-ray) menus later without a rewrite.
 
 It builds on, and does not replace:
 
-- [`motion-menus.md`](motion-menus.md) — DVD motion-menu pipeline detail
-  (spumux/dvdauthor mechanics, validation rules, ffmpeg filter graphs)
-- [`blu-ray-integration-plan.md`](blu-ray-integration-plan.md) — the full BD/UHD
-  backend programme (phases 1–8)
+- [`motion-menus.md`](motion-menus.md) — DVD motion-menu pipeline detail (spumux/dvdauthor mechanics, validation rules, ffmpeg filter graphs)
+- [`blu-ray-integration-plan.md`](blu-ray-integration-plan.md) — the full BD/UHD backend programme (phases 1–8)
 - [`lib-igs-author-plan.md`](lib-igs-author-plan.md) — IGS authoring library
-- [`initial-planning/dvd_bd_architecture_note.md`](initial-planning/dvd_bd_architecture_note.md)
-  — the layering rule this plan follows: _share the authoring language, not the
-  compiler_
+- [`initial-planning/dvd_bd_architecture_note.md`](initial-planning/dvd_bd_architecture_note.md) — the layering rule this plan follows: _share the authoring language, not the compiler_
 
-Where those documents describe backends, this one describes the **authored
-model, the editor, and the seams between them and the backends**.
+Where those documents describe backends, this one describes the **authored model, the editor, and the seams between them and the backends**.
 
 ---
 
@@ -27,20 +19,9 @@ model, the editor, and the seams between them and the backends**.
 
 ### What works today (v0.3.0)
 
-- **Authored model** (`plugins/tauri-plugin-spindle-project/src/models/menu.rs`):
-  `MenuDocument` cleanly separates scene graph, interaction graph, timing, and
-  compile policy. Design-space coordinates scale to the raster at compile time.
-  The model already contains per-state button styles (`ButtonStyleMap`), motion
-  timing (`MenuTiming`), animated highlight keyframes, `SceneNode::Video`,
-  `Group`, `ComponentInstance`, `GeneratedCollection`, and `theme_ref`.
-- **Editor** (`apps/spindle/src/components/menus/`): drag/resize/snap canvas
-  with safe areas, text/image/shape/button tools, per-state button styling
-  including shadows and glows, remote-navigation preview with select/activate
-  simulation, DVD-safe compile preview, menu map, and chapter/audio/subtitle
-  menu generators.
-- **DVD build** (`src/build/`): Skia renders the scene to a PNG, ffmpeg
-  composites it over the background and encodes an MPEG-2 still, and highlights
-  are emitted as a 4-colour subpicture overlay.
+- **Authored model** (`plugins/tauri-plugin-spindle-project/src/models/menu.rs`): `MenuDocument` cleanly separates scene graph, interaction graph, timing, and compile policy. Design-space coordinates scale to the raster at compile time. The model already contains per-state button styles (`ButtonStyleMap`), motion timing (`MenuTiming`), animated highlight keyframes, `SceneNode::Video`, `Group`, `ComponentInstance`, `GeneratedCollection`, and `theme_ref`.
+- **Editor** (`apps/spindle/src/components/menus/`): drag/resize/snap canvas with safe areas, text/image/shape/button tools, per-state button styling including shadows and glows, remote-navigation preview with select/activate simulation, DVD-safe compile preview, menu map, and chapter/audio/subtitle menu generators.
+- **DVD build** (`src/build/`): Skia renders the scene to a PNG, ffmpeg composites it over the background and encodes an MPEG-2 still, and highlights are emitted as a 4-colour subpicture overlay.
 
 ### Today's pipeline, and where it diverges
 
@@ -66,9 +47,7 @@ flowchart LR
     Canvas -. "no parity check\n(shadows render here…)" .-> Skia
 ```
 
-The two dotted edges are the structural problems: the legacy mirror keeps a
-second model alive that cannot express the roadmap below, and nothing forces
-the DOM render and the Skia render to agree.
+The two dotted edges are the structural problems: the legacy mirror keeps a second model alive that cannot express the roadmap below, and nothing forces the DOM render and the Skia render to agree.
 
 ### The gap: the model is two phases ahead of everything else
 
@@ -88,50 +67,26 @@ the DOM render and the Skia render to agree.
 
 Two structural warts amplify the gap:
 
-1. **The legacy `Menu.buttons` mirror.** Every edit syncs the authored document
-   back to the flat pre-scene button model (`project-store.ts`, sync layer in
-   `updateMenuDocument`). It keeps old readers alive but is the source of
-   drift bugs (issue #29) and structurally cannot express anything on the
-   roadmap below.
-2. **Editor/build render divergence.** The editor renders with DOM/CSS, the
-   build renders with Skia, and nothing enforces parity. Shadows are the
-   proof: authored, previewed, silently dropped from the disc.
+1. **The legacy `Menu.buttons` mirror.** Every edit syncs the authored document back to the flat pre-scene button model (`project-store.ts`, sync layer in `updateMenuDocument`). It keeps old readers alive but is the source of drift bugs (issue #29) and structurally cannot express anything on the roadmap below.
+2. **Editor/build render divergence.** The editor renders with DOM/CSS, the build renders with Skia, and nothing enforces parity. Shadows are the proof: authored, previewed, silently dropped from the disc.
 
 ---
 
 ## 2. What BDMV changes, and why it shapes decisions now
 
-HDMV Interactive Graphics menus (the realistic BD target — see
-`lib-igs-author-plan.md`) are structurally _richer_ than DVD in exactly the
-directions this plan pursues:
+HDMV Interactive Graphics menus (the realistic BD target — see `lib-igs-author-plan.md`) are structurally _richer_ than DVD in exactly the directions this plan pursues:
 
-- **Button states are full bitmaps, not colour overlays.** Normal / selected /
-  activated each get their own image, and each state can be an **animated
-  frame sequence**. DVD's 4-colour subpicture highlight is the degenerate
-  case, not the general model.
+- **Button states are full bitmaps, not colour overlays.** Normal / selected / activated each get their own image, and each state can be an **animated frame sequence**. DVD's 4-colour subpicture highlight is the degenerate case, not the general model.
 - **256-colour palettized graphics** at up to 1920×1080, square pixels, BT.709.
-- **Popup menus over playing video** — a menu is not necessarily a place you
-  navigate to; it can be an overlay on playback.
-- Multi-page menus in one stream, button **sound effects**, page in/out
-  transition effects, and a richer navigation VM.
+- **Popup menus over playing video** — a menu is not necessarily a place you navigate to; it can be an overlay on playback.
+- Multi-page menus in one stream, button **sound effects**, page in/out transition effects, and a richer navigation VM.
 
-Everything "rich" the user wants (motion, imagery, animated buttons) is
-_native_ on BD and _emulated_ on DVD. Therefore: **the authored model
-expresses the rich intent; each format backend owns the degradation.**
+Everything "rich" the user wants (motion, imagery, animated buttons) is _native_ on BD and _emulated_ on DVD. Therefore: **the authored model expresses the rich intent; each format backend owns the degradation.**
 
 ### Design decisions (binding for the slices below)
 
-1. **Button states are fully rendered visuals; DVD-ness is a compile policy.**
-   The Skia renderer must be able to render _any_ state of any button — DVD
-   uses that for its compile preview and to derive the subpicture; BD will
-   emit per-state bitmaps directly.
-2. **Animation is deterministic keyframed property tracks**, evaluated by one
-   Rust implementation that the compiler and the editor preview both agree
-   with (parity-tested, same approach as scene rendering). BD lowers tracks to
-   sampled bitmap frames; DVD lowers them to subpicture display-control
-   sequences (DCSQ palette updates). Nothing browser-only (CSS transitions,
-   open-ended easing) goes into the model. `HighlightKeyframe` becomes a
-   special case of this system, not a parallel one.
+1. **Button states are fully rendered visuals; DVD-ness is a compile policy.** The Skia renderer must be able to render _any_ state of any button — DVD uses that for its compile preview and to derive the subpicture; BD will emit per-state bitmaps directly.
+2. **Animation is deterministic keyframed property tracks**, evaluated by one Rust implementation that the compiler and the editor preview both agree with (parity-tested, same approach as scene rendering). BD lowers tracks to sampled bitmap frames; DVD lowers them to subpicture display-control sequences (DCSQ palette updates). Nothing browser-only (CSS transitions, open-ended easing) goes into the model. `HighlightKeyframe` becomes a special case of this system, not a parallel one.
 
    ```rust
    /// A keyframed animation on one property of one scene node (or button
@@ -189,16 +144,10 @@ expresses the rich intent; each format backend owns the degradation.**
        EV -->|"requestAnimationFrame\n(same evaluate, TS port + parity tests)"| PREV["Editor: animated\nPreview mode"]
    ```
 
-   The DVD lowering is lossy by design (palette/contrast only, hold-steps);
-   the diagnostics layer says exactly what survives, per Section 3.3.
+The DVD lowering is lossy by design (palette/contrast only, hold-steps); the diagnostics layer says exactly what survives, per Section 3.3.
 
 3. **Menus carry a semantic role, not just a physical domain.** `MenuDomain::
-Vmgm | Titleset` is DVD's physical layout leaking into authored intent.
-   Menus gain a `role` (root, title-select, chapter, setup, popup, extras);
-   the DVD backend maps role → VMGM/VTSM placement, the BD backend maps role →
-   Top Menu / popup IG stream. This reconciles with `blu-ray-integration-plan.md`
-   §1.7 (`BdMenuType`) — role is the shared concept, `BdMenuType` and
-   `MenuDomain` become backend mappings of it.
+Vmgm | Titleset` is DVD's physical layout leaking into authored intent. Menus gain a `role` (root, title-select, chapter, setup, popup, extras); the DVD backend maps role → VMGM/VTSM placement, the BD backend maps role → Top Menu / popup IG stream. This reconciles with `blu-ray-integration-plan.md` §1.7 (`BdMenuType`) — role is the shared concept, `BdMenuType` and `MenuDomain` become backend mappings of it.
 
    ```rust
    /// What the user means this menu to be. Backends map role → physical
@@ -215,68 +164,25 @@ Vmgm | Titleset` is DVD's physical layout leaking into authored intent.
    }
    ```
 
-   `MenuDocument.role` is authoritative; `MenuDomain` stays only as the DVD
-   backend's placement output. Existing projects infer a role on load, in
-   order:
-   1. **Generation metadata, once it can discriminate.** Today it cannot:
-      `createGeneratedMenuFromButtons` writes the same
-      `generationMeta.generatorId: 'menu-workspace'` for chapter, audio, and
-      subtitle menus (`menuGenerators.ts`). The role slice therefore also adds
-      a `generatorKind` (or per-generator ids) to `MenuGenerationMeta`, written
-      by the generators from then on.
-   2. **Interaction-content detection for existing projects**, where metadata
-      is uniform — counting actions after **recursively flattening
-      `Sequence`**, because the setup generators wrap the stream setter in a
-      `sequence` with an optional `showMenu` return (`menuGenerators.ts`):
-      predominantly `PlayChapter` → `Chapter`; predominantly
-      `SetAudioStream`/`SetSubtitleStream` → `Setup`; menu-name hints
-      ("Chapter", "Audio", "Subtitle") as a weak tiebreaker only.
-   3. Among `Vmgm` menus, only the disc's entry menu (the default/first global
-      menu a player reaches via the title-menu key) → `Root` — a project can
-      hold several VMGM pages (title-select, extras), and all remaining `Vmgm`
-      menus infer `TitleSelect`.
+`MenuDocument.role` is authoritative; `MenuDomain` stays only as the DVD backend's placement output. Existing projects infer a role on load, in order:
+   1. **Generation metadata, once it can discriminate.** Today it cannot: `createGeneratedMenuFromButtons` writes the same `generationMeta.generatorId: 'menu-workspace'` for chapter, audio, and subtitle menus (`menuGenerators.ts`). The role slice therefore also adds a `generatorKind` (or per-generator ids) to `MenuGenerationMeta`, written by the generators from then on.
+   2. **Interaction-content detection for existing projects**, where metadata is uniform — counting actions after **recursively flattening `Sequence`**, because the setup generators wrap the stream setter in a `sequence` with an optional `showMenu` return (`menuGenerators.ts`): predominantly `PlayChapter` → `Chapter`; predominantly `SetAudioStream`/`SetSubtitleStream` → `Setup`; menu-name hints ("Chapter", "Audio", "Subtitle") as a weak tiebreaker only.
+   3. Among `Vmgm` menus, only the disc's entry menu (the default/first global menu a player reaches via the title-menu key) → `Root` — a project can hold several VMGM pages (title-select, extras), and all remaining `Vmgm` menus infer `TitleSelect`.
    4. Everything else → `TitleSelect`.
 
-   Inference is a one-time default — the inspector lets the user reassign any
-   role afterwards.
+Inference is a one-time default — the inspector lets the user reassign any role afterwards.
 
-4. **Constraint profiles, not constants.** Button limits, palette depth,
-   raster, safe-area, and minimum font sizes become a per-format data table
-   consumed by diagnostics, the compile preview, and validation — replacing
-   hardcoded `MAX_DVD_BUTTONS = 36`, `DVD_PALETTE_COLOURS = 4`
-   (`CompileMode.tsx`) and `MENU_WIDTH = 720` (`SceneCanvas.tsx`).
-5. **The editor speaks design-space only.** Retire the legacy `buttons` mirror
-   and the 720-raster remnants; the authored document (already
-   resolution-agnostic, with a 1920×1080 BluRay arm in `MenuSize::default_for`)
-   becomes the single model.
-6. **Actions stay semantic — with the titleset-relative variants normalised
-   per backend.** Most of `PlaybackAction` (play title/chapter, show menu, set
-   streams, sequence, stop, return) ports to BD's VM as-is. The exceptions are
-   the grouping-relative variants: `PlayNextInTitleset` is documented DVD-only
-   in the model, and `PlayAllInTitleset` expands against titleset order at
-   authoring time (`models/mod.rs`). Since BD abstracts titlesets away
-   (`blu-ray-integration-plan.md` §1.6), each backend must define its mapping
-   for these — DVD keeps the current expansion; BD maps them onto its grouping
-   unit (playlist order) or normalises them into expanded `PlayTitle`/
-   `Sequence` forms at compile — and the `FormatProfile` gains a
-   supported-actions list so validation flags any variant the target cannot
-   express. Popup show/hide, button sounds, and auto-action buttons are
-   additive later.
-7. **A `MenuCompiler` backend boundary is carved during the motion slice** —
-   scene render → per-state assets → format mux — so ffmpeg/dvdauthor
-   specifics stop spreading into shared code and a BD backend becomes "add a
-   backend", not "untangle the DVD one".
-8. **Flagged, no action yet:** colour management (author in sRGB, convert
-   per-target: BT.601 for DVD, BT.709 for BD) and background transparency for
-   popup menus (the model's `Option`s already permit a "no background" menu).
+4. **Constraint profiles, not constants.** Button limits, palette depth, raster, safe-area, and minimum font sizes become a per-format data table consumed by diagnostics, the compile preview, and validation — replacing hardcoded `MAX_DVD_BUTTONS = 36`, `DVD_PALETTE_COLOURS = 4` (`CompileMode.tsx`) and `MENU_WIDTH = 720` (`SceneCanvas.tsx`).
+5. **The editor speaks design-space only.** Retire the legacy `buttons` mirror and the 720-raster remnants; the authored document (already resolution-agnostic, with a 1920×1080 BluRay arm in `MenuSize::default_for`) becomes the single model.
+6. **Actions stay semantic — with the titleset-relative variants normalised per backend.** Most of `PlaybackAction` (play title/chapter, show menu, set streams, sequence, stop, return) ports to BD's VM as-is. The exceptions are the grouping-relative variants: `PlayNextInTitleset` is documented DVD-only in the model, and `PlayAllInTitleset` expands against titleset order at authoring time (`models/mod.rs`). Since BD abstracts titlesets away (`blu-ray-integration-plan.md` §1.6), each backend must define its mapping for these — DVD keeps the current expansion; BD maps them onto its grouping unit (playlist order) or normalises them into expanded `PlayTitle`/ `Sequence` forms at compile — and the `FormatProfile` gains a supported-actions list so validation flags any variant the target cannot express. Popup show/hide, button sounds, and auto-action buttons are additive later.
+7. **A `MenuCompiler` backend boundary is carved during the motion slice** — scene render → per-state assets → format mux — so ffmpeg/dvdauthor specifics stop spreading into shared code and a BD backend becomes "add a backend", not "untangle the DVD one".
+8. **Flagged, no action yet:** colour management (author in sRGB, convert per-target: BT.601 for DVD, BT.709 for BD) and background transparency for popup menus (the model's `Option`s already permit a "no background" menu).
 
 ---
 
 ## 3. Disc-aware UI: the editor reflects the target format
 
-The project already knows its `DiscFamily`; the menu workspace should wear it.
-The user should always see **which disc they are making, in that disc's
-language, with an honest preview of what the disc will actually do.**
+The project already knows its `DiscFamily`; the menu workspace should wear it. The user should always see **which disc they are making, in that disc's language, with an honest preview of what the disc will actually do.**
 
 ### 3.1 Format context chrome
 
@@ -295,15 +201,11 @@ BD-25`. The badge is also the entry point to the compile-policy inspector.
   └──────────────────────────────────┘    └──────────────────────────────────┘
   ```
 
-- Diagnostics, planner rows, and validation messages quote the profile's
-  limits ("36-button DVD limit", "4-colour subpicture palette") rather than
-  bare numbers, so the same message renders correctly for BD ("255-button IG
-  page limit", "256-colour palette").
+- Diagnostics, planner rows, and validation messages quote the profile's limits ("36-button DVD limit", "4-colour subpicture palette") rather than bare numbers, so the same message renders correctly for BD ("255-button IG page limit", "256-colour palette").
 
 ### 3.2 Format terminology
 
-UI copy comes from a per-family terminology map (a small frontend module keyed
-by `DiscFamily`, colocated with the constraint profile):
+UI copy comes from a per-family terminology map (a small frontend module keyed by `DiscFamily`, colocated with the constraint profile):
 
 | Concept (shared model)   | DVD-Video term       | BDMV term            |
 | ------------------------ | -------------------- | -------------------- |
@@ -315,9 +217,7 @@ by `DiscFamily`, colocated with the constraint profile):
 | Menu video unit          | Motion menu VOB      | IG stream + clip     |
 | Grouping unit            | Titleset             | Playlist             |
 
-The editor never invents a neutral vocabulary that satisfies neither format —
-per `dvd_bd_architecture_note.md`, shared concepts live in the model, but the
-_words on screen_ are the target format's.
+The editor never invents a neutral vocabulary that satisfies neither format — per `dvd_bd_architecture_note.md`, shared concepts live in the model, but the _words on screen_ are the target format's.
 
 ```typescript
 // apps/spindle/src/format/terminology.ts (new)
@@ -332,44 +232,27 @@ export interface FormatTerminology {
 export function terminologyFor(family: DiscFamily): FormatTerminology { ... }
 ```
 
-Components stop writing `"DVD Preview"` inline and render
-`terminologyFor(project.disc.family).compilePreviewLabel` — mechanical, but it
-is the difference between "BD support means a new profile row" and "BD support
-means auditing every string in `components/menus/`".
+Components stop writing `"DVD Preview"` inline and render `terminologyFor(project.disc.family).compilePreviewLabel` — mechanical, but it is the difference between "BD support means a new profile row" and "BD support means auditing every string in `components/menus/`".
 
 ### 3.3 Honest target preview
 
-- **Compile preview becomes profile-driven.** `CompileMode` currently
-  hardcodes the DVD treatment; it becomes a renderer parameterised by the
-  constraint profile: DVD shows the 4-colour-quantised subpicture look, BD
-  will show full-colour state bitmaps.
-- **Preview modes are labelled with the format**: "DVD Preview" stays, and the
-  toggle group is generated from the active profile so a BD project shows
-  "BD Preview" with BD behaviours (e.g. popup overlay preview).
-- **Unsupported-on-target authoring degrades visibly, not silently.** If an
-  authored feature can't survive the target compile (e.g. a gradient that
-  quantises badly to the DVD palette, a popup role on a DVD project), the
-  canvas and diagnostics say so at authoring time — the same mechanism that
-  today warns about safe areas.
+- **Compile preview becomes profile-driven.** `CompileMode` currently hardcodes the DVD treatment; it becomes a renderer parameterised by the constraint profile: DVD shows the 4-colour-quantised subpicture look, BD will show full-colour state bitmaps.
+- **Preview modes are labelled with the format**: "DVD Preview" stays, and the toggle group is generated from the active profile so a BD project shows "BD Preview" with BD behaviours (e.g. popup overlay preview).
+- **Unsupported-on-target authoring degrades visibly, not silently.** If an authored feature can't survive the target compile (e.g. a gradient that quantises badly to the DVD palette, a popup role on a DVD project), the canvas and diagnostics say so at authoring time — the same mechanism that today warns about safe areas.
 
-This section is deliberately implementable _now_ against DVD only: the profile
-table has one row, but everything that reads it stops assuming DVD.
+This section is deliberately implementable _now_ against DVD only: the profile table has one row, but everything that reads it stops assuming DVD.
 
 ---
 
 ## 4. Implementation slices
 
-Each slice is independently shippable and lists what it must do differently
-because of Section 2.
+Each slice is independently shippable and lists what it must do differently because of Section 2.
 
 ### Slice A — Format profile & terminology layer
 
 **Goal:** the UI reflects the disc type; DVD-isms move from constants into data.
 
-- Add a `FormatProfile` (Rust, serialised to the frontend alongside the
-  project): raster, design-size defaults, max buttons per menu/page, palette
-  model (`FourColourSubpicture` | `Palette256`), min font size, safe-area
-  defaults, supported menu roles, supported background modes.
+- Add a `FormatProfile` (Rust, serialised to the frontend alongside the project): raster, design-size defaults, max buttons per menu/page, palette model (`FourColourSubpicture` | `Palette256`), min font size, safe-area defaults, supported menu roles, supported background modes.
 
   ```rust
   /// Format law as data. One row per DiscFamily; consumed by diagnostics,
@@ -402,9 +285,7 @@ because of Section 2.
   ```
 
 - Add the terminology map (frontend) keyed by `DiscFamily` (Section 3.2).
-- Drive `CompileMode`, `inspectorDiagnostics.ts`, and canvas chrome from the
-  profile; delete `MAX_DVD_BUTTONS`, `DVD_PALETTE_COLOURS`, `MENU_WIDTH`
-  constants.
+- Drive `CompileMode`, `inspectorDiagnostics.ts`, and canvas chrome from the profile; delete `MAX_DVD_BUTTONS`, `DVD_PALETTE_COLOURS`, `MENU_WIDTH` constants.
 - Format badge in the menu editor header and menu rail.
 
 **BD-readiness:** this is the seam BD plugs into (`blu-ray-integration-plan.md`
@@ -414,30 +295,10 @@ because of Section 2.
 
 **Goal:** what you author is what the disc shows; richer still imagery.
 
-- Skia renders **any button state** (normal/focus/activate), shadows and
-  glows, and `Group` nodes (position offset + z-order container). The DVD
-  compiler keeps consuming `normal` plus subpicture, but the compile preview
-  and render-preview export can now show true focus/activate appearance.
-  Rendering groups is not enough on its own: `AuthorableMenuRef::buttons()`
-  (`build/menu.rs`) only scans top-level `scene.nodes`, so a button inside a
-  group would become visible without gaining spumux rectangles or navigation.
-  Authoring/interaction extraction must **recursively flatten grouped
-  buttons** (with accumulated group offsets), as scene validation already
-  does — this is an explicit acceptance criterion.
-- New shared visual properties on positioned scene nodes: opacity, rotation,
-  corner radius (shape/image), 2-stop linear gradient fill, image fit/crop.
-  Implemented in **both** renderers in the same PR — a renderer-parity golden
-  test (existing render-preview export vs DOM snapshot) is the acceptance
-  gate, so the shadow-class divergence cannot recur.
-- Give `SceneNode::Video` width/height and render its poster frame in both
-  renderers (still menus render the poster; motion consumes it in Slice E).
-- **Retire the legacy `Menu.buttons` mirror**: migrate remaining readers
-  (planner, validation, compiler fallback) onto `authored_document`, keep the
-  one-time `migrate_to_document` lift on load, delete the write-back sync.
-  This includes moving the fields that today live **only** on the legacy
-  `Menu` onto `MenuDocument` — notably the audio bed
-  (`resolved_motion_audio_asset_id()` reads just `Menu.motion_audio_asset_id`)
-  — so retiring the mirror doesn't orphan them.
+- Skia renders **any button state** (normal/focus/activate), shadows and glows, and `Group` nodes (position offset + z-order container). The DVD compiler keeps consuming `normal` plus subpicture, but the compile preview and render-preview export can now show true focus/activate appearance. Rendering groups is not enough on its own: `AuthorableMenuRef::buttons()` (`build/menu.rs`) only scans top-level `scene.nodes`, so a button inside a group would become visible without gaining spumux rectangles or navigation. Authoring/interaction extraction must **recursively flatten grouped buttons** (with accumulated group offsets), as scene validation already does — this is an explicit acceptance criterion.
+- New shared visual properties on positioned scene nodes: opacity, rotation, corner radius (shape/image), 2-stop linear gradient fill, image fit/crop. Implemented in **both** renderers in the same PR — a renderer-parity golden test (existing render-preview export vs DOM snapshot) is the acceptance gate, so the shadow-class divergence cannot recur.
+- Give `SceneNode::Video` width/height and render its poster frame in both renderers (still menus render the poster; motion consumes it in Slice E).
+- **Retire the legacy `Menu.buttons` mirror**: migrate remaining readers (planner, validation, compiler fallback) onto `authored_document`, keep the one-time `migrate_to_document` lift on load, delete the write-back sync. This includes moving the fields that today live **only** on the legacy `Menu` onto `MenuDocument` — notably the audio bed (`resolved_motion_audio_asset_id()` reads just `Menu.motion_audio_asset_id`) — so retiring the mirror doesn't orphan them.
 
 Intersecting issues: #28, #29, #53, #55, #63, #64.
 
@@ -446,13 +307,8 @@ Intersecting issues: #28, #29, #53, #55, #63, #64.
 **Goal:** motion backgrounds and audio beds actually build; the plan-time
 block is removed.
 
-- Implement the pipeline in `motion-menus.md` (loop-segment extraction from
-  `loopStartSecs`, scene PNG composited over looping video, AC-3 audio bed,
-  intro cell + loop cell with `<post>` jump, loop-count/timeout via g-register
-  post-commands).
-- Carve the **`MenuCompiler` boundary** while writing it: trait with
-  `render_states → compose_background → mux` stages; the DVD implementation is
-  the only one, but ffmpeg/dvdauthor types stop appearing in shared build code.
+- Implement the pipeline in `motion-menus.md` (loop-segment extraction from `loopStartSecs`, scene PNG composited over looping video, AC-3 audio bed, intro cell + loop cell with `<post>` jump, loop-count/timeout via g-register post-commands).
+- Carve the **`MenuCompiler` boundary** while writing it: trait with `render_states → compose_background → mux` stages; the DVD implementation is the only one, but ffmpeg/dvdauthor types stop appearing in shared build code.
 
   ```rust
   /// Format backend seam for menu compilation. Stage 1 is shared (Skia);
@@ -503,19 +359,14 @@ block is removed.
       BDC --> M2TS["BDMV"]
   ```
 
-- Planner: replace the "switch these menus back to still mode" error with real
-  motion jobs (capacity model already estimates motion sizes).
-- Editor: motion settings stay in the inspector but gain a working
-  scrub-preview of the background video (`<video>` + `convertFileSrc`) so loop
-  points can be set against real frames.
+- Planner: replace the "switch these menus back to still mode" error with real motion jobs (capacity model already estimates motion sizes).
+- Editor: motion settings stay in the inspector but gain a working scrub-preview of the background video (`<video>` + `convertFileSrc`) so loop points can be set against real frames.
 
 ### Slice D — Timeline & animated highlights
 
 **Goal:** a real timeline in the editor; keyframed animation that compiles.
 
-- **Timeline strip** under the canvas (visible when the menu is motion, or
-  when any animation track exists): intro region, loop region, scrubber,
-  per-node keyframe lanes.
+- **Timeline strip** under the canvas (visible when the menu is motion, or when any animation track exists): intro region, loop region, scrubber, per-node keyframe lanes.
 
   ```text
   ┌─ Canvas ────────────────────────────────────────────────────────────────┐
@@ -532,15 +383,7 @@ block is removed.
      ◆ = keyframe (drag to retime; double-click to edit value/easing)
   ```
 
-- **Property-track animation model** (design decision 2): keyframes + fixed
-  easing set, evaluated in Rust; editor preview evaluates the same tracks
-  (parity-tested). First lowered targets: highlight colour/opacity → spumux
-  multi-`<spu>` sequences per `motion-menus.md`. spumux's `image`/`select`/
-  `highlight` attributes take overlay **bitmap paths**, not colours — each
-  keyframe's colour/opacity is baked into per-keyframe rendered overlay PNGs
-  (as the existing still-menu builder already does for its single overlay). A
-  pulsing highlight (`0s → #ffaa40@0.6`, `1s → #ffaa40@0.2`,
-  `2s → #ffaa40@0.6`, Hold easing, sampled at keyframes) lowers to:
+- **Property-track animation model** (design decision 2): keyframes + fixed easing set, evaluated in Rust; editor preview evaluates the same tracks (parity-tested). First lowered targets: highlight colour/opacity → spumux multi-`<spu>` sequences per `motion-menus.md`. spumux's `image`/`select`/ `highlight` attributes take overlay **bitmap paths**, not colours — each keyframe's colour/opacity is baked into per-keyframe rendered overlay PNGs (as the existing still-menu builder already does for its single overlay). A pulsing highlight (`0s → #ffaa40@0.6`, `1s → #ffaa40@0.2`, `2s → #ffaa40@0.6`, Hold easing, sampled at keyframes) lowers to:
 
   ```xml
   <!-- hl_k*_sel.png / hl_k*_hl.png are rendered per keyframe with the
@@ -567,39 +410,27 @@ block is removed.
   </spu>
   ```
 
-  If per-keyframe overlay swaps prove too coarse or bloaty in practice, the
-  fallback is a lower-level DCSQ writer emitting palette/contrast updates
-  directly (bypassing spumux for menus with animated tracks) — the DCSQ
-  player-compatibility research issue covers evaluating both routes.
+If per-keyframe overlay swaps prove too coarse or bloaty in practice, the fallback is a lower-level DCSQ writer emitting palette/contrast updates directly (bypassing spumux for menus with animated tracks) — the DCSQ player-compatibility research issue covers evaluating both routes.
 
-- Keyframe editor UI replaces the dead Static/Animated dropdown; Preview mode
-  animates highlights over the loop.
+- Keyframe editor UI replaces the dead Static/Animated dropdown; Preview mode animates highlights over the loop.
 - Migration: existing `HighlightKeyframe` arrays lift into tracks on load.
 
-**BD-readiness:** tracks must be offline-sampleable at any timestamp — that is
-exactly what IGS frame-sequence generation needs (`lib-igs-author-plan.md`
-Phase B).
+**BD-readiness:** tracks must be offline-sampleable at any timestamp — that is exactly what IGS frame-sequence generation needs (`lib-igs-author-plan.md` Phase B).
 
 ### Slice E — Motion thumbnails / video buttons
 
 **Goal:** the classic "moving chapter tile" idiom.
 
-- Button `videoAssetId` and `SceneNode::Video` get compiled: ffmpeg `overlay`
-  chains composite per-button video into the motion background at button
-  bounds (approach 2 in `motion-menus.md`), beneath a standard highlight.
-- Editor: video asset picker on buttons/video nodes, poster-frame display,
-  scrub-on-hover; timeline scrubbing shows composited motion.
-- Generators: chapter grids can opt into motion tiles sourced from the
-  existing thumbnail/preview cache timestamps.
+- Button `videoAssetId` and `SceneNode::Video` get compiled: ffmpeg `overlay` chains composite per-button video into the motion background at button bounds (approach 2 in `motion-menus.md`), beneath a standard highlight.
+- Editor: video asset picker on buttons/video nodes, poster-frame display, scrub-on-hover; timeline scrubbing shows composited motion.
+- Generators: chapter grids can opt into motion tiles sourced from the existing thumbnail/preview cache timestamps.
 
 ### Slice F — Themes & components
 
 **Goal:** `theme_ref` and the Templates rail stop being stubs; generated menus
 restyle without regeneration.
 
-- Theme document: typography set, button `ButtonStyleMap`, highlight palette,
-  spacing tokens, background treatment. `theme_ref` resolves against project
-  themes; unset properties inherit from the theme.
+- Theme document: typography set, button `ButtonStyleMap`, highlight palette, spacing tokens, background treatment. `theme_ref` resolves against project themes; unset properties inherit from the theme.
 
   ```jsonc
   // A theme is data the existing style structs already understand —
@@ -620,64 +451,28 @@ restyle without regeneration.
   }
   ```
 
-  Resolution order per property: explicit node override → component default →
-  theme token → model default. Only the explicit override is stored in the
-  scene, which is what makes re-theming and regeneration non-destructive.
+Resolution order per property: explicit node override → component default → theme token → model default. Only the explicit override is stored in the scene, which is what makes re-theming and regeneration non-destructive.
 
-- Templates rail lists starter themes; applying one is undoable and
-  non-destructive (explicit overrides survive).
-- Generators become theme-aware (SPEC §14.8) and emit `generation_meta` so
-  regeneration preserves overrides.
-- `ComponentInstance` implemented for the SPEC's `HeroTitleButton` and
-  `ChapterThumbnailTile` as the first components.
+- Templates rail lists starter themes; applying one is undoable and non-destructive (explicit overrides survive).
+- Generators become theme-aware (SPEC §14.8) and emit `generation_meta` so regeneration preserves overrides.
+- `ComponentInstance` implemented for the SPEC's `HeroTitleButton` and `ChapterThumbnailTile` as the first components.
 
 ### Menu role model (lands with whichever of A/C ships first)
 
-- Add `role` to `MenuDocument` (root, title-select, chapter, setup, extras,
-  popup); infer roles for existing menus from domain + generator metadata.
-- DVD backend maps role → `MenuDomain`; generators and the menu map group by
-  role; the terminology map renders role names per format.
-- `popup` is authorable only when the profile supports it (no profile does
-  until BD lands) — but the model, map view, and generators understand it now.
+- Add `role` to `MenuDocument` (root, title-select, chapter, setup, extras, popup); infer roles for existing menus from domain + generator metadata.
+- DVD backend maps role → `MenuDomain`; generators and the menu map group by role; the terminology map renders role names per format.
+- `popup` is authorable only when the profile supports it (no profile does until BD lands) — but the model, map view, and generators understand it now.
 
 ---
 
 ## 5. Companion library review — `igs-author` (libhdmv)
 
-`lib-igs-author-plan.md` proposes the BD equivalent of the spumux pipeline:
-compile authored menus into IGS elementary streams, as
-`libhdmv/crates/igs-author`. It is the right next companion crate — it is the
-consumer of everything Slices B and D produce — but reviewing it against the
-**actual state of libhdmv** (checked July 2026) and against this plan's
-decisions surfaces four corrections:
+`lib-igs-author-plan.md` proposes the BD equivalent of the spumux pipeline: compile authored menus into IGS elementary streams, as `libhdmv/crates/igs-author`. It is the right next companion crate — it is the consumer of everything Slices B and D produce — but reviewing it against the **actual state of libhdmv** (checked July 2026) and against this plan's decisions surfaces four corrections:
 
-1. **The `igs` crate is decode-only today.** The plan states libhdmv "can
-   encode individual segments (palette, object)" and Phase A builds on
-   `igs::write_object_segment` / `igs::write_palette_segment` — neither exists
-   anywhere in the repo. `pgs::rle::encode_rle` ✅ and the `hdmv-insn` encoder
-   (`encode`, `jump_object`, `play_playlist`, `set_button_page`, …) ✅ are
-   real, but IGS **segment writers are new work** and belong at the front of
-   Phase A (or a Phase A0), which moves its estimate accordingly.
-2. **Phase D integrates from the wrong model.** The converter is specified as
-   `Menu` + `MenuButton` → `AuthorPage` — the legacy flat model this plan
-   retires in Slice B. Phase D should consume `MenuDocument` (scene +
-   interaction + role) and **pre-rendered per-state RGBA bitmaps** from the
-   Spindle Skia renderer. This also resolves the plan's research question 5 in
-   the direction it already recommends: igs-author takes RGBA, never renders
-   text. The `MenuCompiler` seam from Slice C is exactly this boundary —
-   `render_states` (Spindle) → `compile_igs` (igs-author) → mux (tsMuxeR).
-3. **`ButtonImage` should be a frame sequence, not a single bitmap.** IGS
-   button states can be animated (the plan's `animation_frame_rate` on
-   `AuthorPage` hints at this, but `AuthorButton` only carries one image per
-   state). Slice D's property tracks are designed to be sampled into exactly
-   these frame sequences — the API should take `Vec<ButtonImage>` per state
-   (length 1 = static) so the composition model reserves animation from day
-   one rather than retrofitting it.
-4. **Palette quantisation is per display set, not per image.** All objects in
-   a page share one 256-entry palette; `AuthorPalette::Auto` must quantise
-   jointly across every state of every button on the page (plus per-page
-   palettes for multi-page menus). Worth stating in the plan because per-image
-   quantisation is the natural-but-wrong first implementation.
+1. **The `igs` crate is decode-only today.** The plan states libhdmv "can encode individual segments (palette, object)" and Phase A builds on `igs::write_object_segment` / `igs::write_palette_segment` — neither exists anywhere in the repo. `pgs::rle::encode_rle` ✅ and the `hdmv-insn` encoder (`encode`, `jump_object`, `play_playlist`, `set_button_page`, …) ✅ are real, but IGS **segment writers are new work** and belong at the front of Phase A (or a Phase A0), which moves its estimate accordingly.
+2. **Phase D integrates from the wrong model.** The converter is specified as `Menu` + `MenuButton` → `AuthorPage` — the legacy flat model this plan retires in Slice B. Phase D should consume `MenuDocument` (scene + interaction + role) and **pre-rendered per-state RGBA bitmaps** from the Spindle Skia renderer. This also resolves the plan's research question 5 in the direction it already recommends: igs-author takes RGBA, never renders text. The `MenuCompiler` seam from Slice C is exactly this boundary — `render_states` (Spindle) → `compile_igs` (igs-author) → mux (tsMuxeR).
+3. **`ButtonImage` should be a frame sequence, not a single bitmap.** IGS button states can be animated (the plan's `animation_frame_rate` on `AuthorPage` hints at this, but `AuthorButton` only carries one image per state). Slice D's property tracks are designed to be sampled into exactly these frame sequences — the API should take `Vec<ButtonImage>` per state (length 1 = static) so the composition model reserves animation from day one rather than retrofitting it.
+4. **Palette quantisation is per display set, not per image.** All objects in a page share one 256-entry palette; `AuthorPalette::Auto` must quantise jointly across every state of every button on the page (plus per-page palettes for multi-page menus). Worth stating in the plan because per-image quantisation is the natural-but-wrong first implementation.
 
 Corrections 2 and 3 as an API revision:
 
@@ -704,12 +499,7 @@ pub fn author_pages_from_document(
 ) -> Vec<AuthorPage>;
 ```
 
-Sequencing: igs-author Phases A–C are pure libhdmv work and can proceed in
-parallel with Slices A–D here. Phase D depends on Slice B (per-state Skia
-rendering), the menu `role` model, and the mirror retirement — which is
-another reason Slice B lands early. Button sound effects (`sound.bdmv`,
-`blu-ray-integration-plan.md` §5.4) remain out of scope for igs-author v1;
-they attach at the composition/mux layer later.
+Sequencing: igs-author Phases A–C are pure libhdmv work and can proceed in parallel with Slices A–D here. Phase D depends on Slice B (per-state Skia rendering), the menu `role` model, and the mirror retirement — which is another reason Slice B lands early. Button sound effects (`sound.bdmv`, `blu-ray-integration-plan.md` §5.4) remain out of scope for igs-author v1; they attach at the composition/mux layer later.
 
 ---
 
@@ -728,39 +518,22 @@ flowchart LR
     IGSA["igs-author Phases A–C\n(libhdmv, parallel)"] -.-> IGSD
 ```
 
-- A before B: the parity tests and preview treatments B adds should read the
-  profile, not new constants.
-- B before C: motion output reuses the Skia compositing path — parity bugs
-  would otherwise get baked into encoded video.
+- A before B: the parity tests and preview treatments B adds should read the profile, not new constants.
+- B before C: motion output reuses the Skia compositing path — parity bugs would otherwise get baked into encoded video.
 - C before D: the timeline needs real loop semantics to scrub against.
 - F is independent after B (components must render to be themable).
 
-Risks worth naming: DCSQ animated-highlight support varies across ancient
-players (mitigate: validation warning + static fallback per keyframe track);
-renderer parity is a maintenance tax (mitigate: golden tests in CI, one
-shared evaluator for animation); the legacy-mirror retirement touches
-planner/validation/build and needs its own careful PR.
+Risks worth naming: DCSQ animated-highlight support varies across ancient players (mitigate: validation warning + static fallback per keyframe track); renderer parity is a maintenance tax (mitigate: golden tests in CI, one shared evaluator for animation); the legacy-mirror retirement touches planner/validation/build and needs its own careful PR.
 
 ---
 
 ## 7. Candidate issue breakdown (for later filing)
 
-- Slice A: format profile plumbing · terminology map + format badge ·
-  profile-driven CompileMode/diagnostics
-- Slice B: render-any-state Skia + shadows/glows · shared visual properties
-  (both renderers + golden tests) · Group rendering · Video poster frames ·
-  legacy `buttons` mirror retirement
-- Slice C: motion transcode/mux jobs + looping PGC · MenuCompiler trait
-  extraction · loop-point scrub preview
-- Slice D: property-track model + Rust evaluator · timeline strip UI ·
-  keyframe editor + animated preview · DCSQ spumux lowering
-- Slice E: button/video-node compositing · editor video pickers + hover scrub
-  · motion chapter-grid tiles
-- Slice F: theme document + resolution · Templates rail · theme-aware
-  generators · HeroTitleButton/ChapterThumbnailTile
-- Cross-cutting: menu `role` model · colour-management spike ·
-  DCSQ player-compatibility research
-- libhdmv (filed in that repo): IGS segment writers (palette/object/
-  composition) · igs-author Phase A–C · revise `lib-igs-author-plan.md` per
-  Section 5 (frame-sequence `ButtonImage`, `MenuDocument` integration, joint
-  palette quantisation)
+- Slice A: format profile plumbing · terminology map + format badge · profile-driven CompileMode/diagnostics
+- Slice B: render-any-state Skia + shadows/glows · shared visual properties (both renderers + golden tests) · Group rendering · Video poster frames · legacy `buttons` mirror retirement
+- Slice C: motion transcode/mux jobs + looping PGC · MenuCompiler trait extraction · loop-point scrub preview
+- Slice D: property-track model + Rust evaluator · timeline strip UI · keyframe editor + animated preview · DCSQ spumux lowering
+- Slice E: button/video-node compositing · editor video pickers + hover scrub · motion chapter-grid tiles
+- Slice F: theme document + resolution · Templates rail · theme-aware generators · HeroTitleButton/ChapterThumbnailTile
+- Cross-cutting: menu `role` model · colour-management spike · DCSQ player-compatibility research
+- libhdmv (filed in that repo): IGS segment writers (palette/object/ composition) · igs-author Phase A–C · revise `lib-igs-author-plan.md` per Section 5 (frame-sequence `ButtonImage`, `MenuDocument` integration, joint palette quantisation)

--- a/plugins/tauri-plugin-display-awareness/README.md
+++ b/plugins/tauri-plugin-display-awareness/README.md
@@ -4,27 +4,16 @@ Cross-platform monitor geometry for density-aware, responsive UIs.
 
 ## Purpose
 
-Exposes per-monitor logical geometry (physical pixels divided by the OS
-scale factor), scale factor, position, and best-effort physical size in
-millimetres, plus an event fired when the active window's scale factor
-changes (e.g. dragged to a different monitor).
+Exposes per-monitor logical geometry (physical pixels divided by the OS scale factor), scale factor, position, and best-effort physical size in millimetres, plus an event fired when the active window's scale factor changes (e.g. dragged to a different monitor).
 
-This plugin is Spindle-agnostic — it has no dependency on
-`tauri-plugin-spindle-project` or any Spindle-specific types, and could be
-reused by any Tauri app that needs density-aware layout.
+This plugin is Spindle-agnostic — it has no dependency on `tauri-plugin-spindle-project` or any Spindle-specific types, and could be reused by any Tauri app that needs density-aware layout.
 
-Logical geometry is the primary signal: the OS scale factor already encodes
-the user's chosen UI density, so a responsive layout should key its
-breakpoints off logical width, not physical pixels. Physical millimetre size
-is reported best-effort via [`display-info`](https://crates.io/crates/display-info)
-(`null` when the OS/EDID does not report it) and is not used to override the
-OS scale.
+Logical geometry is the primary signal: the OS scale factor already encodes the user's chosen UI density, so a responsive layout should key its breakpoints off logical width, not physical pixels. Physical millimetre size is reported best-effort via [`display-info`](https://crates.io/crates/display-info) (`null` when the OS/EDID does not report it) and is not used to override the OS scale.
 
 ## Commands
 
 - `get_displays` — enumerate all connected displays.
-- `get_active_display` — the display the current window resides on (falls
-  back to the primary display, then the first enumerated one).
+- `get_active_display` — the display the current window resides on (falls back to the primary display, then the first enumerated one).
 
 ## Events
 
@@ -42,6 +31,4 @@ import {
 
 ## Platform support
 
-Linux (xcb/xrandr), Windows, and macOS via `display-info`. Physical
-millimetre size may be unavailable on some Wayland sessions, VMs, and
-panels with no EDID — treat `widthMm`/`heightMm` as optional.
+Linux (xcb/xrandr), Windows, and macOS via `display-info`. Physical millimetre size may be unavailable on some Wayland sessions, VMs, and panels with no EDID — treat `widthMm`/`heightMm` as optional.

--- a/plugins/tauri-plugin-spindle-project/README.md
+++ b/plugins/tauri-plugin-spindle-project/README.md
@@ -184,9 +184,7 @@ That smoke test requires `ffmpeg`, `spumux`, and `dvdauthor` to be available on 
 
 ## JavaScript bindings
 
-The plugin ships typed bindings in `tauri-plugin-spindle-project-api`, following the
-same `guest-js` convention as `tauri-plugin-display-awareness`. App code should
-import from the package rather than calling `invoke` with raw command strings:
+The plugin ships typed bindings in `tauri-plugin-spindle-project-api`, following the same `guest-js` convention as `tauri-plugin-display-awareness`. App code should import from the package rather than calling `invoke` with raw command strings:
 
 ```ts
 import { createProject, parseProject, serialiseProject } from 'tauri-plugin-spindle-project-api';

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,7 +1,6 @@
 # Spindle tools
 
-Standalone CLI utilities for development and debugging. Each tool lives in its
-own crate under `tools/` and is part of the workspace.
+Standalone CLI utilities for development and debugging. Each tool lives in its own crate under `tools/` and is part of the workspace.
 
 ## Building
 
@@ -23,9 +22,7 @@ Binaries land in `target/debug/`.
 
 **Crate:** [`tools/menu-debug`](menu-debug/)
 
-Loads a `.spindle` project file and runs the full Skia rendering pipeline for
-every menu, writing intermediate images to an output directory and printing font
-and node diagnostics to stdout.
+Loads a `.spindle` project file and runs the full Skia rendering pipeline for every menu, writing intermediate images to an output directory and printing font and node diagnostics to stdout.
 
 ### What it produces
 
@@ -49,8 +46,7 @@ Stdout shows:
 ./target/debug/menu-debug <project.spindle> [output-dir]
 ```
 
-If `output-dir` is omitted, a `<project-stem>_menu_debug/` directory is created
-next to the project file.
+If `output-dir` is omitted, a `<project-stem>_menu_debug/` directory is created next to the project file.
 
 ```sh
 # Example — render Test Project to a debug directory
@@ -67,20 +63,12 @@ MENU_DEBUG_SHOW_SYSTEM_FONTS=1 ./target/debug/menu-debug project.spindle
 
 ### Diagnosing font issues
 
-The tool prints per-node font info. When a button or text node shows
-`font: default (no label_style)` or `font: default 24px`, the corresponding
-scene node has a null style in the project file — the Skia renderer falls back
-to `TextStyle::default()` (Inter 14px).
+The tool prints per-node font info. When a button or text node shows `font: default (no label_style)` or `font: default 24px`, the corresponding scene node has a null style in the project file — the Skia renderer falls back to `TextStyle::default()` (Inter 14px).
 
 To fix:
 
 1. Select the node in the Spindle menu editor.
-2. Change the font family in the inspector — this writes `labelStyle` (for
-   buttons) or `fontFamily` (for text nodes) into the scene node.
-3. Save the project. The style is now persisted and the build pipeline will
-   use it.
+2. Change the font family in the inspector — this writes `labelStyle` (for buttons) or `fontFamily` (for text nodes) into the scene node.
+3. Save the project. The style is now persisted and the build pipeline will use it.
 
-For project-asset fonts (fonts you add to the project's asset list), the tool
-reports them as `[project-asset]` in the font resolution section. System fonts
-available in the build environment are listed when
-`MENU_DEBUG_SHOW_SYSTEM_FONTS=1` is set.
+For project-asset fonts (fonts you add to the project's asset list), the tool reports them as `[project-asset]` in the font resolution section. System fonts available in the build environment are listed when `MENU_DEBUG_SHOW_SYSTEM_FONTS=1` is set.


### PR DESCRIPTION
## Summary

### Documentation

- **New rule**: markdown prose is never hard-wrapped — one line per paragraph or list item, letting viewers soft-wrap. Codified in `AGENTS.md` (`## Documentation`) and `CLAUDE.md` (`## Conventions`).
- **Existing docs unwrapped**: 308 line-joins across 15 files (largest: `docs/rich-menu-editor-plan.md` with 232). The other 43 tracked markdown files were already single-line prose; the two autogenerated `permissions/autogenerated/reference.md` files were left untouched.
- One pre-existing stray artifact removed: a lone `.` continuation line in `SPEC.md`.

## Test plan

- [x] Scripted structural verification per changed file: heading, code-fence, table-row, and list-item counts identical before/after
- [x] Whitespace-normalized full-file comparison: byte-identical content modulo line joins (nothing lost, duplicated, or altered — including inside code fences)
- [x] Explicit hard breaks (trailing double-space) preserved where intended
- [x] `prettier --check` clean in the dev container (`proseWrap: preserve`)
