### PR TITLE
Fix titleset audio-consistency validation and DTS re-encode fallback gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Current DVD authoring capabilities include:
 - menu editing with authored scene documents, layers, still-image composition nodes, and motion menus with intro/loop timing, audio beds, and timeout actions
 - animated button highlights authored as keyframe tracks on a timeline strip and compiled into the disc's subpicture stream
 - semantic interaction graphs and remote-navigation preview simulation
-- asset inspection with embedded metadata title surfacing, compatibility explanations (including per-codec DVD-Video audio bitrate ceilings, not just codec-name matching), fix-oriented validation, and still-image imports for menu authoring
+- asset inspection with embedded metadata title surfacing, compatibility explanations (including per-codec DVD-Video audio bitrate ceilings, not just codec-name matching), fix-oriented validation — including flagging titles that share a titleset but declare inconsistent audio codec or language at the same slot, since dvdauthor authors that declaration once per titleset, not per title — and still-image imports for menu authoring
 - DVD build planning and execution with diagnostics export and toolchain checks
 - bitmap subtitle muxing plus first-pass text subtitle rendering for DVD authoring
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -543,8 +543,10 @@ The native toolchain adapter should detect which encoders and pass-through paths
 This matters especially for:
 
 - MP2 output availability
-- DTS output availability — confirmed unavailable as a re-encode target regardless of environment: ffmpeg's only DTS encoder path produces a stream that decodes fine in isolation but corrupts once muxed through the DVD program-stream muxer, so re-encoding to DTS is refused outright at validation and build time. DTS remains available as a stream copy of an already-DTS source.
+- DTS output availability — confirmed unavailable as a re-encode target regardless of environment: ffmpeg's only DTS encoder path produces a stream that decodes fine in isolation but corrupts once muxed through the DVD program-stream muxer, so re-encoding to DTS is refused outright at validation and build time. DTS remains available as a stream copy of an already-DTS source. The editor enforces this proactively: any control that would flip a DTS copy-mode track to re-encode (changing copy mode, channel layout, or bitrate) falls the output target back to AC-3 automatically, rather than letting the UI produce a re-encode+DTS combination that only fails later at validation or build time.
 - copy and passthrough eligibility for existing compliant streams — a source stream is only copy-eligible when both its codec name _and_ its bitrate are DVD-legal (e.g. AC-3 above 448 kbps is a valid AC-3 bitstream but exceeds the DVD-Video ceiling and still requires a re-encode despite the codec name matching)
+
+DVD-Video's per-titleset audio attribute table is shared across every title in that titleset, not authored per-title — dvdauthor's `<audio>` declaration for a given slot index applies uniformly to all of a titleset's titles. If two titles in the same titleset declare a different codec or language at the same audio slot, only one of them can be correctly authored; validation flags the mismatch as a blocking error rather than silently authoring one title's declaration over another's actual stream. A title with no audio tracks at all still occupies slot 0 with a synthesised silent AC-3 stream (see §21.2), which is itself subject to this same consistency check.
 
 ### 12.2.5 Planner integration
 
@@ -1104,6 +1106,7 @@ The app should not hide the build pipeline, but it also should not dump raw tool
 - "Subtitle track 2 is text-based and must be converted before DVD authoring."
 - "Cannot re-encode audio track \"English\" to DTS — ffmpeg has no reliable DTS encoder (its native encoder produces DVD-incompatible output). DTS is only supported as a stream copy of an already-DTS source; re-encode to AC3 instead."
 - "Menu button 'Scenes' points to a missing chapter menu."
+- "Titles \"Feature\" and \"Alternate Cut\" share a titleset but declare different audio at slot 0, which dvdauthor can only author for one of them."
 
 ---
 

--- a/apps/spindle/src/pages/TitlesPage.tsx
+++ b/apps/spindle/src/pages/TitlesPage.tsx
@@ -893,6 +893,7 @@ function TitleEditor({
 									title="Selecting a channel layout switches this track to Re-encode, since a stream copy can't change channels."
 									onChange={(e) => {
 										const channelLayout = e.target.value === '' ? null : Number(e.target.value);
+										const copyMode = channelLayout !== null ? 're-encode' : am.copyMode;
 										onUpdate({
 											...title,
 											audioMappings: title.audioMappings.map((a) =>
@@ -902,7 +903,14 @@ function TitleEditor({
 															channelLayout,
 															// A stream copy can't change channels — picking a
 															// real layout implies re-encoding.
-															copyMode: channelLayout !== null ? 're-encode' : a.copyMode,
+															copyMode,
+															// DTS re-encode isn't offered — falling into
+															// re-encode from a DTS copy must not silently
+															// keep an option the UI no longer lets you pick.
+															outputTarget:
+																copyMode === 're-encode' && a.outputTarget === 'DTS'
+																	? 'AC3'
+																	: a.outputTarget,
 														}
 													: a,
 											),
@@ -926,6 +934,7 @@ function TitleEditor({
 									}
 									onChange={(e) => {
 										const bitrateBps = e.target.value === '' ? null : Number(e.target.value);
+										const copyMode = bitrateBps !== null ? 're-encode' : am.copyMode;
 										onUpdate({
 											...title,
 											audioMappings: title.audioMappings.map((a) =>
@@ -935,7 +944,14 @@ function TitleEditor({
 															bitrateBps,
 															// A stream copy can't change bitrate — picking a
 															// real value implies re-encoding.
-															copyMode: bitrateBps !== null ? 're-encode' : a.copyMode,
+															copyMode,
+															// DTS re-encode isn't offered — falling into
+															// re-encode from a DTS copy must not silently
+															// keep an option the UI no longer lets you pick.
+															outputTarget:
+																copyMode === 're-encode' && a.outputTarget === 'DTS'
+																	? 'AC3'
+																	: a.outputTarget,
 														}
 													: a,
 											),

--- a/apps/spindle/src/pages/TitlesPage.tsx
+++ b/apps/spindle/src/pages/TitlesPage.tsx
@@ -933,8 +933,25 @@ function TitleEditor({
 											: "Selecting a bitrate switches this track to Re-encode, since a stream copy can't change bitrate."
 									}
 									onChange={(e) => {
-										const bitrateBps = e.target.value === '' ? null : Number(e.target.value);
+										let bitrateBps = e.target.value === '' ? null : Number(e.target.value);
 										const copyMode = bitrateBps !== null ? 're-encode' : am.copyMode;
+										// DTS re-encode isn't offered — falling into re-encode from
+										// a DTS copy must not silently keep an option the UI no
+										// longer lets you pick.
+										const outputTarget =
+											copyMode === 're-encode' && am.outputTarget === 'DTS'
+												? 'AC3'
+												: am.outputTarget;
+										// The just-picked bitrate may only be valid for the codec
+										// being left behind (e.g. DTS's 768/1536 kbps options are
+										// out of range for AC3) — drop it if it doesn't survive the
+										// fallback rather than smuggling an illegal value through.
+										if (
+											outputTarget !== am.outputTarget &&
+											!AUDIO_BITRATE_OPTIONS[outputTarget]?.some((o) => o.bps === bitrateBps)
+										) {
+											bitrateBps = null;
+										}
 										onUpdate({
 											...title,
 											audioMappings: title.audioMappings.map((a) =>
@@ -945,13 +962,7 @@ function TitleEditor({
 															// A stream copy can't change bitrate — picking a
 															// real value implies re-encoding.
 															copyMode,
-															// DTS re-encode isn't offered — falling into
-															// re-encode from a DTS copy must not silently
-															// keep an option the UI no longer lets you pick.
-															outputTarget:
-																copyMode === 're-encode' && a.outputTarget === 'DTS'
-																	? 'AC3'
-																	: a.outputTarget,
+															outputTarget,
 														}
 													: a,
 											),

--- a/apps/spindle/src/pages/titles.test.tsx
+++ b/apps/spindle/src/pages/titles.test.tsx
@@ -237,5 +237,49 @@ describe('TitlesPage', () => {
 			expect(mapping?.outputTarget).toBe('LPCM');
 			expect(mapping?.bitrateBps).toBeNull();
 		});
+
+		describe('DTS copy falling into re-encode', () => {
+			function buildProjectWithDtsCopyMapping() {
+				const project = buildProjectWithAudioMapping();
+				project.disc.titlesets[0].titles[0].audioMappings[0].outputTarget = 'DTS';
+				project.disc.titlesets[0].titles[0].audioMappings[0].copyMode = 'copy';
+				return project;
+			}
+
+			function selectFeatureTitleAndGetChannelLayoutSelect() {
+				fireEvent.click(screen.getByText('Feature'));
+				const label = screen.getByDisplayValue('English');
+				const row = label.closest('.titles__track-row') as HTMLElement;
+				return within(row).getByTitle(
+					/Selecting a channel layout switches this track to Re-encode/,
+				) as HTMLSelectElement;
+			}
+
+			it('falls back to AC3 when picking a bitrate flips a DTS copy to re-encode', () => {
+				useProjectStore.setState({ project: buildProjectWithDtsCopyMapping() });
+				render(<TitlesPage />);
+
+				const select = selectFeatureTitleAndGetBitrateSelect();
+				fireEvent.change(select, { target: { value: '768000' } });
+
+				const mapping =
+					useProjectStore.getState().project?.disc.titlesets[0].titles[0].audioMappings[0];
+				expect(mapping?.copyMode).toBe('re-encode');
+				expect(mapping?.outputTarget).toBe('AC3');
+			});
+
+			it('falls back to AC3 when picking a channel layout flips a DTS copy to re-encode', () => {
+				useProjectStore.setState({ project: buildProjectWithDtsCopyMapping() });
+				render(<TitlesPage />);
+
+				const select = selectFeatureTitleAndGetChannelLayoutSelect();
+				fireEvent.change(select, { target: { value: '2' } });
+
+				const mapping =
+					useProjectStore.getState().project?.disc.titlesets[0].titles[0].audioMappings[0];
+				expect(mapping?.copyMode).toBe('re-encode');
+				expect(mapping?.outputTarget).toBe('AC3');
+			});
+		});
 	});
 });

--- a/apps/spindle/src/pages/titles.test.tsx
+++ b/apps/spindle/src/pages/titles.test.tsx
@@ -266,6 +266,9 @@ describe('TitlesPage', () => {
 					useProjectStore.getState().project?.disc.titlesets[0].titles[0].audioMappings[0];
 				expect(mapping?.copyMode).toBe('re-encode');
 				expect(mapping?.outputTarget).toBe('AC3');
+				// The picked value (768 kbps) is a DTS-only option, out of range
+				// for AC3 — it must not survive the fallback as an illegal bitrate.
+				expect(mapping?.bitrateBps).toBeNull();
 			});
 
 			it('falls back to AC3 when picking a channel layout flips a DTS copy to re-encode', () => {

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/language.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/language.rs
@@ -6,7 +6,7 @@
 
 use isolang::Language;
 
-pub(super) fn dvdauthor_language_code(language: &str) -> Option<String> {
+pub(crate) fn dvdauthor_language_code(language: &str) -> Option<String> {
     let normalised = language
         .trim()
         .split(['-', '_'])

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/mod.rs
@@ -11,11 +11,11 @@ use crate::models::*;
 use super::menu::MenuDomain;
 use super::util::xml_escape;
 
-mod language;
+pub(crate) mod language;
 mod menu;
 #[cfg(test)]
 mod tests;
-mod title;
+pub(crate) mod title;
 
 use menu::{append_menu_section, menu_section_aspect};
 use title::append_titles_section;

--- a/plugins/tauri-plugin-spindle-project/src/build/authoring/title.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/authoring/title.rs
@@ -176,7 +176,7 @@ fn dvdauthor_audio_format(target: AudioOutputTarget) -> &'static str {
 /// copied mappings instead, falling back to `output_target` only if the
 /// source asset/stream can't be resolved (so declaration never regresses to
 /// no declaration at all).
-fn declared_audio_format(
+pub(crate) fn declared_audio_format(
     am: &AudioTrackMapping,
     title: &Title,
     assets: &HashMap<&str, &Asset>,

--- a/plugins/tauri-plugin-spindle-project/src/build/mod.rs
+++ b/plugins/tauri-plugin-spindle-project/src/build/mod.rs
@@ -3,7 +3,7 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: MIT
 
-mod authoring;
+pub(crate) mod authoring;
 mod capacity;
 mod dvd_navigation;
 mod executor;

--- a/plugins/tauri-plugin-spindle-project/src/validation/title.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/title.rs
@@ -339,6 +339,13 @@ pub(super) fn validate_titles(
 /// disagree on the declared codec or language at the same audio slot index,
 /// the authored XML can only match one of them; the rest get silently wrong
 /// metadata. Flag the mismatch instead of authoring it.
+/// `build::ffmpeg`'s `synthesise_silent_audio` gives every title with no
+/// audio mappings at all a silent stream at slot 0, always encoded as AC3.
+/// That title still physically occupies the slot and must be considered
+/// here — skipping it (as if it contributed nothing) would let a mismatch
+/// against a real track at slot 0 go undetected.
+const SYNTHESISED_SILENT_AUDIO_FORMAT: &str = "ac3";
+
 fn validate_titleset_audio_consistency(
     titleset: &Titleset,
     asset_map: &HashMap<&str, &Asset>,
@@ -352,19 +359,31 @@ fn validate_titleset_audio_consistency(
         .unwrap_or(0);
 
     for i in 0..max_audio {
-        let mut first: Option<(&Title, &'static str, Option<String>)> = None;
+        let mut first: Option<(&Title, &'static str, Option<String>, bool)> = None;
 
         for title in &titleset.titles {
-            let Some(am) = title.audio_mappings.get(i) else {
+            let (format, lang, is_real) = if let Some(am) = title.audio_mappings.get(i) {
+                (
+                    declared_audio_format(am, title, asset_map),
+                    dvdauthor_language_code(&am.language),
+                    true,
+                )
+            } else if i == 0 && title.audio_mappings.is_empty() {
+                (SYNTHESISED_SILENT_AUDIO_FORMAT, None, false)
+            } else {
                 continue;
             };
-            let format = declared_audio_format(am, title, asset_map);
-            let lang = dvdauthor_language_code(&am.language);
 
             match &first {
-                None => first = Some((title, format, lang)),
-                Some((first_title, first_format, first_lang)) => {
-                    if format != *first_format || lang != *first_lang {
+                None => first = Some((title, format, lang, is_real)),
+                Some((first_title, first_format, first_lang, first_is_real)) => {
+                    // A synthesised silent track never carries a real
+                    // language declaration, so only compare language when
+                    // both sides actually have one — otherwise every
+                    // silent/real pairing would falsely flag as a language
+                    // mismatch regardless of the real track's language.
+                    let lang_mismatch = is_real && *first_is_real && lang != *first_lang;
+                    if format != *first_format || lang_mismatch {
                         issues.push(ValidationIssue {
                             severity: IssueSeverity::Error,
                             code: "audio.titleset-inconsistent-declaration".to_string(),
@@ -570,6 +589,86 @@ mod tests {
                 .iter()
                 .any(|i| i.code == "audio.titleset-inconsistent-declaration"),
             "matching codec and language should not be flagged, got: {issues:?}"
+        );
+    }
+
+    fn title_with_no_audio(id: &str, name: &str) -> Title {
+        Title {
+            id: id.to_string(),
+            name: name.to_string(),
+            source_asset_id: None,
+            video_mapping: None,
+            video_output_profile: None,
+            audio_mappings: vec![],
+            subtitle_mappings: vec![],
+            chapters: vec![],
+            end_action: None,
+            order_index: 0,
+            bitrate_weight: 1.0,
+            bitrate_floor_bps: None,
+            bitrate_ceiling_bps: None,
+            pinned_bitrate_bps: None,
+        }
+    }
+
+    #[test]
+    fn validate_titles_flags_synthesised_silent_audio_against_a_mismatched_real_codec() {
+        let mut dts_mapping = audio_mapping(AudioOutputTarget::Dts, "eng");
+        dts_mapping.copy_mode = CopyMode::Copy;
+        let mut project = SpindleProjectFile::default();
+        project.disc.titlesets = vec![Titleset {
+            id: "titleset-1".to_string(),
+            name: "Main".to_string(),
+            titles: vec![
+                Title {
+                    audio_mappings: vec![dts_mapping],
+                    ..title_with_no_audio("title-1", "Feature")
+                },
+                title_with_no_audio("title-2", "Silent Cut"),
+            ],
+            menus: vec![],
+        }];
+        let asset_ids: HashSet<&str> = HashSet::new();
+        let asset_map: HashMap<&str, &Asset> = HashMap::new();
+        let mut issues = Vec::new();
+
+        validate_titles(&project, &asset_ids, &asset_map, &mut issues);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "audio.titleset-inconsistent-declaration"
+                    && i.severity == IssueSeverity::Error),
+            "a real DTS track sharing a titleset with a synthesised (AC3) silent track should be flagged, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_titles_does_not_flag_synthesised_silent_audio_against_a_matching_ac3_codec() {
+        let mut project = SpindleProjectFile::default();
+        project.disc.titlesets = vec![Titleset {
+            id: "titleset-1".to_string(),
+            name: "Main".to_string(),
+            titles: vec![
+                Title {
+                    audio_mappings: vec![audio_mapping(AudioOutputTarget::Ac3, "eng")],
+                    ..title_with_no_audio("title-1", "Feature")
+                },
+                title_with_no_audio("title-2", "Silent Cut"),
+            ],
+            menus: vec![],
+        }];
+        let asset_ids: HashSet<&str> = HashSet::new();
+        let asset_map: HashMap<&str, &Asset> = HashMap::new();
+        let mut issues = Vec::new();
+
+        validate_titles(&project, &asset_ids, &asset_map, &mut issues);
+
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.code == "audio.titleset-inconsistent-declaration"),
+            "an AC3 track sharing a slot with a synthesised (also AC3) silent track should not be flagged just because the silent track has no language, got: {issues:?}"
         );
     }
 }

--- a/plugins/tauri-plugin-spindle-project/src/validation/title.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/title.rs
@@ -339,6 +339,7 @@ pub(super) fn validate_titles(
 /// disagree on the declared codec or language at the same audio slot index,
 /// the authored XML can only match one of them; the rest get silently wrong
 /// metadata. Flag the mismatch instead of authoring it.
+///
 /// `build::ffmpeg`'s `synthesise_silent_audio` gives every title with no
 /// audio mappings at all a silent stream at slot 0, always encoded as AC3.
 /// That title still physically occupies the slot and must be considered
@@ -359,7 +360,13 @@ fn validate_titleset_audio_consistency(
         .unwrap_or(0);
 
     for i in 0..max_audio {
-        let mut first: Option<(&Title, &'static str, Option<String>, bool)> = None;
+        // Tracked separately from the format reference: a synthesised
+        // silent track never carries a real language declaration, so it
+        // must never become the reference two later *real* tracks get
+        // compared against — that would permanently suppress language
+        // mismatches between them for the rest of the loop.
+        let mut first_format: Option<(&Title, &'static str)> = None;
+        let mut first_lang: Option<(&Title, Option<String>)> = None;
 
         for title in &titleset.titles {
             let (format, lang, is_real) = if let Some(am) = title.audio_mappings.get(i) {
@@ -374,33 +381,44 @@ fn validate_titleset_audio_consistency(
                 continue;
             };
 
-            match &first {
-                None => first = Some((title, format, lang, is_real)),
-                Some((first_title, first_format, first_lang, first_is_real)) => {
-                    // A synthesised silent track never carries a real
-                    // language declaration, so only compare language when
-                    // both sides actually have one — otherwise every
-                    // silent/real pairing would falsely flag as a language
-                    // mismatch regardless of the real track's language.
-                    let lang_mismatch = is_real && *first_is_real && lang != *first_lang;
-                    if format != *first_format || lang_mismatch {
-                        issues.push(ValidationIssue {
-                            severity: IssueSeverity::Error,
-                            code: "audio.titleset-inconsistent-declaration".to_string(),
-                            message: format!(
-                                "Titles \"{}\" and \"{}\" share a titleset but declare different audio at slot {}, which dvdauthor can only author for one of them.",
-                                first_title.name, title.name, i
-                            ),
-                            context: Some(titleset.id.clone()),
-                            entity_type: Some("titleset".to_string()),
-                            entity_name: Some(first_title.name.clone()),
-                            suggested_fix: Some(
-                                "Give every title in this titleset the same codec/copy-mode and language for this audio slot, or move one title to its own titleset."
-                                    .to_string(),
-                            ),
-                        });
-                    }
+            let format_mismatch = match first_format {
+                None => {
+                    first_format = Some((title, format));
+                    None
                 }
+                Some((ref_title, ref_format)) if format != ref_format => Some(ref_title),
+                Some(_) => None,
+            };
+
+            let lang_mismatch = if !is_real {
+                None
+            } else {
+                match &first_lang {
+                    None => {
+                        first_lang = Some((title, lang));
+                        None
+                    }
+                    Some((ref_title, ref_lang)) if lang != *ref_lang => Some(*ref_title),
+                    Some(_) => None,
+                }
+            };
+
+            if let Some(ref_title) = format_mismatch.or(lang_mismatch) {
+                issues.push(ValidationIssue {
+                    severity: IssueSeverity::Error,
+                    code: "audio.titleset-inconsistent-declaration".to_string(),
+                    message: format!(
+                        "Titles \"{}\" and \"{}\" share a titleset but declare different audio at slot {}, which dvdauthor can only author for one of them.",
+                        ref_title.name, title.name, i
+                    ),
+                    context: Some(titleset.id.clone()),
+                    entity_type: Some("titleset".to_string()),
+                    entity_name: Some(ref_title.name.clone()),
+                    suggested_fix: Some(
+                        "Give every title in this titleset the same codec/copy-mode and language for this audio slot, or move one title to its own titleset."
+                            .to_string(),
+                    ),
+                });
             }
         }
     }
@@ -669,6 +687,44 @@ mod tests {
                 .iter()
                 .any(|i| i.code == "audio.titleset-inconsistent-declaration"),
             "an AC3 track sharing a slot with a synthesised (also AC3) silent track should not be flagged just because the silent track has no language, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_titles_flags_mismatched_language_between_two_real_tracks_after_a_leading_silent_title(
+    ) {
+        // A leading synthesised (silent, no-language) title must not become
+        // the permanent language reference — two later *real* tracks that
+        // disagree on language still need to be caught.
+        let mut project = SpindleProjectFile::default();
+        project.disc.titlesets = vec![Titleset {
+            id: "titleset-1".to_string(),
+            name: "Main".to_string(),
+            titles: vec![
+                title_with_no_audio("title-1", "Silent Cut"),
+                Title {
+                    audio_mappings: vec![audio_mapping(AudioOutputTarget::Ac3, "eng")],
+                    ..title_with_no_audio("title-2", "English Cut")
+                },
+                Title {
+                    audio_mappings: vec![audio_mapping(AudioOutputTarget::Ac3, "fra")],
+                    ..title_with_no_audio("title-3", "French Cut")
+                },
+            ],
+            menus: vec![],
+        }];
+        let asset_ids: HashSet<&str> = HashSet::new();
+        let asset_map: HashMap<&str, &Asset> = HashMap::new();
+        let mut issues = Vec::new();
+
+        validate_titles(&project, &asset_ids, &asset_map, &mut issues);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "audio.titleset-inconsistent-declaration"
+                    && i.severity == IssueSeverity::Error),
+            "English and French real tracks should be flagged even though a silent title came first, got: {issues:?}"
         );
     }
 }

--- a/plugins/tauri-plugin-spindle-project/src/validation/title.rs
+++ b/plugins/tauri-plugin-spindle-project/src/validation/title.rs
@@ -6,6 +6,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::build::authoring::language::dvdauthor_language_code;
+use crate::build::authoring::title::declared_audio_format;
 use crate::models::*;
 
 use super::chapter::{chapter_target_exists, dangling_play_chapter_issue};
@@ -325,6 +327,63 @@ pub(super) fn validate_titles(
                 }
             }
         }
+
+        validate_titleset_audio_consistency(titleset, asset_map, issues);
+    }
+}
+
+/// dvdauthor's per-titleset `<audio>` declarations (see
+/// `build::authoring::title::append_titles_section`) apply uniformly to
+/// every title in the titleset — DVD-Video's VTSI audio attribute table is
+/// shared across all of a titleset's PGCs, not per-title. When titles
+/// disagree on the declared codec or language at the same audio slot index,
+/// the authored XML can only match one of them; the rest get silently wrong
+/// metadata. Flag the mismatch instead of authoring it.
+fn validate_titleset_audio_consistency(
+    titleset: &Titleset,
+    asset_map: &HashMap<&str, &Asset>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let max_audio = titleset
+        .titles
+        .iter()
+        .map(|t| t.audio_mappings.len())
+        .max()
+        .unwrap_or(0);
+
+    for i in 0..max_audio {
+        let mut first: Option<(&Title, &'static str, Option<String>)> = None;
+
+        for title in &titleset.titles {
+            let Some(am) = title.audio_mappings.get(i) else {
+                continue;
+            };
+            let format = declared_audio_format(am, title, asset_map);
+            let lang = dvdauthor_language_code(&am.language);
+
+            match &first {
+                None => first = Some((title, format, lang)),
+                Some((first_title, first_format, first_lang)) => {
+                    if format != *first_format || lang != *first_lang {
+                        issues.push(ValidationIssue {
+                            severity: IssueSeverity::Error,
+                            code: "audio.titleset-inconsistent-declaration".to_string(),
+                            message: format!(
+                                "Titles \"{}\" and \"{}\" share a titleset but declare different audio at slot {}, which dvdauthor can only author for one of them.",
+                                first_title.name, title.name, i
+                            ),
+                            context: Some(titleset.id.clone()),
+                            entity_type: Some("titleset".to_string()),
+                            entity_name: Some(first_title.name.clone()),
+                            suggested_fix: Some(
+                                "Give every title in this titleset the same codec/copy-mode and language for this audio slot, or move one title to its own titleset."
+                                    .to_string(),
+                            ),
+                        });
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -403,6 +462,114 @@ mod tests {
                 .iter()
                 .any(|i| i.code == "audio.dts-reencode-unsupported"),
             "copy-mode DTS should not be flagged, got: {issues:?}"
+        );
+    }
+
+    fn two_title_titleset(mapping_a: AudioTrackMapping, mapping_b: AudioTrackMapping) -> Titleset {
+        let make_title = |id: &str, name: &str, mapping: AudioTrackMapping| Title {
+            id: id.to_string(),
+            name: name.to_string(),
+            source_asset_id: None,
+            video_mapping: None,
+            video_output_profile: None,
+            audio_mappings: vec![mapping],
+            subtitle_mappings: vec![],
+            chapters: vec![],
+            end_action: None,
+            order_index: 0,
+            bitrate_weight: 1.0,
+            bitrate_floor_bps: None,
+            bitrate_ceiling_bps: None,
+            pinned_bitrate_bps: None,
+        };
+        Titleset {
+            id: "titleset-1".to_string(),
+            name: "Main".to_string(),
+            titles: vec![
+                make_title("title-1", "Feature", mapping_a),
+                make_title("title-2", "Alternate Cut", mapping_b),
+            ],
+            menus: vec![],
+        }
+    }
+
+    fn audio_mapping(output_target: AudioOutputTarget, language: &str) -> AudioTrackMapping {
+        AudioTrackMapping {
+            id: "audio-1".to_string(),
+            source_stream_index: 0,
+            output_target,
+            copy_mode: CopyMode::ReEncode,
+            label: "English".to_string(),
+            language: language.to_string(),
+            order_index: 0,
+            is_default: true,
+            channel_layout: None,
+            bitrate_bps: None,
+        }
+    }
+
+    #[test]
+    fn validate_titles_flags_inconsistent_codec_across_titles_in_a_titleset() {
+        let mut project = SpindleProjectFile::default();
+        project.disc.titlesets.push(two_title_titleset(
+            audio_mapping(AudioOutputTarget::Ac3, "eng"),
+            audio_mapping(AudioOutputTarget::Mp2, "eng"),
+        ));
+        let asset_ids: HashSet<&str> = HashSet::new();
+        let asset_map: HashMap<&str, &Asset> = HashMap::new();
+        let mut issues = Vec::new();
+
+        validate_titles(&project, &asset_ids, &asset_map, &mut issues);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "audio.titleset-inconsistent-declaration"
+                    && i.severity == IssueSeverity::Error),
+            "expected an error-level audio.titleset-inconsistent-declaration issue, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_titles_flags_inconsistent_language_across_titles_in_a_titleset() {
+        let mut project = SpindleProjectFile::default();
+        project.disc.titlesets.push(two_title_titleset(
+            audio_mapping(AudioOutputTarget::Ac3, "eng"),
+            audio_mapping(AudioOutputTarget::Ac3, "fra"),
+        ));
+        let asset_ids: HashSet<&str> = HashSet::new();
+        let asset_map: HashMap<&str, &Asset> = HashMap::new();
+        let mut issues = Vec::new();
+
+        validate_titles(&project, &asset_ids, &asset_map, &mut issues);
+
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.code == "audio.titleset-inconsistent-declaration"
+                    && i.severity == IssueSeverity::Error),
+            "expected an error-level audio.titleset-inconsistent-declaration issue, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_titles_does_not_flag_consistent_titleset_audio() {
+        let mut project = SpindleProjectFile::default();
+        project.disc.titlesets.push(two_title_titleset(
+            audio_mapping(AudioOutputTarget::Ac3, "eng"),
+            audio_mapping(AudioOutputTarget::Ac3, "eng"),
+        ));
+        let asset_ids: HashSet<&str> = HashSet::new();
+        let asset_map: HashMap<&str, &Asset> = HashMap::new();
+        let mut issues = Vec::new();
+
+        validate_titles(&project, &asset_ids, &asset_map, &mut issues);
+
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.code == "audio.titleset-inconsistent-declaration"),
+            "matching codec and language should not be flagged, got: {issues:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Two follow-up fixes from a post-merge Codex review on #137, both real regressions introduced in that PR:
- Titles that share a titleset but declare different audio codec or language at the same slot index now fail validation with a clear error, instead of the authored dvdauthor XML silently matching only the first title (DVD-Video's VTSI audio attribute table is shared across an entire titleset, not per-title).
- Picking a channel layout or bitrate on a DTS copy-mode track now falls back `outputTarget` to AC3, matching the fallback the copy-mode selector already had — previously this combination flipped to re-encode+DTS, which fails validation and the build.

## Test plan
- [x] `pnpm validate` (format:check, vitest, tsc build, cargo fmt/clippy -D warnings, cargo nextest) — all green
- [x] New Rust tests: `validate_titles_flags_inconsistent_codec_across_titles_in_a_titleset`, `validate_titles_flags_inconsistent_language_across_titles_in_a_titleset`, `validate_titles_does_not_flag_consistent_titleset_audio`
- [x] New JS tests: DTS→AC3 fallback via the bitrate control and the channel-layout control
