### PR TITLE
Prepare the 0.4.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "spindle"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "log",
  "serde",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-spindle-project"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "image",

--- a/apps/spindle/package.json
+++ b/apps/spindle/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@liminal-hq/spindle",
 	"private": true,
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"type": "module",
 	"scripts": {
 		"predev": "pnpm --filter tauri-plugin-display-awareness-api --filter tauri-plugin-spindle-project-api build",

--- a/apps/spindle/src-tauri/Cargo.toml
+++ b/apps/spindle/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spindle"
-version = "0.3.0"
+version = "0.4.0"
 description = "Spindle desktop authoring shell"
 authors = ["Liminal HQ, Scott Morris"]
 edition = "2021"

--- a/apps/spindle/src-tauri/tauri.conf.json
+++ b/apps/spindle/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Spindle",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"identifier": "ca.liminalhq.spindle",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@liminal-hq/spindle-workspace",
 	"private": true,
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"packageManager": "pnpm@10.32.1",
 	"engines": {
 		"node": "24.14.0",

--- a/plugins/tauri-plugin-spindle-project/Cargo.toml
+++ b/plugins/tauri-plugin-spindle-project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-spindle-project"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Liminal HQ, Scott Morris"]
 description = "Tauri plugin for Spindle project schema, validation, and domain logic"
 edition = "2021"


### PR DESCRIPTION
## Summary
- Prepare the v0.4.0 release: bump all release-facing manifest versions (root and desktop `package.json`, `tauri.conf.json`, both Cargo manifests, `Cargo.lock`) from 0.3.0 to 0.4.0.
- Since 0.3.0, this brings in the full motion-menu authoring stack (per-format constraint profiles, semantic menu roles, colour-management rules, motion menus with animated button highlights, a timeline editor, and supporting docs — PRs #116–#128) and the audio/DVD-compatibility fixes (bitrate ceilings, DTS refusal, authored audio track order, titleset audio consistency validation — PRs #137–#138).

## Test plan
- [x] `pnpm release:version:check` — all manifests synchronised at 0.4.0
- [x] `pnpm validate` (format:check, vitest, tsc build, cargo fmt/clippy -D warnings, cargo nextest) — all green
